### PR TITLE
[LDR-R1]: EOS-15028:s3:[splunk] fix for handling invalid bucket name

### DIFF
--- a/server/s3_auth_client.cc
+++ b/server/s3_auth_client.cc
@@ -680,6 +680,7 @@ bool S3AuthClient::setup_auth_request_body() {
     // decode plus into space, this special handling
     // is not required for other charcters.
     S3CommonUtilities::find_and_replaceall(uri_full_path, "+", "%20");
+    S3CommonUtilities::find_and_replaceall(uri_full_path, "!", "%21");
     add_key_val_to_body("ClientAbsoluteUri", uri_full_path);
   } else {
     add_key_val_to_body("ClientAbsoluteUri", "");


### PR DESCRIPTION
Handle '!' case for invalid bucket name

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>