### PR TITLE
[LDR-R1] S3: EOS-15028: Handle invalid bucket name urlencoding

### DIFF
--- a/server/s3_auth_client.cc
+++ b/server/s3_auth_client.cc
@@ -675,11 +675,13 @@ bool S3AuthClient::setup_auth_request_body() {
   const char *full_path = request->c_get_full_encoded_path();
   if (full_path != NULL) {
     std::string uri_full_path = full_path;
-    // in encoded uri path space is encoding as '+'
-    // but cannonical request should have '%20' for verification.
-    // decode plus into space, this special handling
-    // is not required for other charcters.
-    S3CommonUtilities::find_and_replaceall(uri_full_path, "+", "%20");
+    // Handle encoding of common special characters in uri path space,
+    // if not then cannonical request generation might break with
+    // SignatureDoesNotMatch error.
+    // List of special characters handled are,
+    // '!', '"', '$', '&', ''', '(', ')', '*', '+', ',', ':', ';', '', '<',
+    // '=', '>', '*'
+    uri_full_path = S3CommonUtilities::replace_special_chars(uri_full_path);
     add_key_val_to_body("ClientAbsoluteUri", uri_full_path);
   } else {
     add_key_val_to_body("ClientAbsoluteUri", "");

--- a/server/s3_common_utilities.cc
+++ b/server/s3_common_utilities.cc
@@ -30,6 +30,34 @@
 
 namespace S3CommonUtilities {
 
+// hashtable to identify special character for replacement into encoded format
+// in canonical request
+// supported special characters are '!', '"', '$', '&', ''', '(', ')', '*',
+// '+', ',', ':', ';', '', '<', '=', '>', '@'
+// e.g '!' -> canonical_special_char[33] -> url_encoded_special_chars[33] ->
+// '%21'
+const char canonical_special_char[128] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1,
+    1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 1, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+const char *url_encoded_special_chars[128] = {
+    "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",
+    "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",
+    "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "%20",
+    "%21", "%22", "%23", "%24", "%25", "%26", "%27", "%28", "%29", "%2A", "%2B",
+    "%2C", "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",
+    "0",   "0",   "0",   "%3A", "%3B", "%3C", "%3D", "%3E", "0",   "%40", "0",
+    "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",
+    "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",
+    "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",
+    "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",
+    "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",   "0",
+    "0",   "0",   "0",   "0",   "0",   "0",   "0"};
+
 S3XORObfuscator::S3XORObfuscator() : S3Obfuscator() {}
 
 // Implement simple XOR obfuscator by xoring each byte of the string with
@@ -181,6 +209,24 @@ std::string evhtp_error_flags_description(uint8_t errtype) {
   return errtype_str;
 }
 
+// Special characters will be replacement with their encoded value
+// e.g '!' -> '%21'
+std::string replace_special_chars(std::string &url) {
+  std::string url_replaced_chars;
+  size_t url_len = url.length();
+  if (url_len <= 0) {
+    return url_replaced_chars;
+  }
+  for (unsigned i = 0; i < url_len; i++) {
+    // check if special char
+    if (((int)url[i] < 128) && canonical_special_char[(int)url[i]]) {
+      url_replaced_chars += url_encoded_special_chars[(int)url[i]];
+    } else {
+      url_replaced_chars += url[i];
+    }
+  }
+  return url_replaced_chars;
+}
 }  // namespace S3CommonUtilities
 
 void s3_kickoff_graceful_shutdown(int ignore) {

--- a/server/s3_common_utilities.h
+++ b/server/s3_common_utilities.h
@@ -28,6 +28,9 @@
 
 namespace S3CommonUtilities {
 
+extern const char canonical_special_char[128];
+extern const char *url_encoded_special_chars[128];
+
 class S3Obfuscator {
  public:
   std::string virtual encode(const std::string &input) = 0;
@@ -89,6 +92,9 @@ void find_and_replaceall(std::string &data, const std::string &to_search,
 bool is_yaml_value_null(const std::string &value);
 
 std::string evhtp_error_flags_description(uint8_t errtype);
+
+// encode special characters in uri
+std::string replace_special_chars(std::string &url);
 
 }  // namespace S3CommonUtilities
 


### PR DESCRIPTION
invalid bucketname with special characters needs to be handled before while sending Authenication request to auth client 
if not then Auth server might fail with SignatureDoesNotMatch error

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>