### PR TITLE
EOS-14281: [LDR R1] Enable addb dump for s3server by default.

### DIFF
--- a/dev-starts3.sh
+++ b/dev-starts3.sh
@@ -153,12 +153,6 @@ import yaml;
 print yaml.load(open("'$s3_config_file'"))["S3_SERVER_CONFIG"]["S3_SERVER_BIND_PORT"];
 ' | tr -d '\r\n'`
 
-addb_dump=$(python -c '
-import yaml;
-print yaml.load(open("'$s3_config_file'"))["S3_SERVER_CONFIG"]["S3_SERVER_ENABLE_MOTR_ADDB_DUMP"];
-' | tr -d '\r\n'
-)
-
 # Start the s3server
 export PATH=$PATH:/opt/seagate/cortx/s3/bin
 counter=0
@@ -196,12 +190,6 @@ then
     callgraph_cmd="valgrind -q --tool=callgrind --collect-jumps=yes --collect-systime=yes --callgrind-out-file=$callgraph_out"
 fi
 
-addb_option=""
-if [ $addb_dump = True ]
-then
-  addb_option="--addb"
-fi
-
 while [[ $counter -lt $num_instances ]]
 do
   motr_local_port=`expr 101 + $counter`
@@ -209,6 +197,6 @@ do
   pid_filename='/var/run/s3server.'$s3port'.pid'
   $callgraph_cmd s3server --s3pidfile $pid_filename \
            --motrlocal $local_ep:${motr_local_port} --motrha $ha_ep \
-           --s3port $s3port --fault_injection true $fake_params --loading_indicators $addb_option --getoid true
+           --s3port $s3port --fault_injection true $fake_params --loading_indicators --getoid true
   ((++counter))
 done

--- a/dev-starts3.sh
+++ b/dev-starts3.sh
@@ -153,6 +153,12 @@ import yaml;
 print yaml.load(open("'$s3_config_file'"))["S3_SERVER_CONFIG"]["S3_SERVER_BIND_PORT"];
 ' | tr -d '\r\n'`
 
+addb_dump=$(python -c '
+import yaml;
+print yaml.load(open("'$s3_config_file'"))["S3_SERVER_CONFIG"]["S3_SERVER_ENABLE_MOTR_ADDB_DUMP"];
+' | tr -d '\r\n'
+)
+
 # Start the s3server
 export PATH=$PATH:/opt/seagate/cortx/s3/bin
 counter=0
@@ -190,6 +196,12 @@ then
     callgraph_cmd="valgrind -q --tool=callgrind --collect-jumps=yes --collect-systime=yes --callgrind-out-file=$callgraph_out"
 fi
 
+addb_option=""
+if [ $addb_dump = True ]
+then
+  addb_option="--addb"
+fi
+
 while [[ $counter -lt $num_instances ]]
 do
   motr_local_port=`expr 101 + $counter`
@@ -197,6 +209,6 @@ do
   pid_filename='/var/run/s3server.'$s3port'.pid'
   $callgraph_cmd s3server --s3pidfile $pid_filename \
            --motrlocal $local_ep:${motr_local_port} --motrha $ha_ep \
-           --s3port $s3port --fault_injection true $fake_params --loading_indicators --addb --getoid true
+           --s3port $s3port --fault_injection true $fake_params --loading_indicators $addb_option --getoid true
   ((++counter))
 done

--- a/s3config-test.yaml
+++ b/s3config-test.yaml
@@ -69,6 +69,7 @@ S3_SERVER_CONFIG:                                     # Section for S3 Server
    S3_REDIS_SERVER_PORT: 6379                           # In case if redis is used for kvs contains redis server port
    S3_SERVER_MOTR_ETIMEDOUT_MAX_THRESHOLD: 100          # Number of ETIMEDOUT errors per monitoring window before s3server restart
    S3_SERVER_MOTR_ETIMEDOUT_WINDOW_SEC: 2               # Monitoring window for motr ETIMEDOUT errors in seconds
+   S3_SERVER_ENABLE_MOTR_ADDB_DUMP: true                # If set to true, then addb dump will be collected
 S3_AUTH_CONFIG:                                         # Section for S3 Auth Service
    S3_AUTH_IP_ADDR: ipv4:10.10.1.2                      # Auth server IP address. Should be in below format:
                                                         # ipv4 address format: ipv4:127.0.0.1

