### PR TITLE
[LDR-R1]EOS-14148: Memory pool alignment is displayed incorrectly

### DIFF
--- a/mempool/s3_memory_pool.c
+++ b/mempool/s3_memory_pool.c
@@ -50,7 +50,7 @@ struct mempool {
   /* Whenever pool frees any memory, use this to
      indicate to user of pool that memory was
      free'd with actual free() sys call. */
-  int alignment;               /* Memory aligment */
+  size_t alignment;            /* Memory aligment */
   size_t max_memory_threshold; /* Maximum memory that the system can have from
                                   pool */
   size_t mempool_item_size; /* Size of items managed by this pool */


### PR DESCRIPTION
Signed-off-by: evgeniy-brazhnikov <evgeniy.brazhnikov@seagate.com>