### PR TITLE
[POC - DO_NOT_MERGE] EOS-14356: During cleanup, stop deletion of old object for PUT overwrite requests

### DIFF
--- a/s3backgrounddelete/s3backgrounddelete/config/s3_background_delete_config.yaml
+++ b/s3backgrounddelete/s3backgrounddelete/config/s3_background_delete_config.yaml
@@ -61,7 +61,7 @@ rabbitmq:                                    # Section for RabbitMQ configs
     exchange_type: "direct"                                 # Exchanges type includes direct, fanout, topic exchange, header exchange
     mode: 2                                                 # Valid values are Non-persistent (1) or persistent (2). persistent ensures that the task_queue queue won't be lost even if RabbitMQ restarts.
     durable: "True"                                         # Ensure that RabbitMQ will never lose our queue.
-    schedule_interval_secs: 7200                            # Schedule Interval is time period at which object recovery scheduler will be executed (in seconds). Increasing this value leads to reduced RabbitMQ memory consumption.
+    schedule_interval_secs: 300                             # Schedule Interval is time period at which object recovery scheduler will be executed (in seconds). Increasing this value leads to reduced RabbitMQ memory consumption.
 
 indexid:
 
@@ -72,5 +72,5 @@ indexid:
    max_keys: 1000                                             # Maximum number of keys in global index to be queried from list of probable delete object oid.
 
 leakconfig:                                  # Section for object leak config
-   leak_processing_delay_in_mins: 15                          # Time delay in mins after which probable delete entry is procesed for leak.
+   leak_processing_delay_in_mins: 5                           # Time delay in mins after which probable delete entry is procesed for leak.
    version_processing_delay_in_mins: 5                        # Time delay in mins after which object version is processed

--- a/s3config-test.yaml
+++ b/s3config-test.yaml
@@ -65,6 +65,7 @@ S3_SERVER_CONFIG:                                     # Section for S3 Server
    S3_STATS_ALLOWLIST_FILENAME: "s3stats-allowlist-test.yaml"  # Allow list of Stats metrics to be published to the backend.
    S3_PERF_STATS_INOUT_BYTES_INTERVAL_MSEC: 1000        # Specifies how often to send number of in/out-comping bytes to StatsD. Milliseconds.
    S3_SERVER_ENABLE_OBJECT_LEAK_TRACKING: false         # Enables the object leak feature changes
+   S3_SERVER_OBJECT_OVERWRITE_DEL_OLD: false            # When false, skips deleting old object during PUT object overwrite and DEL object
    S3_REDIS_SERVER_ADDRESS: "127.0.0.1"                 # In case if redis is used for kvs contains redis server address
    S3_REDIS_SERVER_PORT: 6379                           # In case if redis is used for kvs contains redis server port
    S3_SERVER_MOTR_ETIMEDOUT_MAX_THRESHOLD: 100          # Number of ETIMEDOUT errors per monitoring window before s3server restart

--- a/s3config.release.yaml
+++ b/s3config.release.yaml
@@ -65,6 +65,7 @@ S3_SERVER_CONFIG:                                     # Section for S3 Server
    S3_STATS_ALLOWLIST_FILENAME: "/opt/seagate/cortx/s3/conf/s3stats-allowlist.yaml"  # Allow list of Stats metrics to be published to the backend.
    S3_PERF_STATS_INOUT_BYTES_INTERVAL_MSEC: 1000        # Specifies how often to send number of in/out-comping bytes to StatsD. Milliseconds.
    S3_SERVER_ENABLE_OBJECT_LEAK_TRACKING: false         # Enables the object leak feature changes
+   S3_SERVER_OBJECT_OVERWRITE_DEL_OLD: false            # When false, skips deleting old object during PUT object overwrite and DEL object   
    S3_REDIS_SERVER_ADDRESS: "127.0.0.1"                 # In case if redis is used for kvs contains redis server address
    S3_REDIS_SERVER_PORT: 6379                           # In case if redis is used for kvs contains redis server port
    S3_SERVER_MOTR_ETIMEDOUT_MAX_THRESHOLD: 5            # Number of ETIMEDOUT errors per monitoring window before s3server restart

--- a/s3config.yaml
+++ b/s3config.yaml
@@ -65,6 +65,7 @@ S3_SERVER_CONFIG:
    S3_STATS_ALLOWLIST_FILENAME: "/opt/seagate/cortx/s3/conf/s3stats-allowlist.yaml"  # Allow list of Stats metrics to be published to the backend.
    S3_PERF_STATS_INOUT_BYTES_INTERVAL_MSEC: 1000        # Specifies how often to send number of in/out-comping bytes to StatsD. Milliseconds.
    S3_SERVER_ENABLE_OBJECT_LEAK_TRACKING: false         # Enables the object leak feature changes
