### PR TITLE
EOS-14069:Auth : Node replacement should preserve jksstore and keystore file

### DIFF
--- a/scripts/provisioning/setup.yaml
+++ b/scripts/provisioning/setup.yaml
@@ -43,6 +43,8 @@ s3:
     files:
       - /opt/seagate/cortx/auth/resources/authserver.properties
       - /opt/seagate/cortx/s3/s3backgrounddelete/config.yaml
+      - /opt/seagate/cortx/auth/resources/s3authserver.jks
+      - /opt/seagate/cortx/auth/resources/keystore.properties
 # Script path used by CSM to generate s3 support bundle
 support_bundle:
   - sh /opt/seagate/cortx/s3/scripts/s3_bundle_generate.sh


### PR DESCRIPTION
Preserve jks files in node replacement
Two files needs to be preserved or copied to another node after node replacement
      - /opt/seagate/cortx/auth/resources/s3authserver.jks
      - /opt/seagate/cortx/auth/resources/keystore.properties
Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>