### PR TITLE
EOS-13706: Fix for object listing getting timeout

### DIFF
--- a/server/s3_get_bucket_action.h
+++ b/server/s3_get_bucket_action.h
@@ -38,6 +38,8 @@ class S3GetBucketAction : public S3BucketAction {
   std::shared_ptr<MotrAPI> s3_motr_api;
   size_t max_record_count;
   short retry_count;
+  // Identify total keys visited/touched in the object listing
+  size_t total_keys_visited;
 
  protected:
   std::shared_ptr<S3ObjectListResponse> object_list;


### PR DESCRIPTION
Description:
 The last_key is set to the actual last element of the fetched result set, instead of setting it
in different logical conditions. This is done to avoid any situation of last_key being not set properly, thereby causing
repetitive same keyset fetch and causing request timeout.

Signed-off-by: ‘Dattaprasad <dattaprasad.govekar@seagate.com>