### PR TITLE
EOS-13841: fix failed to remove snapshot during  datarecovery

### DIFF
--- a/orchastrator.sh
+++ b/orchastrator.sh
@@ -63,5 +63,5 @@ else
   ./s3_data_recovery.sh || { echo "S3 data recovery has failed. Run only s3 recovery again" && exit 1; }
 fi
 
-echo "===============      Recovery completed         ==============="
-echo "===============  Please reboot all the nodes    ==============="
+echo "/=========                 Recovery completed                 ==========/"
+echo "/=========  Please stop the cluster and reboot all the nodes  ==========/"

--- a/orchastrator.sh
+++ b/orchastrator.sh
@@ -62,3 +62,6 @@ then
 else
   ./s3_data_recovery.sh || { echo "S3 data recovery has failed. Run only s3 recovery again" && exit 1; }
 fi
+
+echo "===============      Recovery completed         ==============="
+echo "===============  Please reboot all the nodes    ==============="


### PR DESCRIPTION
Issue:
    Recovery script exited with description
    "device-mapper: create ioctl on vg_metadata_srvnode--2-MD_Snapshot
     LVM-x8S3hpJ1KvhcpXuuPRBlunRYM70m332wdiytMJXGbdDqauX4uRhmXFAr48osxJh7
     failed: Device or resource busy"
    Snapshot is not able to be delete because it's present in multipath device.
    Due to last executed recovery device caches.

Fix:
    Add print for requesting to reboot all the nodes at the end of recovery
    to clean all the caches for the device