### PR TITLE
EOS-13540: (LDR r1) Fixed cortx_s3_util to read correct value of s3recovery flag.

### DIFF
--- a/s3backgrounddelete/s3backgrounddelete/cortx_s3_util.py
+++ b/s3backgrounddelete/s3backgrounddelete/cortx_s3_util.py
@@ -102,7 +102,7 @@ class CORTXS3Util(object):
 
        algorithm = 'AWS4-HMAC-SHA256'
 
-       if self._config.get_s3recovery_flag :
+       if self._config.get_s3recovery_flag():
            access_key = self._config.get_s3_recovery_access_key()
            secret_key = self._config.get_s3_recovery_secret_key()
        else:


### PR DESCRIPTION
Because there were no opening-closing function brackets in call to get_s3recovery_flag(),
the statement was always evaluating to 'True', resulting in backgroundservice reading
s3recovery credentials.

Signed-off-by: Amit Kumar <amit.kumar@seagate.com>