### PR TITLE
[POC - DO_NOT_MERGE] EOS-14357: Disable deletion of object during DEL <obj> api.

### DIFF
--- a/s3config-test.yaml
+++ b/s3config-test.yaml
@@ -65,6 +65,7 @@ S3_SERVER_CONFIG:                                     # Section for S3 Server
    S3_STATS_ALLOWLIST_FILENAME: "s3stats-allowlist-test.yaml"  # Allow list of Stats metrics to be published to the backend.
    S3_PERF_STATS_INOUT_BYTES_INTERVAL_MSEC: 1000        # Specifies how often to send number of in/out-comping bytes to StatsD. Milliseconds.
    S3_SERVER_ENABLE_OBJECT_LEAK_TRACKING: false         # Enables the object leak feature changes
+   S3_SERVER_OBJECT_OVERWRITE_DEL_OLD: false            # When false, skips deleting old object during PUT object overwrite and DEL object   
    S3_REDIS_SERVER_ADDRESS: "127.0.0.1"                 # In case if redis is used for kvs contains redis server address
    S3_REDIS_SERVER_PORT: 6379                           # In case if redis is used for kvs contains redis server port
    S3_SERVER_MOTR_ETIMEDOUT_MAX_THRESHOLD: 100          # Number of ETIMEDOUT errors per monitoring window before s3server restart

--- a/s3config.yaml
+++ b/s3config.yaml
@@ -65,6 +65,7 @@ S3_SERVER_CONFIG:
    S3_STATS_ALLOWLIST_FILENAME: "/opt/seagate/cortx/s3/conf/s3stats-allowlist.yaml"  # Allow list of Stats metrics to be published to the backend.
    S3_PERF_STATS_INOUT_BYTES_INTERVAL_MSEC: 1000        # Specifies how often to send number of in/out-comping bytes to StatsD. Milliseconds.
    S3_SERVER_ENABLE_OBJECT_LEAK_TRACKING: false         # Enables the object leak feature changes
+   S3_SERVER_OBJECT_OVERWRITE_DEL_OLD: false            # When false, skips deleting old object during PUT object overwrite and DEL object
    S3_REDIS_SERVER_ADDRESS: "127.0.0.1"                 # In case if redis is used for kvs contains redis server address
    S3_REDIS_SERVER_PORT: 6379                           # In case if redis is used for kvs contains redis server port
    S3_SERVER_MOTR_ETIMEDOUT_MAX_THRESHOLD: 100          # Number of ETIMEDOUT errors per monitoring window before s3server restart

