### PR TITLE
EOS-14371:S3:Update repourl for dependency pkgs

### DIFF
--- a/scripts/env/common/create-cortx-repo.sh
+++ b/scripts/env/common/create-cortx-repo.sh
@@ -52,13 +52,9 @@ rm -rf /root/releases_cortx_s3deps /etc/yum.repos.d/releases_cortx_s3deps.repo
 mkdir -p /root/releases_cortx_s3deps
 cd /root/releases_cortx_s3deps
 
-TAG_NAME=$(curl -H "Authorization: token $GITHUB_TOKEN" -s https://api.github.com/repos/Seagate/cortx-s3server/releases/latest | grep "tag_name" | sed -E 's/.*"([^"]+)".*/\1/')
-
-if [ -z "${TAG_NAME}" ]; then
-  echo "Please use proper Git access token"; exit 1;
-fi
-
-githubrelease --github-token $GITHUB_TOKEN asset seagate/cortx-s3server download ${TAG_NAME}
+# Download CORTX dependencies rpm
+TAG_NAME="build-dependencies"
+githubrelease --github-token "$GITHUB_TOKEN" asset seagate/cortx download "${TAG_NAME}"
 
 cd -
 


### PR DESCRIPTION
Update path for build dependencies of github release for s3server 

Old values : https://github.com/Seagate/cortx-s3server/releases 

New  values : https://github.com/Seagate/cortx/releases/tag/build-dependencies

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>