### PR TITLE
EOS:14187: [LDR R1] handle error scenario in callback: save_object_metadata_failed

### DIFF
--- a/server/s3_put_object_action.cc
+++ b/server/s3_put_object_action.cc
@@ -603,6 +603,9 @@ void S3PutObjectAction::save_object_metadata_failed() {
   if (new_object_metadata->get_state() ==
       S3ObjectMetadataState::failed_to_launch) {
     set_s3_error("ServiceUnavailable");
+  } else {
+    s3_log(S3_LOG_ERROR, request_id, "failed to save object metadata.");
+    set_s3_error("InternalError");
   }
   // Clean up will be done after response.
   send_response_to_s3_client();

--- a/server/s3_put_object_action.h
+++ b/server/s3_put_object_action.h
@@ -197,6 +197,7 @@ class S3PutObjectAction : public S3ObjectAction {
   FRIEND_TEST(S3PutObjectActionTest,
               WriteObjectSuccessfulShouldRestartReadingData);
   FRIEND_TEST(S3PutObjectActionTest, SaveMetadata);
+  FRIEND_TEST(S3PutObjectActionTest, SaveObjectMetadataFailed);
   FRIEND_TEST(S3PutObjectActionTest, SendResponseWhenShuttingDown);
   FRIEND_TEST(S3PutObjectActionTest, SendErrorResponse);
   FRIEND_TEST(S3PutObjectActionTest, SendSuccessResponse);


### PR DESCRIPTION
Put object was returning 200 even if motr set state to "failed", becasue
we were only checking "failed_to_launch" state in the callback. Added else
condition to return InternalError for all other states in the callback for failure.

Signed-off-by: Amit Kumar <amit.kumar@seagate.com>