### PR TITLE
EOS-14826: [Splunk, ceph] Fix for Ceph S3 failed test cases in ListObject api

### DIFF
--- a/server/s3_get_bucket_action.cc
+++ b/server/s3_get_bucket_action.cc
@@ -344,10 +344,10 @@ void S3GetBucketAction::get_next_objects_successful() {
       }  // else no prefix match, filter it out
     }
 
-    if (--length == 0 ||
-        ((!last_key_in_common_prefix &&
-          object_list->size() + object_list->common_prefixes_size()) ==
-         max_keys)) {
+    if ((--length == 0) ||
+        (!last_key_in_common_prefix &&
+         ((object_list->size() + object_list->common_prefixes_size()) ==
+          max_keys))) {
       // This is the last element returned or we reached limit requested, we
       // break.
       last_key = kv.first;

--- a/server/s3_get_bucket_action.cc
+++ b/server/s3_get_bucket_action.cc
@@ -192,7 +192,7 @@ void S3GetBucketAction::get_next_objects_successful() {
       bucket_metadata->get_object_list_index_oid();
   bool atleast_one_json_error = false;
   bool last_key_in_common_prefix = false;
-  std::string last_common_prefix;
+  std::string last_common_prefix = "";
   auto& kvps = motr_kv_reader->get_key_values();
   size_t length = kvps.size();
   // Statistics - Total keys visited/loaded
@@ -205,32 +205,44 @@ void S3GetBucketAction::get_next_objects_successful() {
     s3_log(S3_LOG_DEBUG, request_id, "Read Object Value = %s\n",
            kv.second.second.c_str());
 
+    // Check if the current key cannot be rolled into the last common prefix.
+    // If can't be rolled into last common prefix, reset
+    // 'last_key_in_common_prefix'
     if (last_key_in_common_prefix) {
-      bool prefix_match = (kv.first.find(request_prefix) == 0) ? true : false;
-      if (!prefix_match) {
-        // Prefix does not match, skip the key
-        if (--length == 0) {
-          // Before breaking the loop, set the last key
-          last_key = kv.first;
-          break;
-        } else {
-          continue;
+      // Filter by prefix, if prefix specified
+      if (!request_prefix.empty()) {
+        // Filter out by prefix
+        if (kv.first.find(request_prefix) == std::string::npos) {
+          // Key does not start with specified prefix; key filetered out.
+          // Check the next key.
+          if (--length == 0) {
+            break;
+          } else {
+            continue;
+          }
         }
       }
-      // Check if the current key cannot be rolled into the last common prefix.
-      // In such situation, reset 'last_key_in_common_prefix'
       size_t common_prefix_pos = kv.first.find(last_common_prefix);
       if (common_prefix_pos == std::string::npos) {
+        // As we didn't find key with same common prefix, it means we have one
+        // more key added to the list.
+        // Now check if we have reached the max keys requested. If yes, break
+        if ((object_list->size() + object_list->common_prefixes_size()) ==
+            max_keys) {
+          // Before breaking the loop, set the last key to last common prefix
+          last_key = last_common_prefix;
+          break;
+        }
         // We didn't find current key with same last common prefix.
         // Reset 'last_key_in_common_prefix'
         last_key_in_common_prefix = false;
-        // Check if we reached the max keys requested. If yes, break
-        if ((object_list->size() + object_list->common_prefixes_size()) ==
-            max_keys) {
-          // Before breaking the loop, set the last key
-          last_key = kv.first;
-          break;
-        }
+        last_common_prefix = "";
+      } else {
+        // Continue to next key as current key also rolls into the same
+        // last common prefix.
+        --length;
+        last_key = kv.first;
+        continue;
       }
     }
 
@@ -332,17 +344,12 @@ void S3GetBucketAction::get_next_objects_successful() {
       }  // else no prefix match, filter it out
     }
 
-    if (--length == 0 || (!last_key_in_common_prefix &&
-                          (object_list->size() +
-                           object_list->common_prefixes_size()) == max_keys)) {
+    if (--length == 0 ||
+        ((!last_key_in_common_prefix &&
+          object_list->size() + object_list->common_prefixes_size()) ==
+         max_keys)) {
       // This is the last element returned or we reached limit requested, we
       // break.
-      // When the state 'last_key_in_common_prefix' is true, we don't want to
-      // check whether we reached max_keys,
-      // because there may be still some more keys in the result KV set that
-      // starts with the same last common prefix.
-      // So, we want to stop breaking from the 'if' condition here, and
-      // enumerate further keys with same last common prefix.
       last_key = kv.first;
       break;
     }
@@ -359,6 +366,13 @@ void S3GetBucketAction::get_next_objects_successful() {
     // Go ahead and respond.
     if (key_Count == max_keys && length != 0) {
       object_list->set_response_is_truncated(true);
+      // Before sending response, check if the previous key was in common prefix
+      // If yes, we need to return the common prefix as next marker
+      // This is required to fix Ceph S3 test case.
+      if (last_key_in_common_prefix) {
+        last_key = last_common_prefix;
+      }
+      s3_log(S3_LOG_DEBUG, request_id, "Next marker = %s\n", last_key.c_str());
       object_list->set_next_marker_key(last_key);
     }
     fetch_successful = true;

--- a/server/s3_get_bucket_action_v2.cc
+++ b/server/s3_get_bucket_action_v2.cc
@@ -61,9 +61,13 @@ void S3GetBucketActionV2::validate_request() {
   s3_log(S3_LOG_INFO, request_id, "Entering\n");
   s3_log(S3_LOG_INFO, request_id, "Validate ListObjects V2 request\n");
 
-  request_cont_token = request->get_query_string_value("continuation-token");
-  s3_log(S3_LOG_DEBUG, request_id, "continuation-token = %s\n",
-         request_cont_token.c_str());
+  bool is_cont_token_present = false;
+  is_cont_token_present = request->has_query_param_key("continuation-token");
+  if (is_cont_token_present) {
+    request_cont_token = request->get_query_string_value("continuation-token");
+    s3_log(S3_LOG_DEBUG, request_id, "continuation-token = %s\n",
+           request_cont_token.c_str());
+  }
   request_fetch_owner =
       (request->get_query_string_value("fetch-owner") == "true") ? true : false;
   s3_log(S3_LOG_DEBUG, request_id, "fetch-owner = %d\n", request_fetch_owner);
@@ -74,7 +78,9 @@ void S3GetBucketActionV2::validate_request() {
   std::shared_ptr<S3ObjectListResponseV2> obj_v2_list =
       std::dynamic_pointer_cast<S3ObjectListResponseV2>(object_list);
   if (obj_v2_list) {
-    obj_v2_list->set_continuation_token(request_cont_token);
+    if (is_cont_token_present) {
+      obj_v2_list->set_continuation_token(request_cont_token);
+    }
     obj_v2_list->set_fetch_owner(request_fetch_owner);
     obj_v2_list->set_start_after(request_start_after);
   }

--- a/server/s3_object_list_v2_response.cc
+++ b/server/s3_object_list_v2_response.cc
@@ -28,12 +28,14 @@ S3ObjectListResponseV2::S3ObjectListResponseV2(const std::string& encoding_type)
       continuation_token(""),
       fetch_owner(false),
       start_after(""),
-      response_v2_xml("") {
+      response_v2_xml(""),
+      cont_token_specified(false) {
   s3_log(S3_LOG_DEBUG, "", "Constructor\n");
   s3_log(S3_LOG_DEBUG, "", "Encoding type = %s", encoding_type.c_str());
 }
 
 void S3ObjectListResponseV2::set_continuation_token(const std::string& token) {
+  cont_token_specified = true;
   continuation_token = token;
 }
 
@@ -66,8 +68,9 @@ std::string& S3ObjectListResponseV2::get_xml(
     response_xml += S3CommonUtilities::format_xml_string("EncodingType", "url");
   }
   response_xml += S3CommonUtilities::format_xml_string("KeyCount", key_count);
-  // If 'continuation-token' specified in request, include it in the response
-  if (!continuation_token.empty()) {
+  // If 'continuation-token' specified in original request, include it in the
+  // response
+  if (cont_token_specified) {
     response_xml += S3CommonUtilities::format_xml_string("ContinuationToken",
                                                          continuation_token);
   }

--- a/server/s3_object_list_v2_response.h
+++ b/server/s3_object_list_v2_response.h
@@ -34,6 +34,8 @@ class S3ObjectListResponseV2 : public S3ObjectListResponse {
   std::string start_after;
   std::string response_v2_xml;
   std::string next_continuation_token;
+  // Continuation-token presen in original request
+  bool cont_token_specified;
 
  public:
   S3ObjectListResponseV2(const std::string &encoding_type = "");

--- a/ut/s3_get_bucket_action_v2_test.cc
+++ b/ut/s3_get_bucket_action_v2_test.cc
@@ -146,6 +146,10 @@ TEST_F(S3GetBucketActionV2Test, V2ValidateRequest) {
   CREATE_ACTION_UNDER_TEST_OBJ;
   CREATE_BUCKET_METADATA_OBJ;
 
+  EXPECT_CALL(*request_mock, has_query_param_key("continuation-token"))
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(true));
+
   EXPECT_CALL(*request_mock, get_query_string_value("prefix"))
       .Times(AtLeast(1))
       .WillRepeatedly(Return(""));


### PR DESCRIPTION
Failed TCs are below:
  s3tests.functional.test_s3.test_bucket_list_delimiter_prefix
  s3tests.functional.test_s3.test_bucket_list_delimiter_prefix_underscore

These TCs are now passing. Locally (on my local VM) verified that existing UT and STs are running fine.

Note:
 - QA needs to re-run third party solutions, e.g., veeam backup, and any other solution to make sure there is no regression, before merging to GA branch.

Signed-off-by: ‘Dattaprasad <dattaprasad.govekar@seagate.com>