### PR TITLE
EOS-8719: Fix Ceph S3 bad MD5 tests

### DIFF
--- a/resources/s3_error_messages.json
+++ b/resources/s3_error_messages.json
@@ -143,6 +143,10 @@
     "Description": "The Content-MD5 you specified did not match what we received.",
     "httpcode": 400
   },
+  "InvalidDigest": {
+    "Description": "The Content-MD5 you specified is not valid",
+    "httpcode": 400
+  },  
   "MaxMessageLengthExceeded": {
     "Description": "Your request was too big.",
     "httpcode": 400

--- a/server/request_object.cc
+++ b/server/request_object.cc
@@ -31,6 +31,7 @@
 #include "request_object.h"
 #include "s3_stats.h"
 #include "s3_addb.h"
+#include "base64.h"
 
 extern S3Option* g_option_instance;
 
@@ -478,6 +479,22 @@ std::string RequestObject::get_content_length_str() {
     len = "0";
   }
   return len;
+}
+
+bool RequestObject::validate_content_md5() {
+  bool is_content_md5_valid = true;
+  std::string content_md5 = get_header_value("content-md5");
+  if (content_md5.empty()) {
+    // Invalid digest: content-md5 is with empty value
+    return false;
+  } else {
+    std::string decoded_md5 = base64_decode(content_md5);
+    if (decoded_md5.empty() || (decoded_md5.size() != MD5_DIGEST_LENGTH)) {
+      // Invalid digest: MD5 hash is empty or hash size is not 16
+      is_content_md5_valid = false;
+    }
+  }
+  return is_content_md5_valid;
 }
 
 bool RequestObject::validate_content_length() {

--- a/server/request_object.h
+++ b/server/request_object.h
@@ -177,6 +177,7 @@ class RequestObject {
   // care of both above headers (chunked and non-chunked cases)
   virtual size_t get_data_length();
   virtual std::string get_data_length_str();
+  virtual bool validate_content_md5();
   virtual bool validate_content_length();
   virtual size_t get_content_length();
   virtual std::string get_content_length_str();

--- a/ut/s3_request_object_test.cc
+++ b/ut/s3_request_object_test.cc
@@ -304,6 +304,39 @@ TEST_F(S3RequestObjectTest, ValidateContentLengthValidTest2) {
   EXPECT_TRUE(request->validate_content_length());
 }
 
+TEST_F(S3RequestObjectTest, ValidateContentMD5Empty) {
+  std::map<std::string, std::string> input_headers;
+  input_headers["content-md5"] = "";
+  fake_in_headers(input_headers);
+
+  EXPECT_FALSE(request->validate_content_md5());
+}
+
+TEST_F(S3RequestObjectTest, ValidateContentMD5Short) {
+  std::map<std::string, std::string> input_headers;
+  // MD5 value is less than 16 bytes
+  input_headers["content-md5"] = "YWJyYWNhZGFicmE=";
+  fake_in_headers(input_headers);
+
+  EXPECT_FALSE(request->validate_content_md5());
+}
+
+TEST_F(S3RequestObjectTest, ValidateContentMD5GarbageInvalid) {
+  std::map<std::string, std::string> input_headers;
+  input_headers["content-md5"] = "AWS HAHAHA";
+  fake_in_headers(input_headers);
+
+  EXPECT_FALSE(request->validate_content_md5());
+}
+
+TEST_F(S3RequestObjectTest, ValidateContentMD5Valid) {
+  std::map<std::string, std::string> input_headers;
+  input_headers["content-md5"] = "RfyyiTBjdeeYZXU50B05MQ==";
+  fake_in_headers(input_headers);
+
+  EXPECT_TRUE(request->validate_content_md5());
+}
+
 TEST_F(S3RequestObjectTest, ReturnsValidContentBody) {
   std::string content = "Hello World";
   std::map<std::string, std::string> input_headers;


### PR DESCRIPTION
Code changes to return "InvalidDigest" for bad/empty Content-MD5