+   S3_SERVER_OBJECT_OVERWRITE_DEL_OLD: false            # When false, skips deleting old object during PUT object overwrite and DEL object
    S3_REDIS_SERVER_ADDRESS: "127.0.0.1"                 # In case if redis is used for kvs contains redis server address
    S3_REDIS_SERVER_PORT: 6379                           # In case if redis is used for kvs contains redis server port
    S3_SERVER_MOTR_ETIMEDOUT_MAX_THRESHOLD: 100          # Number of ETIMEDOUT errors per monitoring window before s3server restart

--- a/server/s3_option.cc
+++ b/server/s3_option.cc
@@ -137,6 +137,12 @@ bool S3Option::load_section(std::string section_name,
                                "S3_SERVER_ENABLE_OBJECT_LEAK_TRACKING");
       s3server_objectleak_tracking_enabled =
           s3_option_node["S3_SERVER_ENABLE_OBJECT_LEAK_TRACKING"].as<bool>();
+
+      S3_OPTION_ASSERT_AND_RET(s3_option_node,
+                               "S3_SERVER_OBJECT_OVERWRITE_DEL_OLD");
+      s3server_obj_overwrite_del_old_enabled =
+          s3_option_node["S3_SERVER_OBJECT_OVERWRITE_DEL_OLD"].as<bool>();
+
       S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_READ_AHEAD_MULTIPLE");
       read_ahead_multiple = s3_option_node["S3_READ_AHEAD_MULTIPLE"].as<int>();
       S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_SERVER_DEFAULT_ENDPOINT");
@@ -433,6 +439,12 @@ bool S3Option::load_section(std::string section_name,
                                "S3_SERVER_ENABLE_OBJECT_LEAK_TRACKING");
       s3server_objectleak_tracking_enabled =
           s3_option_node["S3_SERVER_ENABLE_OBJECT_LEAK_TRACKING"].as<bool>();
+
+      S3_OPTION_ASSERT_AND_RET(s3_option_node,
+                               "S3_SERVER_OBJECT_OVERWRITE_DEL_OLD");
+      s3server_obj_overwrite_del_old_enabled =
+          s3_option_node["S3_SERVER_OBJECT_OVERWRITE_DEL_OLD"].as<bool>();
+
       S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_READ_AHEAD_MULTIPLE");
       read_ahead_multiple = s3_option_node["S3_READ_AHEAD_MULTIPLE"].as<int>();
       S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_MAX_RETRY_COUNT");
