### PR TITLE
EOS-14821: [Splunk] fix for allowing grantee displayname as None

### DIFF
--- a/auth/server/src/main/java/com/seagates3/acl/ACLValidation.java
+++ b/auth/server/src/main/java/com/seagates3/acl/ACLValidation.java
@@ -243,7 +243,7 @@ class ACLValidation {
       return false;
     }
 
-    if (displayname != null) {
+    if (displayname != null && !(displayname.equalsIgnoreCase("None"))) {
       if (!(account.getName().equals(displayname))) {
 
         return false;


### PR DESCRIPTION
[Splunk] fix for "s3tests.functional.test_s3.**test_bucket_acls_changes_persistent**"
Changes : Allowing ACL display name as "None" inorder to fix splunk test failures

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>