--- a/s3config-test.yaml
+++ b/s3config-test.yaml
@@ -69,7 +69,7 @@ S3_SERVER_CONFIG:                                     # Section for S3 Server
    S3_REDIS_SERVER_PORT: 6379                           # In case if redis is used for kvs contains redis server port
    S3_SERVER_MOTR_ETIMEDOUT_MAX_THRESHOLD: 100          # Number of ETIMEDOUT errors per monitoring window before s3server restart
    S3_SERVER_MOTR_ETIMEDOUT_WINDOW_SEC: 2               # Monitoring window for motr ETIMEDOUT errors in seconds
-   S3_SERVER_ENABLE_MOTR_ADDB_DUMP: true                # If set to true, then addb dump will be collected
+   S3_SERVER_ENABLE_ADDB_DUMP: true                     # If set to true, then addb dump will be collected
 S3_AUTH_CONFIG:                                         # Section for S3 Auth Service
    S3_AUTH_IP_ADDR: ipv4:10.10.1.2                      # Auth server IP address. Should be in below format:
                                                         # ipv4 address format: ipv4:127.0.0.1

--- a/s3config.release.yaml
+++ b/s3config.release.yaml
@@ -69,6 +69,7 @@ S3_SERVER_CONFIG:                                     # Section for S3 Server
    S3_REDIS_SERVER_PORT: 6379                           # In case if redis is used for kvs contains redis server port
    S3_SERVER_MOTR_ETIMEDOUT_MAX_THRESHOLD: 5            # Number of ETIMEDOUT errors per monitoring window before s3server restart
    S3_SERVER_MOTR_ETIMEDOUT_WINDOW_SEC: 60              # Monitoring window for motr ETIMEDOUT errors in seconds
+   S3_SERVER_ENABLE_MOTR_ADDB_DUMP: true                # If set to true, then addb dump will be collected
 S3_AUTH_CONFIG:                                         # Section for S3 Auth Service
    S3_AUTH_IP_ADDR: ipv4:127.0.0.1                      # Auth server IP address Should be in below format:
                                                         # ipv4 address format: ipv4:127.0.0.1

--- a/s3config.release.yaml
+++ b/s3config.release.yaml
@@ -69,7 +69,7 @@ S3_SERVER_CONFIG:                                     # Section for S3 Server
    S3_REDIS_SERVER_PORT: 6379                           # In case if redis is used for kvs contains redis server port
    S3_SERVER_MOTR_ETIMEDOUT_MAX_THRESHOLD: 5            # Number of ETIMEDOUT errors per monitoring window before s3server restart
    S3_SERVER_MOTR_ETIMEDOUT_WINDOW_SEC: 60              # Monitoring window for motr ETIMEDOUT errors in seconds
-   S3_SERVER_ENABLE_MOTR_ADDB_DUMP: true                # If set to true, then addb dump will be collected
+   S3_SERVER_ENABLE_ADDB_DUMP: true                     # If set to true, then addb dump will be collected
 S3_AUTH_CONFIG:                                         # Section for S3 Auth Service
    S3_AUTH_IP_ADDR: ipv4:127.0.0.1                      # Auth server IP address Should be in below format:
                                                         # ipv4 address format: ipv4:127.0.0.1

--- a/s3config.yaml
+++ b/s3config.yaml
@@ -69,6 +69,7 @@ S3_SERVER_CONFIG:
    S3_REDIS_SERVER_PORT: 6379                           # In case if redis is used for kvs contains redis server port
    S3_SERVER_MOTR_ETIMEDOUT_MAX_THRESHOLD: 100          # Number of ETIMEDOUT errors per monitoring window before s3server restart
    S3_SERVER_MOTR_ETIMEDOUT_WINDOW_SEC: 1               # Monitoring window for motr ETIMEDOUT errors in seconds
+   S3_SERVER_ENABLE_MOTR_ADDB_DUMP: true                # If set to true, then addb dump will be collected
 S3_AUTH_CONFIG:
    S3_AUTH_IP_ADDR: ipv4:127.0.0.1                      # Auth server IP address Should be in below format:
                                                         # ipv4 address format: ipv4:127.0.0.1

--- a/s3config.yaml
+++ b/s3config.yaml
@@ -69,7 +69,7 @@ S3_SERVER_CONFIG:
    S3_REDIS_SERVER_PORT: 6379                           # In case if redis is used for kvs contains redis server port
    S3_SERVER_MOTR_ETIMEDOUT_MAX_THRESHOLD: 100          # Number of ETIMEDOUT errors per monitoring window before s3server restart
    S3_SERVER_MOTR_ETIMEDOUT_WINDOW_SEC: 1               # Monitoring window for motr ETIMEDOUT errors in seconds