@@ -785,6 +797,8 @@ void S3Option::dump_options() {
   s3_log(S3_LOG_INFO, "", "S3_SERVER_SSL_ENABLE = %d\n", s3server_ssl_enabled);
   s3_log(S3_LOG_INFO, "", "S3_SERVER_ENABLE_OBJECT_LEAK_TRACKING = %d\n",
          s3server_objectleak_tracking_enabled);
+  s3_log(S3_LOG_INFO, "", "S3_SERVER_OBJECT_OVERWRITE_DEL_OLD = %d\n",
+         s3server_obj_overwrite_del_old_enabled);
   s3_log(S3_LOG_INFO, "", "S3_SERVER_CERT_FILE = %s\n",
          s3server_ssl_cert_file.c_str());
   s3_log(S3_LOG_INFO, "", "S3_SERVER_PEM_FILE = %s\n",
@@ -1148,6 +1162,14 @@ bool S3Option::is_s3server_objectleak_tracking_enabled() {
 
 void S3Option::set_s3server_objectleak_tracking_enabled(const bool& flag) {
   s3server_objectleak_tracking_enabled = flag;
+}
+
+bool S3Option::is_s3server_obj_overwrite_del_old_enabled() {
+  return s3server_obj_overwrite_del_old_enabled;
+}
+
+void S3Option::set_s3server_obj_overwrite_del_old_enabled(const bool& flag) {
+  s3server_obj_overwrite_del_old_enabled = flag;
 }
 
 bool S3Option::is_fake_motr_createobj() { return FLAGS_fake_motr_createobj; }

--- a/server/s3_option.h
+++ b/server/s3_option.h
@@ -127,6 +127,7 @@ class S3Option {
   bool s3_enable_auth_ssl;
   bool s3server_ssl_enabled;
   bool s3server_objectleak_tracking_enabled;
+  bool s3server_obj_overwrite_del_old_enabled;
   bool s3_reuseport;
   bool motr_http_reuseport;
   bool log_buffering_enable;
@@ -206,6 +207,7 @@ class S3Option {
     s3server_ssl_session_timeout_in_sec = DAY_IN_SECONDS;
     s3server_ssl_enabled = false;
     s3server_objectleak_tracking_enabled = false;
+    s3server_obj_overwrite_del_old_enabled = true;
 
     s3_grace_period_sec = 10;  // 10 seconds
     is_s3_shutting_down = false;
@@ -369,6 +371,10 @@ class S3Option {
   bool is_s3server_ssl_enabled();
   bool is_s3server_objectleak_tracking_enabled();
   void set_s3server_objectleak_tracking_enabled(const bool& flag);
+
+  bool is_s3server_obj_overwrite_del_old_enabled();
+  void set_s3server_obj_overwrite_del_old_enabled(const bool& flag);
+
   bool is_s3_reuseport_enabled();
   bool is_motr_http_reuseport_enabled();
   const char* get_iam_cert_file();

--- a/server/s3_post_complete_action.cc
+++ b/server/s3_post_complete_action.cc
@@ -875,16 +875,26 @@ void S3PostCompleteAction::delete_old_object() {
   if (!motr_writer) {
     motr_writer =
         motr_writer_factory->create_motr_writer(request, old_object_oid);
-    }
-    // process to delete old object
-    assert(old_object_oid.u_hi || old_object_oid.u_lo);
+  }
+  // process to delete old object
+  assert(old_object_oid.u_hi || old_object_oid.u_lo);
 
-    motr_writer->set_oid(old_object_oid);
-    motr_writer->delete_object(
-        std::bind(&S3PostCompleteAction::remove_old_object_version_metadata,
-                  this),
-        std::bind(&S3PostCompleteAction::next, this), old_layout_id);
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  // If old object exists and deletion of old is disabled, then return
+  if ((old_object_oid.u_hi || old_object_oid.u_lo) &&
+      !S3Option::get_instance()->is_s3server_obj_overwrite_del_old_enabled()) {
+    s3_log(S3_LOG_INFO, request_id,
+           "Skipping deletion of old object. The old object will be deleted by "
+           "BD.\n");
+    // Call next task in the pipeline
+    next();
+    return;
+  }
+  motr_writer->set_oid(old_object_oid);
+  motr_writer->delete_object(
+      std::bind(&S3PostCompleteAction::remove_old_object_version_metadata,
+                this),
+      std::bind(&S3PostCompleteAction::next, this), old_layout_id);
+  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
 }
 
 void S3PostCompleteAction::remove_old_object_version_metadata() {

--- a/server/s3_put_chunk_upload_object_action.cc
+++ b/server/s3_put_chunk_upload_object_action.cc
@@ -951,6 +951,17 @@ void S3PutChunkUploadObjectAction::delete_old_object() {
   // If PUT is success, we delete old object if present
   assert(old_object_oid.u_hi != 0ULL || old_object_oid.u_lo != 0ULL);
 
+  // If old object exists and deletion of old is disabled, then return
+  if ((old_object_oid.u_hi || old_object_oid.u_lo) &&
+      !S3Option::get_instance()->is_s3server_obj_overwrite_del_old_enabled()) {
+    s3_log(S3_LOG_INFO, request_id,
+           "Skipping deletion of old object. The old object will be deleted by "
+           "BD.\n");
+    // Call next task in the pipeline
+    next();
+    return;
+  }
+
   motr_writer->set_oid(old_object_oid);
   motr_writer->delete_object(
       std::bind(

--- a/server/s3_put_object_action.cc
+++ b/server/s3_put_object_action.cc
@@ -868,6 +868,16 @@ void S3PutObjectAction::delete_old_object() {
   // If PUT is success, we delete old object if present
   assert(old_object_oid.u_hi != 0ULL || old_object_oid.u_lo != 0ULL);
 
+  // If old object exists and deletion of old is disabled, then return
+  if ((old_object_oid.u_hi || old_object_oid.u_lo) &&
+      !S3Option::get_instance()->is_s3server_obj_overwrite_del_old_enabled()) {
+    s3_log(S3_LOG_INFO, request_id,
+           "Skipping deletion of old object. The old object will be deleted by "
+           "BD.\n");
+    // Call next task in the pipeline
+    next();
+    return;
+  }
   motr_writer->set_oid(old_object_oid);
   motr_writer->delete_object(
       std::bind(&S3PutObjectAction::remove_old_object_version_metadata, this),


### PR DESCRIPTION
A new flag 'S3_SERVER_OBJECT_OVERWRITE_DEL_OLD' is added in s3config.yaml.
The flag (by default is false) is used to control the deletion of old object during PUT overwrite request or Del object request.
--When false(default), Put overwrite and Del object request processing will skip deletion of existing/old object in S3 request flow.
--S3 Background delete will take care of deleting the object.

This code change is to skip deletion of old object during PUT overwrite S3 request.

This is all done to avoid degradation in write performance during parallel put overwrite and delete object requests.

Signed-off-by: ‘Dattaprasad <dattaprasad.govekar@seagate.com>