### PR TITLE
EOS-13916 Failover may cause some IOs to fail since authserver takes …

### DIFF
--- a/server/action_base.cc
+++ b/server/action_base.cc
@@ -285,6 +285,8 @@ void Action::check_authentication_failed() {
       s3_stats_inc("authentication_failed_invalid_accesskey_count");
     } else if (error_code == "SignatureDoesNotMatch") {
       s3_stats_inc("authentication_failed_signature_mismatch_count");
+    } else if (error_code == "ServiceUnavailable") {
+      base_request->set_out_header_value("Retry-After", "2");
     }
     s3_log(S3_LOG_ERROR, request_id, "Authentication failure: %s\n",
            error_code.c_str());

--- a/server/s3_action_base.cc
+++ b/server/s3_action_base.cc
@@ -76,6 +76,8 @@ void S3Action::check_authorization_failed() {
       s3_stats_inc("authorization_failed_invalid_accesskey_count");
     } else if (error_code == "SignatureDoesNotMatch") {
       s3_stats_inc("authorization_failed_signature_mismatch_count");
+    } else if (error_code == "ServiceUnavailable") {
+      request->set_out_header_value("Retry-After", "2");
     } else {
       // Possible error_code values: AccessDenied, MethodNotAllowed.
       // AccessDenied: When the requesting identity does not have

--- a/server/s3_auth_client.cc
+++ b/server/s3_auth_client.cc
@@ -1118,7 +1118,7 @@ void S3AuthClient::policy_validation_failed() {
       s3_log(S3_LOG_ERROR, request_id,
              "Cannot connect to Auth server (Retry count = %d).\n",
              retry_count);
-      s3_iem(LOG_ALERT, S3_IEM_AUTH_CONN_FAIL, S3_IEM_AUTH_CONN_FAIL_STR,
+      s3_iem(LOG_ERR, S3_IEM_AUTH_CONN_FAIL, S3_IEM_AUTH_CONN_FAIL_STR,
              S3_IEM_AUTH_CONN_FAIL_JSON);
       this->handler_on_failed();
     }
@@ -1279,7 +1279,7 @@ void S3AuthClient::check_authorization_failed() {
       s3_log(S3_LOG_ERROR, request_id,
              "Cannot connect to Auth server (Retry count = %d).\n",
              retry_count);
-      s3_iem(LOG_ALERT, S3_IEM_AUTH_CONN_FAIL, S3_IEM_AUTH_CONN_FAIL_STR,
+      s3_iem(LOG_ERR, S3_IEM_AUTH_CONN_FAIL, S3_IEM_AUTH_CONN_FAIL_STR,
              S3_IEM_AUTH_CONN_FAIL_JSON);
       this->handler_on_failed();
     }
@@ -1355,7 +1355,7 @@ void S3AuthClient::check_authentication_failed() {
       s3_log(S3_LOG_ERROR, request_id,
              "Cannot connect to Auth server (Retry count = %d).\n",
              retry_count);
-      s3_iem(LOG_ALERT, S3_IEM_AUTH_CONN_FAIL, S3_IEM_AUTH_CONN_FAIL_STR,
+      s3_iem(LOG_ERR, S3_IEM_AUTH_CONN_FAIL, S3_IEM_AUTH_CONN_FAIL_STR,
              S3_IEM_AUTH_CONN_FAIL_JSON);
       this->handler_on_failed();
     }
@@ -1382,7 +1382,7 @@ void S3AuthClient::check_aclvalidation_failed() {
       s3_log(S3_LOG_ERROR, request_id,
              "Cannot connect to Auth server (Retry count = %d).\n",
              retry_count);
-      s3_iem(LOG_ALERT, S3_IEM_AUTH_CONN_FAIL, S3_IEM_AUTH_CONN_FAIL_STR,
+      s3_iem(LOG_ERR, S3_IEM_AUTH_CONN_FAIL, S3_IEM_AUTH_CONN_FAIL_STR,
              S3_IEM_AUTH_CONN_FAIL_JSON);
       this->handler_on_failed();
     }


### PR DESCRIPTION
…some time to be listening to port, during this time the failed over IO to secondary node may fail