-   S3_SERVER_ENABLE_MOTR_ADDB_DUMP: true                # If set to true, then addb dump will be collected
+   S3_SERVER_ENABLE_ADDB_DUMP: true                     # If set to true, then addb dump will be collected
 S3_AUTH_CONFIG:
    S3_AUTH_IP_ADDR: ipv4:127.0.0.1                      # Auth server IP address Should be in below format:
                                                         # ipv4 address format: ipv4:127.0.0.1

--- a/server/s3_option.cc
+++ b/server/s3_option.cc
@@ -193,6 +193,8 @@ bool S3Option::load_section(std::string section_name,
                                "S3_SERVER_MOTR_ETIMEDOUT_WINDOW_SEC");
       motr_etimedout_window_sec =
           s3_option_node["S3_SERVER_MOTR_ETIMEDOUT_WINDOW_SEC"].as<uint>();
+      S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_SERVER_ENABLE_ADDB_DUMP");
+      FLAGS_addb = s3_option_node["S3_SERVER_ENABLE_ADDB_DUMP"].as<bool>();
     } else if (section_name == "S3_AUTH_CONFIG") {
       S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_AUTH_PORT");
       auth_port = s3_option_node["S3_AUTH_PORT"].as<unsigned short>();
@@ -496,6 +498,8 @@ bool S3Option::load_section(std::string section_name,
                                "S3_SERVER_MOTR_ETIMEDOUT_WINDOW_SEC");
       motr_etimedout_window_sec =
           s3_option_node["S3_SERVER_MOTR_ETIMEDOUT_WINDOW_SEC"].as<unsigned>();
+      S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_SERVER_ENABLE_ADDB_DUMP");
+      FLAGS_addb = s3_option_node["S3_SERVER_ENABLE_ADDB_DUMP"].as<bool>();
     } else if (section_name == "S3_AUTH_CONFIG") {
       if (!(cmd_opt_flag & S3_OPTION_AUTH_PORT)) {
         S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_AUTH_PORT");
@@ -900,6 +904,8 @@ void S3Option::dump_options() {
   s3_log(S3_LOG_INFO, "", "S3_SERVER_MOTR_ETIMEDOUT_WINDOW_SEC = %u\n",
          motr_etimedout_window_sec);
 
+  s3_log(S3_LOG_INFO, "", "S3_SERVER_ENABLE_ADDB_DUMP = %s\n",
+         is_s3server_addb_dump_enabled() ? "true" : "false");
   s3_log(S3_LOG_INFO, "", "S3_MOTR_READ_MEMPOOL_ZERO_BUFFER=%s\n",
          motr_read_mempool_zeroed_buffer ? "true" : "false");
   s3_log(S3_LOG_INFO, "", "S3_LIBEVENT_MEMPOOL_ZERO_BUFFER=%s\n",
@@ -1137,6 +1143,8 @@ void S3Option::disable_auth() { FLAGS_disable_auth = true; }
 void S3Option::enable_auth() { FLAGS_disable_auth = false; }
 
 bool S3Option::is_auth_disabled() { return FLAGS_disable_auth; }
+
+bool S3Option::is_s3server_addb_dump_enabled() { return FLAGS_addb; }
 
 unsigned short S3Option::s3_performance_enabled() { return perf_enabled; }
 

--- a/server/s3_option.h
+++ b/server/s3_option.h
@@ -369,6 +369,9 @@ class S3Option {
   bool is_s3server_ssl_enabled();
   bool is_s3server_objectleak_tracking_enabled();
   void set_s3server_objectleak_tracking_enabled(const bool& flag);
+  bool is_s3server_addb_dump_enabled();
+  void enable_s3server_addb_dump();
+  void disable_s3server_addb_dump();
   bool is_s3_reuseport_enabled();
   bool is_motr_http_reuseport_enabled();
   const char* get_iam_cert_file();

--- a/server/s3_option.h
+++ b/server/s3_option.h
@@ -370,8 +370,6 @@ class S3Option {
   bool is_s3server_objectleak_tracking_enabled();
   void set_s3server_objectleak_tracking_enabled(const bool& flag);
   bool is_s3server_addb_dump_enabled();
-  void enable_s3server_addb_dump();
-  void disable_s3server_addb_dump();
   bool is_s3_reuseport_enabled();
   bool is_motr_http_reuseport_enabled();
   const char* get_iam_cert_file();

--- a/system/s3startsystem.sh
+++ b/system/s3startsystem.sh
@@ -58,6 +58,12 @@ print yaml.load(open("'$s3_config_file'"))["S3_SERVER_CONFIG"]["S3_LOG_DIR"];
 `"/s3server-$1"
 mkdir -p $s3_log_dir
 
+addb_dump=$(python -c '
+import yaml;
+print yaml.load(open("'$s3_config_file'"))["S3_SERVER_CONFIG"]["S3_SERVER_ENABLE_MOTR_ADDB_DUMP"];
+' | tr -d '\r\n'
+)
+
 #set the maximum size of core file to unlimited
 ulimit -c unlimited
 
@@ -72,22 +78,15 @@ profile_fid="<$MOTR_PROFILE_FID>"
 process_fid="<$MOTR_PROCESS_FID>"
 s3port=$MOTR_S3SERVER_PORT
 
-
-# s3server cmd parameters allowing to fake some motr functionality
-# --fake_motr_writeobj - stub for motr write object with all zeros
-# --fake_motr_readobj - stub for motr read object with all zeros
-# --fake_motr_createidx - stub for motr create idx - does nothing
-# --fake_motr_deleteidx - stub for motr delete idx - does nothing
-# --fake_motr_getkv - stub for motr get key-value - read from memory hash map
-# --fake_motr_putkv - stub for motr put kye-value - stores in memory hash map
-# --fake_motr_deletekv - stub for motr delete key-value - deletes from memory hash map
-# for proper KV mocking one should use following combination
-#    --fake_motr_createidx true --fake_motr_deleteidx true --fake_motr_getkv true --fake_motr_putkv true --fake_motr_deletekv true
-
+addb_option=""
+if [ $addb_dump = True ]
+then
+  addb_option="--addb"
+fi
 
 pid_filename='/var/run/s3server.'$1'.pid'
 set -x
 s3server --s3pidfile $pid_filename \
          --motrlocal $local_ep --motrha $ha_ep \
          --motrprofilefid $profile_fid --motrprocessfid $process_fid \
-         --s3port $s3port --log_dir $s3_log_dir
+         --s3port $s3port --log_dir $s3_log_dir $addb_option

--- a/ut/s3_option_test.cc
+++ b/ut/s3_option_test.cc
@@ -81,6 +81,7 @@ TEST_F(S3OptionsTest, Constructor) {
   EXPECT_EQ(9125, instance->get_statsd_port());
   EXPECT_EQ(15, instance->get_statsd_max_send_retry());
   EXPECT_EQ(5, instance->get_client_req_read_timeout_secs());
+  EXPECT_TRUE(instance->is_s3server_addb_dump_enabled());
 }
 
 TEST_F(S3OptionsTest, SingletonCheck) {
@@ -123,6 +124,7 @@ TEST_F(S3OptionsTest, GetOptionsfromFile) {
   EXPECT_EQ(9125, instance->get_statsd_port());
   EXPECT_EQ(15, instance->get_statsd_max_send_retry());
   EXPECT_EQ(5, instance->get_client_req_read_timeout_secs());
+  EXPECT_TRUE(instance->is_s3server_addb_dump_enabled());
   EXPECT_EQ("s3stats-allowlist-test.yaml",
             instance->get_stats_allowlist_filename());
 }
@@ -243,6 +245,7 @@ TEST_F(S3OptionsTest, LoadS3SectionFromFile) {
   EXPECT_EQ(15, instance->get_statsd_max_send_retry());
   EXPECT_EQ("s3stats-allowlist-test.yaml",
             instance->get_stats_allowlist_filename());
+  EXPECT_TRUE(instance->is_s3server_addb_dump_enabled());
 
   // These will come with default values.
   EXPECT_EQ(std::string("localhost@tcp:12345:33:100"),
@@ -284,6 +287,7 @@ TEST_F(S3OptionsTest, LoadSelectiveS3SectionFromFile) {
   EXPECT_EQ(15, instance->get_statsd_max_send_retry());
   EXPECT_EQ("s3stats-allowlist-test.yaml",
             instance->get_stats_allowlist_filename());
+  EXPECT_TRUE(instance->is_s3server_addb_dump_enabled());
 
   // These should be default values
   EXPECT_EQ(std::string("localhost@tcp:12345:33:100"),


### PR DESCRIPTION
I have added a new config parameter in s3config.yaml to read it in s3server
startup script, and add "--addb" option, if the new conf parameter is set.

Signed-off-by: Amit Kumar <amit.kumar@seagate.com>