--- a/server/s3_delete_object_action.cc
+++ b/server/s3_delete_object_action.cc
@@ -253,6 +253,18 @@ void S3DeleteObjectAction::mark_oid_for_deletion() {
 
 void S3DeleteObjectAction::delete_object() {
   s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  // If old object exists and deletion of old is disabled, then return
+  const m0_uint128& obj_oid = object_metadata->get_oid();
+  if ((obj_oid.u_hi || obj_oid.u_lo) &&
+      !S3Option::get_instance()->is_s3server_obj_overwrite_del_old_enabled()) {
+    s3_log(S3_LOG_INFO, request_id,
+           "Skipping deletion of object with oid %" SCNx64 " : %" SCNx64
+           ". The object will be deleted by BD.\n",
+           obj_oid.u_hi, obj_oid.u_lo);
+    // Call next task in the pipeline
+    next();
+    return;
+  }
   // process to delete object
   if (!motr_writer) {
     motr_writer = motr_writer_factory->create_motr_writer(

--- a/server/s3_option.cc
+++ b/server/s3_option.cc
@@ -137,6 +137,12 @@ bool S3Option::load_section(std::string section_name,
                                "S3_SERVER_ENABLE_OBJECT_LEAK_TRACKING");
       s3server_objectleak_tracking_enabled =
           s3_option_node["S3_SERVER_ENABLE_OBJECT_LEAK_TRACKING"].as<bool>();
+
+      S3_OPTION_ASSERT_AND_RET(s3_option_node,
+                               "S3_SERVER_OBJECT_OVERWRITE_DEL_OLD");
+      s3server_obj_overwrite_del_old_enabled =
+          s3_option_node["S3_SERVER_OBJECT_OVERWRITE_DEL_OLD"].as<bool>();
+
       S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_READ_AHEAD_MULTIPLE");
       read_ahead_multiple = s3_option_node["S3_READ_AHEAD_MULTIPLE"].as<int>();
       S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_SERVER_DEFAULT_ENDPOINT");
@@ -433,6 +439,12 @@ bool S3Option::load_section(std::string section_name,
                                "S3_SERVER_ENABLE_OBJECT_LEAK_TRACKING");
       s3server_objectleak_tracking_enabled =
           s3_option_node["S3_SERVER_ENABLE_OBJECT_LEAK_TRACKING"].as<bool>();
+
+      S3_OPTION_ASSERT_AND_RET(s3_option_node,
+                               "S3_SERVER_OBJECT_OVERWRITE_DEL_OLD");
+      s3server_obj_overwrite_del_old_enabled =
+          s3_option_node["S3_SERVER_OBJECT_OVERWRITE_DEL_OLD"].as<bool>();
+
       S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_READ_AHEAD_MULTIPLE");
       read_ahead_multiple = s3_option_node["S3_READ_AHEAD_MULTIPLE"].as<int>();
       S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_MAX_RETRY_COUNT");
@@ -785,6 +797,8 @@ void S3Option::dump_options() {
   s3_log(S3_LOG_INFO, "", "S3_SERVER_SSL_ENABLE = %d\n", s3server_ssl_enabled);
   s3_log(S3_LOG_INFO, "", "S3_SERVER_ENABLE_OBJECT_LEAK_TRACKING = %d\n",
          s3server_objectleak_tracking_enabled);
+  s3_log(S3_LOG_INFO, "", "S3_SERVER_OBJECT_OVERWRITE_DEL_OLD = %d\n",
+         s3server_obj_overwrite_del_old_enabled);
   s3_log(S3_LOG_INFO, "", "S3_SERVER_CERT_FILE = %s\n",
          s3server_ssl_cert_file.c_str());
   s3_log(S3_LOG_INFO, "", "S3_SERVER_PEM_FILE = %s\n",
@@ -1148,6 +1162,14 @@ bool S3Option::is_s3server_objectleak_tracking_enabled() {
 
 void S3Option::set_s3server_objectleak_tracking_enabled(const bool& flag) {
   s3server_objectleak_tracking_enabled = flag;
+}
+
+bool S3Option::is_s3server_obj_overwrite_del_old_enabled() {
+  return s3server_obj_overwrite_del_old_enabled;
+}
+
+void S3Option::set_s3server_obj_overwrite_del_old_enabled(const bool& flag) {
+  s3server_obj_overwrite_del_old_enabled = flag;
 }
 
 bool S3Option::is_fake_motr_createobj() { return FLAGS_fake_motr_createobj; }

--- a/server/s3_option.h
+++ b/server/s3_option.h
@@ -127,6 +127,7 @@ class S3Option {
   bool s3_enable_auth_ssl;
   bool s3server_ssl_enabled;
   bool s3server_objectleak_tracking_enabled;
+  bool s3server_obj_overwrite_del_old_enabled;
   bool s3_reuseport;
   bool motr_http_reuseport;
   bool log_buffering_enable;
@@ -206,6 +207,7 @@ class S3Option {
     s3server_ssl_session_timeout_in_sec = DAY_IN_SECONDS;
     s3server_ssl_enabled = false;
     s3server_objectleak_tracking_enabled = false;
+    s3server_obj_overwrite_del_old_enabled = true;
 
     s3_grace_period_sec = 10;  // 10 seconds
     is_s3_shutting_down = false;
@@ -369,6 +371,10 @@ class S3Option {
   bool is_s3server_ssl_enabled();
   bool is_s3server_objectleak_tracking_enabled();
   void set_s3server_objectleak_tracking_enabled(const bool& flag);
+
+  bool is_s3server_obj_overwrite_del_old_enabled();
+  void set_s3server_obj_overwrite_del_old_enabled(const bool& flag);
+
   bool is_s3_reuseport_enabled();
   bool is_motr_http_reuseport_enabled();
   const char* get_iam_cert_file();


### PR DESCRIPTION
- A new flag 'S3_SERVER_OBJECT_OVERWRITE_DEL_OLD' is added in s3config.yaml.
- The flag (by default is false) is used to control the deletion of old object during PUT overwrite request or Del object request.
--When false(default), Put overwrite and Del object request processing will skip deletion of existing/old object in S3 request flow.  
--S3 Background delete will take care of deleting the object.

This code change is to skip deletion of existing object during DEL <object> S3 request.
This is all done to avoid degradation in write performance during parallel put overwrite and delete object requests.
 
Signed-off-by: ‘Dattaprasad <dattaprasad.govekar@seagate.com>