### PR TITLE
EOS-14822: Bail out in case if XML string doesn't have parts details

### DIFF
--- a/server/s3_post_complete_action.cc
+++ b/server/s3_post_complete_action.cc
@@ -671,7 +671,7 @@ bool S3PostCompleteAction::validate_request_body(std::string& xml_str) {
   xmlNode* child_node;
   xmlChar* xml_part_number;
   xmlChar* xml_etag;
-  std::string partnumber;
+  std::string partnumber = "";
   std::string prev_partnumber = "";
   int previous_part;
   std::string input_etag;
@@ -738,6 +738,12 @@ bool S3PostCompleteAction::validate_request_body(std::string& xml_str) {
       }
     }
     child = child->next;
+  }
+  if (partnumber == "") {
+    s3_log(S3_LOG_ERROR, request_id,
+           "The xml string %s doesn't contain parts\n", xml_str.c_str());
+    xmlFreeDoc(document);
+    return false;
   }
   total_parts = partnumber;
   xmlFreeDoc(document);

--- a/server/s3_post_complete_action.h
+++ b/server/s3_post_complete_action.h
@@ -163,6 +163,7 @@ class S3PostCompleteAction : public S3ObjectAction {
   FRIEND_TEST(S3PostCompleteActionTest, LoadValidateRequest);
   FRIEND_TEST(S3PostCompleteActionTest, ConsumeIncomingContentMoreContent);
   FRIEND_TEST(S3PostCompleteActionTest, ValidateRequestBody);
+  FRIEND_TEST(S3PostCompleteActionTest, ValidateRequestBodyNoParts);
   FRIEND_TEST(S3PostCompleteActionTest, ValidateRequestBodyEmpty);
   FRIEND_TEST(S3PostCompleteActionTest, ValidateRequestBodyOutOrderParts);
   FRIEND_TEST(S3PostCompleteActionTest, ValidateRequestBodyMissingTag);

--- a/ut/s3_post_complete_action_test.cc
+++ b/ut/s3_post_complete_action_test.cc
@@ -295,6 +295,13 @@ TEST_F(S3PostCompleteActionTest, ValidateRequestBody) {
   EXPECT_STREQ("4", action_under_test_ptr->total_parts.c_str());
 }
 
+TEST_F(S3PostCompleteActionTest, ValidateRequestBodyNoParts) {
+  mock_xml.assign(
+      "<CompleteMultipartUpload></"
+      "CompleteMultipartUpload>");
+  EXPECT_FALSE(action_under_test_ptr->validate_request_body(mock_xml));
+}
+
 TEST_F(S3PostCompleteActionTest, ValidateRequestBodyOutOrderParts) {
   mock_xml.assign(
       "<CompleteMultipartUpload><Part><PartNumber>1</"


### PR DESCRIPTION
In multipart upload complete request, return failure if there is
no parts details in XML request string

Signed-off-by: Rajesh Nambiar <rajesh.nambiar@seagate.com>