### PR TITLE
[LDR R1.1] Implement CopyObject API (skeleton only)

### DIFF
--- a/server/request_object.cc
+++ b/server/request_object.cc
@@ -481,6 +481,10 @@ std::string RequestObject::get_content_length_str() {
   return len;
 }
 
+std::string RequestObject::get_copy_object_source() {
+  return get_header_value("x-amz-copy-source");
+}
+
 std::string RequestObject::get_content_type() {
   std::string type = get_header_value("Content-Type");
   type = S3CommonUtilities::trim(type);

--- a/server/request_object.h
+++ b/server/request_object.h
@@ -173,6 +173,7 @@ class RequestObject {
   virtual std::string get_host_header();
   virtual std::string get_host_name();
 
+  virtual std::string get_copy_object_source();
   // returns x-amz-decoded-content-length OR Content-Length
   // Always prefer get_data_length*() version since it takes
   // care of both above headers (chunked and non-chunked cases)

--- a/server/s3_addb_map_auto.c
+++ b/server/s3_addb_map_auto.c
@@ -25,7 +25,7 @@
 
 #include "s3_addb_map.h"
 
-const uint64_t g_s3_to_addb_idx_func_name_map_size = 201;
+const uint64_t g_s3_to_addb_idx_func_name_map_size = 200;
 
 const char* g_s3_to_addb_idx_func_name_map[] = {
     "Action::check_authentication",
@@ -76,9 +76,8 @@ const char* g_s3_to_addb_idx_func_name_map[] = {
     "S3Action::load_metadata",
     "S3Action::set_authorization_meta",
     "S3BucketActionTest::func_callback_one",
+    "S3CopyObjectAction::copy_object",
     "S3CopyObjectAction::create_object",
-    "S3CopyObjectAction::initiate_data_streaming",
-    "S3CopyObjectAction::read_object",
     "S3CopyObjectAction::save_metadata",
     "S3CopyObjectAction::send_response_to_s3_client",
     "S3CopyObjectAction::validate_copyobject_request",

--- a/server/s3_addb_map_auto.c
+++ b/server/s3_addb_map_auto.c
@@ -25,7 +25,7 @@
 
 #include "s3_addb_map.h"
 
-const uint64_t g_s3_to_addb_idx_func_name_map_size = 196;
+const uint64_t g_s3_to_addb_idx_func_name_map_size = 201;
 
 const char* g_s3_to_addb_idx_func_name_map[] = {
     "Action::check_authentication",
@@ -76,7 +76,12 @@ const char* g_s3_to_addb_idx_func_name_map[] = {
     "S3Action::load_metadata",
     "S3Action::set_authorization_meta",
     "S3BucketActionTest::func_callback_one",
+    "S3CopyObjectAction::create_object",
+    "S3CopyObjectAction::initiate_data_streaming",
+    "S3CopyObjectAction::read_object",
+    "S3CopyObjectAction::save_metadata",
     "S3CopyObjectAction::send_response_to_s3_client",
+    "S3CopyObjectAction::validate_copyobject_request",
     "S3DeleteBucketAction::delete_bucket",
     "S3DeleteBucketAction::delete_multipart_objects",
     "S3DeleteBucketAction::fetch_first_object_metadata",

--- a/server/s3_addb_map_auto.c
+++ b/server/s3_addb_map_auto.c
@@ -25,7 +25,7 @@
 
 #include "s3_addb_map.h"
 
-const uint64_t g_s3_to_addb_idx_func_name_map_size = 195;
+const uint64_t g_s3_to_addb_idx_func_name_map_size = 196;
 
 const char* g_s3_to_addb_idx_func_name_map[] = {
     "Action::check_authentication",
@@ -76,6 +76,7 @@ const char* g_s3_to_addb_idx_func_name_map[] = {
     "S3Action::load_metadata",
     "S3Action::set_authorization_meta",
     "S3BucketActionTest::func_callback_one",
+    "S3CopyObjectAction::send_response_to_s3_client",
     "S3DeleteBucketAction::delete_bucket",
     "S3DeleteBucketAction::delete_multipart_objects",
     "S3DeleteBucketAction::fetch_first_object_metadata",

--- a/server/s3_addb_plugin_auto.cc
+++ b/server/s3_addb_plugin_auto.cc
@@ -45,6 +45,7 @@
 #include "motr_put_key_value_action.h"
 #include "s3_abort_multipart_action.h"
 #include "s3_account_delete_metadata_action.h"
+#include "s3_copy_object_action.h"
 #include "s3_delete_bucket_action.h"
 #include "s3_delete_bucket_policy_action.h"
 #include "s3_delete_bucket_tagging_action.h"
@@ -104,6 +105,8 @@ int s3_addb_init() {
       S3_ADDB_S3_ABORT_MULTIPART_ACTION_ID;
   gs_addb_map[std::type_index(typeid(S3AccountDeleteMetadataAction))] =
       S3_ADDB_S3_ACCOUNT_DELETE_METADATA_ACTION_ID;
+  gs_addb_map[std::type_index(typeid(S3CopyObjectAction))] =
+      S3_ADDB_S3_COPY_OBJECT_ACTION_ID;
   gs_addb_map[std::type_index(typeid(S3DeleteBucketAction))] =
       S3_ADDB_S3_DELETE_BUCKET_ACTION_ID;
   gs_addb_map[std::type_index(typeid(S3DeleteBucketPolicyAction))] =
@@ -228,6 +231,12 @@ int s3_addb_init() {
          ": class S3AccountDeleteMetadataAction\n",
          (uint64_t)S3_ADDB_S3_ACCOUNT_DELETE_METADATA_ACTION_ID,
          (int64_t)S3_ADDB_S3_ACCOUNT_DELETE_METADATA_ACTION_ID);
+
+  s3_log(S3_LOG_DEBUG, "",
+         "  * id 0x%" PRIx64 "/%" PRId64  // suppress clang warning
+         ": class S3CopyObjectAction\n",
+         (uint64_t)S3_ADDB_S3_COPY_OBJECT_ACTION_ID,
+         (int64_t)S3_ADDB_S3_COPY_OBJECT_ACTION_ID);
 
   s3_log(S3_LOG_DEBUG, "",
          "  * id 0x%" PRIx64 "/%" PRId64  // suppress clang warning

--- a/server/s3_addb_plugin_auto.h
+++ b/server/s3_addb_plugin_auto.h
@@ -85,6 +85,8 @@ enum S3AddbActionTypeId {
   S3_ADDB_S3_ABORT_MULTIPART_ACTION_ID,
   /* S3AccountDeleteMetadataAction: */
   S3_ADDB_S3_ACCOUNT_DELETE_METADATA_ACTION_ID,
+  /* S3CopyObjectAction: */
+  S3_ADDB_S3_COPY_OBJECT_ACTION_ID,
   /* S3DeleteBucketAction: */
   S3_ADDB_S3_DELETE_BUCKET_ACTION_ID,
   /* S3DeleteBucketPolicyAction: */

--- a/server/s3_api_handler.h
+++ b/server/s3_api_handler.h
@@ -143,7 +143,7 @@ class S3ObjectAPIHandler : public S3APIHandler {
   FRIEND_TEST(S3ObjectAPIHandlerTest, ShouldCreateS3AbortMultipartAction);
   FRIEND_TEST(S3ObjectAPIHandlerTest, ShouldCreateS3HeadObjectAction);
   FRIEND_TEST(S3ObjectAPIHandlerTest, ShouldCreateS3PutChunkUploadObjectAction);
-  FRIEND_TEST(S3ObjectAPIHandlerTest, DoesNotSupportCopyObject);
+  FRIEND_TEST(S3ObjectAPIHandlerTest, ShouldCreateS3CopyObjectAction);
   FRIEND_TEST(S3ObjectAPIHandlerTest, ShouldCreateS3PutObjectAction);
   FRIEND_TEST(S3ObjectAPIHandlerTest, ShouldCreateS3GetObjectAction);
   FRIEND_TEST(S3ObjectAPIHandlerTest, ShouldCreateS3DeleteObjectAction);

--- a/server/s3_copy_object_action.cc
+++ b/server/s3_copy_object_action.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+#include "s3_copy_object_action.h"
+#include "s3_log.h"
+#include "s3_error_codes.h"
+#include "s3_common_utilities.h"
+
+S3CopyObjectAction::S3CopyObjectAction(
+    std::shared_ptr<S3RequestObject> req, std::shared_ptr<MotrAPI> motr_api,
+    std::shared_ptr<S3BucketMetadataFactory> bucket_meta_factory,
+    std::shared_ptr<S3ObjectMetadataFactory> object_meta_factory,
+    std::shared_ptr<S3MotrWriterFactory> motrwriter_s3_factory,
+    std::shared_ptr<S3MotrReaderFactory> motrreader_s3_factory,
+    std::shared_ptr<S3MotrKVSWriterFactory> kv_writer_factory)
+    : S3ObjectAction(std::move(req), std::move(bucket_meta_factory),
+                     std::move(object_meta_factory)),
+      write_in_progress(false),
+      read_in_progress(false) {
+  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_INFO, request_id,
+         "S3 API: Copy Object. Destination: [%s], Source: [%s]\n",
+         request->get_bucket_name().c_str(),
+         request->get_copy_object_source().c_str());
+  setup_steps();
+};
+
+void S3CopyObjectAction::setup_steps() {
+  s3_log(S3_LOG_DEBUG, request_id, "Setting up the action\n");
+  ACTION_TASK_ADD(S3CopyObjectAction::send_response_to_s3_client, this);
+}
+
+void S3CopyObjectAction::fetch_bucket_info_failed() {
+  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  send_response_to_s3_client();
+  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+}
+
+void S3CopyObjectAction::fetch_object_info_failed() {
+  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  send_response_to_s3_client();
+  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+}
+
+void S3CopyObjectAction::fetch_object_info_success() {
+  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  send_response_to_s3_client();
+  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  next();
+}
+
+void S3CopyObjectAction::send_response_to_s3_client() {
+  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+
+  std::string response_xml = get_response_xml();
+  request->send_response(S3HttpSuccess200, response_xml);
+  done();
+  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+}
+
+std::string S3CopyObjectAction::get_response_xml() {
+  std::string response_xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+  response_xml +=
+      "<CopyObjectResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">";
+  response_xml += S3CommonUtilities::format_xml_string("LastModified", "");
+  response_xml += S3CommonUtilities::format_xml_string("ETag", "");
+  response_xml += "</CopyObjectResult>";
+  return response_xml;
+}

--- a/server/s3_copy_object_action.cc
+++ b/server/s3_copy_object_action.cc
@@ -83,6 +83,7 @@ void S3CopyObjectAction::setup_steps() {
   ACTION_TASK_ADD(S3CopyObjectAction::send_response_to_s3_client, this);
 }
 
+// Destination bucket
 void S3CopyObjectAction::fetch_bucket_info_failed() {
   s3_log(S3_LOG_INFO, request_id, "Entering\n");
   s3_copy_action_state = S3CopyObjectActionState::validationFailed;
@@ -102,42 +103,49 @@ void S3CopyObjectAction::fetch_bucket_info_failed() {
   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
 }
 
+// Destination object
 void S3CopyObjectAction::fetch_object_info_failed() {
   s3_log(S3_LOG_INFO, request_id, "Entering\n");
   next();
   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
 }
 
+// Destination object
 void S3CopyObjectAction::fetch_object_info_success() {
   s3_log(S3_LOG_INFO, request_id, "Entering\n");
   next();
   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
 }
 
+// Validate source bucket and object
 void S3CopyObjectAction::validate_copyobject_request() {
   s3_log(S3_LOG_INFO, request_id, "Entering\n");
   next();
   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
 }
 
+// Create destination object
 void S3CopyObjectAction::create_object() {
   s3_log(S3_LOG_INFO, request_id, "Entering\n");
   next();
   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
 }
 
+// Read source object
 void S3CopyObjectAction::read_object() {
   s3_log(S3_LOG_INFO, request_id, "Entering\n");
   next();
   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
 }
 
+// Write data to destination object
 void S3CopyObjectAction::initiate_data_streaming() {
   s3_log(S3_LOG_INFO, request_id, "Entering\n");
   next();
   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
 }
 
+// Save destination object metadata
 void S3CopyObjectAction::save_metadata() {
   s3_log(S3_LOG_INFO, request_id, "Entering\n");
   next();
@@ -149,6 +157,7 @@ std::string S3CopyObjectAction::get_response_xml() {
   response_xml +=
       "<CopyObjectResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">";
   response_xml += S3CommonUtilities::format_xml_string("LastModified", "");
+  // ETag for the destination object would be same as Etag for Source Object
   response_xml += S3CommonUtilities::format_xml_string("ETag", "");
   response_xml += "</CopyObjectResult>";
   return response_xml;

--- a/server/s3_copy_object_action.cc
+++ b/server/s3_copy_object_action.cc
@@ -77,10 +77,21 @@ void S3CopyObjectAction::setup_steps() {
   s3_log(S3_LOG_DEBUG, request_id, "Setting up the action\n");
   ACTION_TASK_ADD(S3CopyObjectAction::validate_copyobject_request, this);
   ACTION_TASK_ADD(S3CopyObjectAction::create_object, this);
-  ACTION_TASK_ADD(S3CopyObjectAction::read_object, this);
-  ACTION_TASK_ADD(S3CopyObjectAction::initiate_data_streaming, this);
+  ACTION_TASK_ADD(S3CopyObjectAction::copy_object, this);
   ACTION_TASK_ADD(S3CopyObjectAction::save_metadata, this);
   ACTION_TASK_ADD(S3CopyObjectAction::send_response_to_s3_client, this);
+}
+
+// read source object
+void S3CopyObjectAction::read_object() {
+  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+}
+
+// write to destination object
+void S3CopyObjectAction::initiate_data_streaming() {
+  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
 }
 
 // Destination bucket
@@ -131,16 +142,11 @@ void S3CopyObjectAction::create_object() {
   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
 }
 
-// Read source object
-void S3CopyObjectAction::read_object() {
+// Copy source object to destination object
+void S3CopyObjectAction::copy_object() {
   s3_log(S3_LOG_INFO, request_id, "Entering\n");
-  next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
-}
-
-// Write data to destination object
-void S3CopyObjectAction::initiate_data_streaming() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  read_object();              // read source object
+  initiate_data_streaming();  // write to destination object
   next();
   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
 }

--- a/server/s3_copy_object_action.cc
+++ b/server/s3_copy_object_action.cc
@@ -151,19 +151,19 @@ void S3CopyObjectAction::create_object() {
 void S3CopyObjectAction::read_object() {
   s3_log(S3_LOG_INFO, request_id, "Entering\n");
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");  
+  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
 }
 
 void S3CopyObjectAction::initiate_data_streaming() {
   s3_log(S3_LOG_INFO, request_id, "Entering\n");
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");      
+  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
 }
 
 void S3CopyObjectAction::save_metadata() {
   s3_log(S3_LOG_INFO, request_id, "Entering\n");
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");    
+  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
 }
 
 void S3CopyObjectAction::send_response_to_s3_client() {

--- a/server/s3_copy_object_action.h
+++ b/server/s3_copy_object_action.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+#ifndef __S3_SERVER_S3_COPY_OBJECT_ACTION_H__
+#define __S3_SERVER_S3_COPY_OBJECT_ACTION_H__
+
+#include "s3_object_action_base.h"
+
+class S3CopyObjectAction : public S3ObjectAction {
+  bool write_in_progress;
+  bool read_in_progress;
+
+ public:
+  S3CopyObjectAction(
+      std::shared_ptr<S3RequestObject> req,
+      std::shared_ptr<MotrAPI> motr_api = nullptr,
+      std::shared_ptr<S3BucketMetadataFactory> bucket_meta_factory = nullptr,
+      std::shared_ptr<S3ObjectMetadataFactory> object_meta_factory = nullptr,
+      std::shared_ptr<S3MotrWriterFactory> motrwriter_s3_factory = nullptr,
+      std::shared_ptr<S3MotrReaderFactory> motrreader_s3_factory = nullptr,
+      std::shared_ptr<S3MotrKVSWriterFactory> kv_writer_factory = nullptr);
+
+  void setup_steps();
+
+  void fetch_bucket_info_failed();
+  void fetch_object_info_failed();
+  void fetch_object_info_success();
+
+  std::string get_response_xml();
+  void send_response_to_s3_client();
+};
+#endif  // __S3_SERVER_S3_COPY_OBJECT_ACTION_H__

--- a/server/s3_copy_object_action.h
+++ b/server/s3_copy_object_action.h
@@ -25,8 +25,13 @@
 #include "s3_object_metadata.h"
 
 enum class S3CopyObjectActionState {
+<<<<<<< HEAD
   empty,             // Initial state
   validationFailed,  // Any validations failed for request, including metadata
+=======
+  empty,                    // Initial state
+  validationFailed,         // Any validations failed for request, including metadata
+>>>>>>> Added more functions
   probableEntryRecordFailed,
   newObjOidCreated,         // New object created
   newObjOidCreationFailed,  // New object create failed

--- a/server/s3_copy_object_action.h
+++ b/server/s3_copy_object_action.h
@@ -83,6 +83,7 @@ class S3CopyObjectAction : public S3ObjectAction {
   void read_object();
   void initiate_data_streaming();
   void save_metadata();
+  void set_authorization_meta();
   void send_response_to_s3_client();
 };
 #endif  // __S3_SERVER_S3_COPY_OBJECT_ACTION_H__

--- a/server/s3_copy_object_action.h
+++ b/server/s3_copy_object_action.h
@@ -25,8 +25,8 @@
 #include "s3_object_metadata.h"
 
 enum class S3CopyObjectActionState {
-  empty,                    // Initial state
-  validationFailed,         // Any validations failed for request, including metadata
+  empty,             // Initial state
+  validationFailed,  // Any validations failed for request, including metadata
   probableEntryRecordFailed,
   newObjOidCreated,         // New object created
   newObjOidCreationFailed,  // New object create failed

--- a/server/s3_copy_object_action.h
+++ b/server/s3_copy_object_action.h
@@ -25,13 +25,8 @@
 #include "s3_object_metadata.h"
 
 enum class S3CopyObjectActionState {
-<<<<<<< HEAD
-  empty,             // Initial state
-  validationFailed,  // Any validations failed for request, including metadata
-=======
   empty,                    // Initial state
   validationFailed,         // Any validations failed for request, including metadata
->>>>>>> Added more functions
   probableEntryRecordFailed,
   newObjOidCreated,         // New object created
   newObjOidCreationFailed,  // New object create failed

--- a/server/s3_copy_object_action.h
+++ b/server/s3_copy_object_action.h
@@ -61,6 +61,11 @@ class S3CopyObjectAction : public S3ObjectAction {
   std::shared_ptr<MotrAPI> s3_motr_api;
   std::shared_ptr<S3ObjectMetadata> new_object_metadata;
 
+  // TODO Edit the read_object() and initiate_data_streaming()
+  // signatures accordingly in subsequent Check-ins, when the design evolves.
+  void read_object();
+  void initiate_data_streaming();
+
  public:
   S3CopyObjectAction(
       std::shared_ptr<S3RequestObject> req,
@@ -80,8 +85,7 @@ class S3CopyObjectAction : public S3ObjectAction {
   std::string get_response_xml();
   void validate_copyobject_request();
   void create_object();
-  void read_object();
-  void initiate_data_streaming();
+  void copy_object();
   void save_metadata();
   void set_authorization_meta();
   void send_response_to_s3_client();

--- a/server/s3_object_api_handler.cc
+++ b/server/s3_object_api_handler.cc
@@ -24,6 +24,7 @@
 #include "s3_get_multipart_part_action.h"
 #include "s3_get_object_acl_action.h"
 #include "s3_get_object_action.h"
+#include "s3_copy_object_action.h"
 #include "s3_head_object_action.h"
 #include "s3_log.h"
 #include "s3_post_complete_action.h"
@@ -122,6 +123,10 @@ void S3ObjectAPIHandler::create_action() {
           } else if (!request->get_header_value("x-amz-copy-source").empty()) {
             // Copy Object not yet supported.
             // Do nothing = unsupported API
+            request->set_action_str("CopyObject");
+            request->set_object_size(request->get_data_length());
+            action = std::make_shared<S3CopyObjectAction>(request);
+            s3_stats_inc("copy_object_request_count");
           } else {
             // single chunk upload
             request->set_action_str("PutObject");

--- a/server/s3_object_api_handler.cc
+++ b/server/s3_object_api_handler.cc
@@ -121,8 +121,6 @@ void S3ObjectAPIHandler::create_action() {
             action = std::make_shared<S3PutChunkUploadObjectAction>(request);
             s3_stats_inc("put_object_chunkupload_request_count");
           } else if (!request->get_header_value("x-amz-copy-source").empty()) {
-            // Copy Object not yet supported.
-            // Do nothing = unsupported API
             request->set_action_str("CopyObject");
             request->set_object_size(request->get_data_length());
             action = std::make_shared<S3CopyObjectAction>(request);

--- a/ut/s3_object_api_handler_test.cc
+++ b/ut/s3_object_api_handler_test.cc
@@ -315,6 +315,9 @@ TEST_F(S3ObjectAPIHandlerTest, ShouldCreateS3CopyObjectAction) {
   input_headers["Authorization"] = "1";
   EXPECT_CALL(*mock_request, get_in_headers_copy()).Times(1).WillOnce(
       ReturnRef(input_headers));
+
+  S3Option::get_instance()->enable_murmurhash_oid();
+
   handler_under_test.reset(
       new S3ObjectAPIHandler(mock_request, S3OperationCode::none));
 
@@ -331,6 +334,7 @@ TEST_F(S3ObjectAPIHandlerTest, ShouldCreateS3CopyObjectAction) {
                    handler_under_test->_get_action().get())) == nullptr);
 
   handler_under_test->_get_action()->i_am_done();
+  S3Option::get_instance()->disable_murmurhash_oid();
 }
 
 TEST_F(S3ObjectAPIHandlerTest, ShouldCreateS3PutObjectAction) {


### PR DESCRIPTION
CopyObject API skeleton implementation.

**CopyObject request to aws-s3** :
$ aws --endpoint-url https://s3.amazonaws.com --profile aws s3api copy-object --bucket dpg-bucket --copy-source archive-drone-pune-west/west-1745.jpg --key new-west-1745.jpg
{
    "CopyObjectResult": {
        "LastModified": "2020-11-05T04:09:25.000Z",
        "ETag": "\"58870ec3982cbb2d691e8d0639f81c6a\""
    }
}

**CopyObject request to cortx-s3** :
$ aws s3api copy-object --bucket my-bk --copy-source my-bk/one-kb-file --key new-1-kb-file
{
    "CopyObjectResult": {
        "LastModified": "", 
        "ETag": ""
    }
}
