### PR TITLE
EOS:15088 - Load source metadata for CopyObject API

### DIFF
--- a/server/request_object.cc
+++ b/server/request_object.cc
@@ -481,7 +481,7 @@ std::string RequestObject::get_content_length_str() {
   return len;
 }
 
-std::string RequestObject::get_copy_object_source() {
+std::string RequestObject::get_headers_copysource() {
   return get_header_value("x-amz-copy-source");
 }
 

--- a/server/request_object.h
+++ b/server/request_object.h
@@ -173,7 +173,7 @@ class RequestObject {
   virtual std::string get_host_header();
   virtual std::string get_host_name();
 
-  virtual std::string get_copy_object_source();
+  virtual std::string get_headers_copysource();
   // returns x-amz-decoded-content-length OR Content-Length
   // Always prefer get_data_length*() version since it takes
   // care of both above headers (chunked and non-chunked cases)

--- a/server/s3_addb_map_auto.c
+++ b/server/s3_addb_map_auto.c
@@ -25,7 +25,7 @@
 
 #include "s3_addb_map.h"
 
-const uint64_t g_s3_to_addb_idx_func_name_map_size = 200;
+const uint64_t g_s3_to_addb_idx_func_name_map_size = 201;
 
 const char* g_s3_to_addb_idx_func_name_map[] = {
     "Action::check_authentication",
@@ -81,6 +81,7 @@ const char* g_s3_to_addb_idx_func_name_map[] = {
     "S3CopyObjectAction::save_metadata",
     "S3CopyObjectAction::send_response_to_s3_client",
     "S3CopyObjectAction::validate_copyobject_request",
+    "S3CopyObjectActionTest::func_callback_one",
     "S3DeleteBucketAction::delete_bucket",
     "S3DeleteBucketAction::delete_multipart_objects",
     "S3DeleteBucketAction::fetch_first_object_metadata",

--- a/server/s3_bucket_metadata.cc
+++ b/server/s3_bucket_metadata.cc
@@ -29,41 +29,20 @@
 #include "s3_common_utilities.h"
 #include "s3_m0_uint128_helper.h"
 
-S3BucketMetadata::S3BucketMetadata(
-    std::shared_ptr<S3RequestObject> req, std::shared_ptr<MotrAPI> motr_api,
-    std::shared_ptr<S3MotrKVSReaderFactory> motr_s3_kvs_reader_factory,
-    std::shared_ptr<S3MotrKVSWriterFactory> motr_s3_kvs_writer_factory)
-    : request(std::move(req)), json_parsing_error(false) {
-  request_id = request->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor");
-
+void S3BucketMetadata::initialize(std::string str_bucket_name) {
   account_name = request->get_account_name();
   account_id = request->get_account_id();
   user_name = request->get_user_name();
   owner_canonical_id = request->get_canonical_id();
   user_id = request->get_user_id();
-  bucket_name = request->get_bucket_name();
-
+  if (str_bucket_name.empty()) {
+    bucket_name = request->get_bucket_name();
+  } else {
+    bucket_name = str_bucket_name;
+  }
   state = S3BucketMetadataState::empty;
   current_op = S3BucketMetadataCurrentOp::none;
 
-  if (motr_api) {
-    s3_motr_api = std::move(motr_api);
-  } else {
-    s3_motr_api = std::make_shared<ConcreteMotrAPI>();
-  }
-
-  if (motr_s3_kvs_reader_factory) {
-    motr_kvs_reader_factory = std::move(motr_s3_kvs_reader_factory);
-  } else {
-    motr_kvs_reader_factory = std::make_shared<S3MotrKVSReaderFactory>();
-  }
-
-  if (motr_s3_kvs_writer_factory) {
-    motr_kvs_writer_factory = std::move(motr_s3_kvs_writer_factory);
-  } else {
-    motr_kvs_writer_factory = std::make_shared<S3MotrKVSWriterFactory>();
-  }
   collision_salt = "index_salt_";
   collision_attempt_count = 0;
 
@@ -87,6 +66,65 @@ S3BucketMetadata::S3BucketMetadata(
   system_defined_attribute["Owner-User-id"] = "";
   system_defined_attribute["Owner-Account"] = "";
   system_defined_attribute["Owner-Account-id"] = "";
+}
+
+S3BucketMetadata::S3BucketMetadata(
+    std::shared_ptr<S3RequestObject> req, std::shared_ptr<MotrAPI> motr_api,
+    std::shared_ptr<S3MotrKVSReaderFactory> motr_s3_kvs_reader_factory,
+    std::shared_ptr<S3MotrKVSWriterFactory> motr_s3_kvs_writer_factory)
+    : request(std::move(req)), json_parsing_error(false) {
+  request_id = request->get_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "Constructor");
+
+  initialize();
+
+  if (motr_api) {
+    s3_motr_api = std::move(motr_api);
+  } else {
+    s3_motr_api = std::make_shared<ConcreteMotrAPI>();
+  }
+
+  if (motr_s3_kvs_reader_factory) {
+    motr_kvs_reader_factory = std::move(motr_s3_kvs_reader_factory);
+  } else {
+    motr_kvs_reader_factory = std::make_shared<S3MotrKVSReaderFactory>();
+  }
+
+  if (motr_s3_kvs_writer_factory) {
+    motr_kvs_writer_factory = std::move(motr_s3_kvs_writer_factory);
+  } else {
+    motr_kvs_writer_factory = std::make_shared<S3MotrKVSWriterFactory>();
+  }
+}
+
+S3BucketMetadata::S3BucketMetadata(
+    std::shared_ptr<S3RequestObject> req, const std::string& str_bucket_name,
+    std::shared_ptr<MotrAPI> motr_api,
+    std::shared_ptr<S3MotrKVSReaderFactory> motr_s3_kvs_reader_factory,
+    std::shared_ptr<S3MotrKVSWriterFactory> motr_s3_kvs_writer_factory)
+    : request(std::move(req)), json_parsing_error(false) {
+  request_id = request->get_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "Constructor");
+
+  initialize(str_bucket_name);
+
+  if (motr_api) {
+    s3_motr_api = std::move(motr_api);
+  } else {
+    s3_motr_api = std::make_shared<ConcreteMotrAPI>();
+  }
+
+  if (motr_s3_kvs_reader_factory) {
+    motr_kvs_reader_factory = std::move(motr_s3_kvs_reader_factory);
+  } else {
+    motr_kvs_reader_factory = std::make_shared<S3MotrKVSReaderFactory>();
+  }
+
+  if (motr_s3_kvs_writer_factory) {
+    motr_kvs_writer_factory = std::move(motr_s3_kvs_writer_factory);
+  } else {
+    motr_kvs_writer_factory = std::make_shared<S3MotrKVSWriterFactory>();
+  }
 }
 
 std::string S3BucketMetadata::get_bucket_name() { return bucket_name; }

--- a/server/s3_bucket_metadata.h
+++ b/server/s3_bucket_metadata.h
@@ -110,9 +110,19 @@ class S3BucketMetadata {
   void regenerate_new_index_name(std::string base_index_name,
                                  std::string& salted_index_name);
 
+  void initialize(std::string bucket = "");
+
  public:
   S3BucketMetadata(
       std::shared_ptr<S3RequestObject> req,
+      std::shared_ptr<MotrAPI> motr_api = nullptr,
+      std::shared_ptr<S3MotrKVSReaderFactory> motr_s3_kvs_reader_factory =
+          nullptr,
+      std::shared_ptr<S3MotrKVSWriterFactory> motr_s3_kvs_writer_factory =
+          nullptr);
+
+  S3BucketMetadata(
+      std::shared_ptr<S3RequestObject> req, const std::string& bucket,
       std::shared_ptr<MotrAPI> motr_api = nullptr,
       std::shared_ptr<S3MotrKVSReaderFactory> motr_s3_kvs_reader_factory =
           nullptr,

--- a/server/s3_bucket_metadata_v1.h
+++ b/server/s3_bucket_metadata_v1.h
@@ -132,6 +132,16 @@ class S3BucketMetadataV1 : public S3BucketMetadata {
       std::shared_ptr<S3GlobalBucketIndexMetadataFactory>
           s3_global_bucket_index_metadata_factory = nullptr);
 
+  S3BucketMetadataV1(
+      std::shared_ptr<S3RequestObject> req, const std::string& str_bucket_name,
+      std::shared_ptr<MotrAPI> motr_api = nullptr,
+      std::shared_ptr<S3MotrKVSReaderFactory> motr_s3_kvs_reader_factory =
+          nullptr,
+      std::shared_ptr<S3MotrKVSWriterFactory> motr_s3_kvs_writer_factory =
+          nullptr,
+      std::shared_ptr<S3GlobalBucketIndexMetadataFactory>
+          s3_global_bucket_index_metadata_factory = nullptr);
+
   virtual void load(std::function<void(void)> on_success,
                     std::function<void(void)> on_failed);
 

--- a/server/s3_copy_object_action.cc
+++ b/server/s3_copy_object_action.cc
@@ -41,7 +41,7 @@ S3CopyObjectAction::S3CopyObjectAction(
   s3_log(S3_LOG_INFO, request_id,
          "S3 API: CopyObject. Destination: [%s], Source: [%s]\n",
          request->get_object_uri().c_str(),
-         request->get_copy_object_source().c_str());
+         request->get_headers_copysource().c_str());
   s3_copy_action_state = S3CopyObjectActionState::empty;
 
   old_object_oid = {0ULL, 0ULL};
@@ -82,6 +82,158 @@ void S3CopyObjectAction::setup_steps() {
   ACTION_TASK_ADD(S3CopyObjectAction::send_response_to_s3_client, this);
 }
 
+void S3CopyObjectAction::get_source_bucket_and_object() {
+  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  std::string source = request->get_headers_copysource();
+  size_t separator_pos = source.find("/");
+  if (separator_pos != std::string::npos) {
+    source_bucket_name = source.substr(0, separator_pos);
+    source_object_name = source.substr(separator_pos + 1);
+  }
+  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+}
+
+void S3CopyObjectAction::fetch_source_bucket_info() {
+  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "Fetch metadata of bucket: %s\n",
+         source_bucket_name.c_str());
+
+  source_bucket_metadata = bucket_metadata_factory->create_bucket_metadata_obj(
+      request, source_bucket_name);
+
+  source_bucket_metadata->load(
+      std::bind(&S3CopyObjectAction::fetch_source_bucket_info_success, this),
+      std::bind(&S3CopyObjectAction::fetch_source_bucket_info_failed, this));
+
+  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+}
+
+void S3CopyObjectAction::fetch_source_bucket_info_success() {
+  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "Found source bucket: [%s] metadata\n",
+         source_bucket_name.c_str());
+
+  // fetch source object metadata
+  fetch_source_object_info();
+
+  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+}
+
+void S3CopyObjectAction::fetch_source_bucket_info_failed() {
+  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+
+  s3_copy_action_state = S3CopyObjectActionState::validationFailed;
+
+  if (source_bucket_metadata->get_state() == S3BucketMetadataState::missing) {
+    s3_log(S3_LOG_DEBUG, request_id, "Source bucket: [%s] not found\n",
+           source_bucket_name.c_str());
+    set_s3_error("NoSuchBucket");
+  } else if (source_bucket_metadata->get_state() ==
+             S3BucketMetadataState::failed_to_launch) {
+    s3_log(S3_LOG_ERROR, request_id,
+           "Source bucket metadata load operation failed due to pre launch "
+           "failure\n");
+    set_s3_error("ServiceUnavailable");
+  } else {
+    s3_log(S3_LOG_DEBUG, request_id, "Source bucket metadata fetch failed\n");
+    set_s3_error("InternalError");
+  }
+  send_response_to_s3_client();
+  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+}
+
+void S3CopyObjectAction::fetch_source_object_info() {
+  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "Found source bucket metadata\n");
+  m0_uint128 source_object_list_oid =
+      source_bucket_metadata->get_object_list_index_oid();
+  m0_uint128 source_object_version_list_oid =
+      source_bucket_metadata->get_objects_version_list_index_oid();
+
+  if ((source_object_list_oid.u_hi == 0ULL &&
+       source_object_list_oid.u_lo == 0ULL) ||
+      (source_object_version_list_oid.u_hi == 0ULL &&
+       source_object_version_list_oid.u_lo == 0ULL)) {
+    // Object list index and version list index missing.
+    fetch_source_object_info_failed();
+  } else {
+    source_object_metadata =
+        object_metadata_factory->create_object_metadata_obj(
+            request, source_bucket_name, source_object_name,
+            source_object_list_oid);
+
+    source_object_metadata->set_objects_version_list_index_oid(
+        source_object_version_list_oid);
+
+    source_object_metadata->load(
+        std::bind(&S3CopyObjectAction::fetch_source_object_info_success, this),
+        std::bind(&S3CopyObjectAction::fetch_source_object_info_failed, this));
+  }
+  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+}
+
+void S3CopyObjectAction::fetch_source_object_info_success() {
+  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id,
+         "Successfully fetched source object metadata\n");
+
+  if (MaxCopyObjectSourceSize < source_object_metadata->get_content_length()) {
+    s3_copy_action_state = S3CopyObjectActionState::validationFailed;
+    set_s3_error("InvalidRequest");
+    send_response_to_s3_client();
+  } else {
+    next();
+  }
+  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+}
+
+void S3CopyObjectAction::fetch_source_object_info_failed() {
+  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+
+  s3_copy_action_state = S3CopyObjectActionState::validationFailed;
+
+  m0_uint128 source_object_list_oid =
+      source_bucket_metadata->get_object_list_index_oid();
+  if (source_object_list_oid.u_hi == 0ULL &&
+      source_object_list_oid.u_lo == 0ULL) {
+    s3_log(S3_LOG_ERROR, request_id, "Object not found\n");
+    set_s3_error("NoSuchKey");
+  } else {
+    if (S3ObjectMetadataState::missing == source_object_metadata->get_state()) {
+      set_s3_error("NoSuchKey");
+    } else if (S3ObjectMetadataState::failed_to_launch ==
+               source_object_metadata->get_state()) {
+      s3_log(S3_LOG_ERROR, request_id,
+             "Source object metadata load operation failed due to pre launch "
+             "failure\n");
+      set_s3_error("ServiceUnavailable");
+    } else {
+      s3_log(S3_LOG_DEBUG, request_id, "Source object metadata fetch failed\n");
+      set_s3_error("InternalError");
+    }
+  }
+  send_response_to_s3_client();
+  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+}
+
+// Validate source bucket and object
+void S3CopyObjectAction::validate_copyobject_request() {
+  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  get_source_bucket_and_object();
+
+  if (source_bucket_name.empty() || source_object_name.empty()) {
+    set_s3_error("InvalidArgument");
+    send_response_to_s3_client();
+  } else if (if_source_and_destination_same()) {
+    s3_copy_action_state = S3CopyObjectActionState::validationFailed;
+    set_s3_error("InvalidRequest");
+    send_response_to_s3_client();
+  } else {
+    fetch_source_bucket_info();
+  }
+  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+}
+
 // read source object
 void S3CopyObjectAction::read_object() {
   s3_log(S3_LOG_INFO, request_id, "Entering\n");
@@ -97,7 +249,9 @@ void S3CopyObjectAction::initiate_data_streaming() {
 // Destination bucket
 void S3CopyObjectAction::fetch_bucket_info_failed() {
   s3_log(S3_LOG_INFO, request_id, "Entering\n");
+
   s3_copy_action_state = S3CopyObjectActionState::validationFailed;
+
   if (bucket_metadata->get_state() == S3BucketMetadataState::missing) {
     s3_log(S3_LOG_DEBUG, request_id, "Bucket not found\n");
     set_s3_error("NoSuchBucket");
@@ -123,13 +277,6 @@ void S3CopyObjectAction::fetch_object_info_failed() {
 
 // Destination object
 void S3CopyObjectAction::fetch_object_info_success() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
-  next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
-}
-
-// Validate source bucket and object
-void S3CopyObjectAction::validate_copyobject_request() {
   s3_log(S3_LOG_INFO, request_id, "Entering\n");
   next();
   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
@@ -181,9 +328,20 @@ void S3CopyObjectAction::send_response_to_s3_client() {
       (is_error_state() && !get_s3_error_code().empty())) {
     // Metadata saved for object is always a success condition.
     assert(s3_copy_action_state != S3CopyObjectActionState::metadataSaved);
+    S3Error error(get_s3_error_code(), request->get_request_id());
 
-    S3Error error(get_s3_error_code(), request->get_request_id(),
-                  request->get_object_uri());
+    if (S3CopyObjectActionState::validationFailed == s3_copy_action_state &&
+        "InvalidRequest" == get_s3_error_code()) {
+      if (if_source_and_destination_same()) {  // Source and Destination same
+        error.set_auth_error_message(InvalidRequestSourceAndDestinationSame);
+      } else if (source_object_metadata->get_content_length() >
+                 MaxCopyObjectSourceSize) {  // Source object size greater than
+                                             // 5GB
+        error.set_auth_error_message(
+            InvalidRequestSourceObjectSizeGreaterThan5GB);
+      }
+    }
+
     std::string& response_xml = error.to_xml();
     request->set_out_header_value("Content-Type", "application/xml");
     request->set_out_header_value("Content-Length",
@@ -203,6 +361,11 @@ void S3CopyObjectAction::send_response_to_s3_client() {
   }
   done();
   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+}
+
+bool S3CopyObjectAction::if_source_and_destination_same() {
+  return ((source_bucket_name == request->get_bucket_name()) &&
+          (source_object_name == request->get_object_name()));
 }
 
 void S3CopyObjectAction::set_authorization_meta() {

--- a/server/s3_error_codes.cc
+++ b/server/s3_error_codes.cc
@@ -31,6 +31,10 @@ S3Error::S3Error(std::string error_code, std::string req_id,
 
 int S3Error::get_http_status_code() { return details.get_http_status_code(); }
 
+void S3Error::set_auth_error_message(const std::string& errmsg) {
+  auth_error_message = errmsg;
+}
+
 std::string& S3Error::to_xml() {
   if (get_http_status_code() == -1) {
     // Object state is invalid, Wrong error code.

--- a/server/s3_error_codes.h
+++ b/server/s3_error_codes.h
@@ -58,10 +58,12 @@ class S3Error {
   std::string xml_message;
 
  public:
-  S3Error(std::string error_code, std::string req_id, std::string res_key,
+  S3Error(std::string error_code, std::string req_id, std::string res_key = "",
           std::string error_message = "");
 
   int get_http_status_code();
+
+  void set_auth_error_message(const std::string&);
 
   std::string& to_xml();
 };

--- a/server/s3_factory.h
+++ b/server/s3_factory.h
@@ -46,6 +46,14 @@ class S3BucketMetadataFactory {
            "S3BucketMetadataFactory::create_bucket_metadata_obj\n");
     return std::make_shared<S3BucketMetadataV1>(req);
   }
+
+  virtual std::shared_ptr<S3BucketMetadata> create_bucket_metadata_obj(
+      std::shared_ptr<S3RequestObject> req,
+      const std::string& str_bucket_name) {
+    s3_log(S3_LOG_DEBUG, "",
+           "S3BucketMetadataFactory::create_bucket_metadata_obj\n");
+    return std::make_shared<S3BucketMetadataV1>(req, str_bucket_name);
+  }
 };
 
 class S3ObjectMetadataFactory {
@@ -58,6 +66,16 @@ class S3ObjectMetadataFactory {
            "S3ObjectMetadataFactory::create_object_metadata_obj\n");
     std::shared_ptr<S3ObjectMetadata> meta =
         std::make_shared<S3ObjectMetadata>(req);
+    meta->set_object_list_index_oid(indx_oid);
+    return meta;
+  }
+  virtual std::shared_ptr<S3ObjectMetadata> create_object_metadata_obj(
+      std::shared_ptr<S3RequestObject> req, const std::string& str_bucket_name,
+      const std::string& str_object_name, m0_uint128 indx_oid = {0ULL, 0ULL}) {
+    s3_log(S3_LOG_DEBUG, "",
+           "S3ObjectMetadataFactory::create_object_metadata_obj\n");
+    std::shared_ptr<S3ObjectMetadata> meta = std::make_shared<S3ObjectMetadata>(
+        req, str_bucket_name, str_object_name);
     meta->set_object_list_index_oid(indx_oid);
     return meta;
   }
@@ -213,6 +231,14 @@ class S3GlobalBucketIndexMetadataFactory {
            "S3GlobalBucketIndexMetadataFactory::create_s3_root_bucket_index_"
            "metadata\n");
     return std::make_shared<S3GlobalBucketIndexMetadata>(req);
+  }
+  virtual std::shared_ptr<S3GlobalBucketIndexMetadata>
+  create_s3_global_bucket_index_metadata(std::shared_ptr<S3RequestObject> req,
+                                         const std::string& str_bucket_name) {
+    s3_log(S3_LOG_DEBUG, "",
+           "S3GlobalBucketIndexMetadataFactory::create_s3_root_bucket_index_"
+           "metadata\n");
+    return std::make_shared<S3GlobalBucketIndexMetadata>(req, str_bucket_name);
   }
 };
 

--- a/server/s3_global_bucket_index_metadata.cc
+++ b/server/s3_global_bucket_index_metadata.cc
@@ -28,6 +28,19 @@
 extern struct m0_uint128 global_bucket_list_index_oid;
 extern struct m0_uint128 replica_global_bucket_list_index_oid;
 
+void S3GlobalBucketIndexMetadata::initialize(
+    const std::string& str_bucket_name) {
+  account_name = request->get_account_name();
+  account_id = request->get_account_id();
+  if (str_bucket_name.empty()) {
+    bucket_name = request->get_bucket_name();
+  } else {
+    bucket_name = str_bucket_name;
+  }
+  state = S3GlobalBucketIndexMetadataState::empty;
+  location_constraint = "us-west-2";
+}
+
 S3GlobalBucketIndexMetadata::S3GlobalBucketIndexMetadata(
     std::shared_ptr<S3RequestObject> req, std::shared_ptr<MotrAPI> motr_api,
     std::shared_ptr<S3MotrKVSReaderFactory> motr_s3_kvs_reader_factory,
@@ -36,11 +49,36 @@ S3GlobalBucketIndexMetadata::S3GlobalBucketIndexMetadata(
   request_id = request->get_request_id();
   s3_log(S3_LOG_DEBUG, request_id, "Constructor");
 
-  account_name = request->get_account_name();
-  account_id = request->get_account_id();
-  bucket_name = request->get_bucket_name();
-  state = S3GlobalBucketIndexMetadataState::empty;
-  location_constraint = "us-west-2";
+  initialize();
+
+  if (motr_api) {
+    s3_motr_api = motr_api;
+  } else {
+    s3_motr_api = std::make_shared<ConcreteMotrAPI>();
+  }
+  if (motr_s3_kvs_reader_factory) {
+    motr_kvs_reader_factory = motr_s3_kvs_reader_factory;
+  } else {
+    motr_kvs_reader_factory = std::make_shared<S3MotrKVSReaderFactory>();
+  }
+  if (motr_s3_kvs_writer_factory) {
+    motr_kvs_writer_factory = motr_s3_kvs_writer_factory;
+  } else {
+    motr_kvs_writer_factory = std::make_shared<S3MotrKVSWriterFactory>();
+  }
+}
+
+S3GlobalBucketIndexMetadata::S3GlobalBucketIndexMetadata(
+    std::shared_ptr<S3RequestObject> req, const std::string& str_bucket_name,
+    std::shared_ptr<MotrAPI> motr_api,
+    std::shared_ptr<S3MotrKVSReaderFactory> motr_s3_kvs_reader_factory,
+    std::shared_ptr<S3MotrKVSWriterFactory> motr_s3_kvs_writer_factory)
+    : request(req), json_parsing_error(false) {
+  request_id = request->get_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "Constructor");
+
+  initialize(str_bucket_name);
+
   if (motr_api) {
     s3_motr_api = motr_api;
   } else {

--- a/server/s3_global_bucket_index_metadata.h
+++ b/server/s3_global_bucket_index_metadata.h
@@ -79,9 +79,18 @@ class S3GlobalBucketIndexMetadata {
   // `true` in case of json parsing failure
   bool json_parsing_error;
 
+  void initialize(const std::string& str_bucket_name = "");
+
  public:
   S3GlobalBucketIndexMetadata(
       std::shared_ptr<S3RequestObject> req,
+      std::shared_ptr<MotrAPI> s3_motr_apii = nullptr,
+      std::shared_ptr<S3MotrKVSReaderFactory> motr_s3_kvs_reader_factory =
+          nullptr,
+      std::shared_ptr<S3MotrKVSWriterFactory> motr_s3_kvs_writer_factory =
+          nullptr);
+  S3GlobalBucketIndexMetadata(
+      std::shared_ptr<S3RequestObject> req, const std::string& str_bucket_name,
       std::shared_ptr<MotrAPI> s3_motr_apii = nullptr,
       std::shared_ptr<S3MotrKVSReaderFactory> motr_s3_kvs_reader_factory =
           nullptr,

--- a/server/s3_object_action_base.cc
+++ b/server/s3_object_action_base.cc
@@ -96,7 +96,7 @@ void S3ObjectAction::fetch_object_info() {
     object_metadata = object_metadata_factory->create_object_metadata_obj(
         request, object_list_oid);
     object_metadata->set_objects_version_list_index_oid(
-        bucket_metadata->get_objects_version_list_index_oid());
+        objects_version_list_oid);
 
     object_metadata->load(
         std::bind(&S3ObjectAction::fetch_object_info_success, this),

--- a/server/s3_object_metadata.cc
+++ b/server/s3_object_metadata.cc
@@ -129,12 +129,12 @@ S3ObjectMetadata::S3ObjectMetadata(
     std::shared_ptr<S3MotrKVSReaderFactory> kv_reader_factory,
     std::shared_ptr<S3MotrKVSWriterFactory> kv_writer_factory,
     std::shared_ptr<MotrAPI> motr_api)
-    : request(std::move(req)) {
+    : bucket_name(str_bucket_name),
+      object_name(str_object_name),
+      request(std::move(req)) {
   request_id = request->get_request_id();
   s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
 
-  bucket_name = request->get_bucket_name();
-  object_name = request->get_object_name();
   initialize(ismultipart, uploadid);
 
   if (motr_api) {

--- a/server/s3_object_metadata.cc
+++ b/server/s3_object_metadata.cc
@@ -42,8 +42,6 @@ void S3ObjectMetadata::initialize(bool ismultipart, std::string uploadid) {
   user_name = request->get_user_name();
   canonical_id = request->get_canonical_id();
   user_id = request->get_user_id();
-  bucket_name = request->get_bucket_name();
-  object_name = request->get_object_name();
   state = S3ObjectMetadataState::empty;
   is_multipart = ismultipart;
   upload_id = uploadid;
@@ -102,6 +100,41 @@ S3ObjectMetadata::S3ObjectMetadata(
   request_id = request->get_request_id();
   s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
 
+  bucket_name = request->get_bucket_name();
+  object_name = request->get_object_name();
+  initialize(ismultipart, uploadid);
+
+  if (motr_api) {
+    s3_motr_api = std::move(motr_api);
+  } else {
+    s3_motr_api = std::make_shared<ConcreteMotrAPI>();
+  }
+
+  if (kv_reader_factory) {
+    motr_kv_reader_factory = std::move(kv_reader_factory);
+  } else {
+    motr_kv_reader_factory = std::make_shared<S3MotrKVSReaderFactory>();
+  }
+
+  if (kv_writer_factory) {
+    mote_kv_writer_factory = std::move(kv_writer_factory);
+  } else {
+    mote_kv_writer_factory = std::make_shared<S3MotrKVSWriterFactory>();
+  }
+}
+
+S3ObjectMetadata::S3ObjectMetadata(
+    std::shared_ptr<S3RequestObject> req, const std::string& str_bucket_name,
+    const std::string& str_object_name, bool ismultipart, std::string uploadid,
+    std::shared_ptr<S3MotrKVSReaderFactory> kv_reader_factory,
+    std::shared_ptr<S3MotrKVSWriterFactory> kv_writer_factory,
+    std::shared_ptr<MotrAPI> motr_api)
+    : request(std::move(req)) {
+  request_id = request->get_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+
+  bucket_name = request->get_bucket_name();
+  object_name = request->get_object_name();
   initialize(ismultipart, uploadid);
 
   if (motr_api) {

--- a/server/s3_object_metadata.h
+++ b/server/s3_object_metadata.h
@@ -156,6 +156,16 @@ class S3ObjectMetadata {
                        nullptr,
                    std::shared_ptr<MotrAPI> motr_api = nullptr);
 
+  S3ObjectMetadata(std::shared_ptr<S3RequestObject> req,
+                   const std::string& str_bucket_name,
+                   const std::string& str_object_name, bool ismultipart = false,
+                   std::string uploadid = "",
+                   std::shared_ptr<S3MotrKVSReaderFactory> kv_reader_factory =
+                       nullptr,
+                   std::shared_ptr<S3MotrKVSWriterFactory> kv_writer_factory =
+                       nullptr,
+                   std::shared_ptr<MotrAPI> motr_api = nullptr);
+
   // Call these when Object metadata save/remove needs to be called.
   // id can be object list index OID or
   // id can be multipart upload list index OID

--- a/ut/mock_s3_bucket_metadata.h
+++ b/ut/mock_s3_bucket_metadata.h
@@ -58,6 +58,10 @@ class MockS3BucketMetadata : public S3BucketMetadataV1 {
   MOCK_METHOD1(set_location_constraint, void(std::string location));
   MOCK_METHOD1(from_json, int(std::string content));
   MOCK_METHOD0(get_owner_canonical_id, std::string());
+  MOCK_METHOD(struct m0_uint128 const, get_object_list_index_oid, (),
+              (override));
+  MOCK_METHOD(struct m0_uint128 const, get_objects_version_list_index_oid, (),
+              (override));
 };
 
 #endif

--- a/ut/mock_s3_factory.h
+++ b/ut/mock_s3_factory.h
@@ -55,10 +55,15 @@ class MockS3BucketMetadataFactory : public S3BucketMetadataFactory {
   }
 
   std::shared_ptr<S3BucketMetadata> create_bucket_metadata_obj(
-      std::shared_ptr<S3RequestObject> req) override {
+      std::shared_ptr<S3RequestObject> req,
+      const std::string& str_bucket_name) override {
     return mock_bucket_metadata;
   }
 
+  std::shared_ptr<S3BucketMetadata> create_bucket_metadata_obj(
+      std::shared_ptr<S3RequestObject> req) override {
+    return mock_bucket_metadata;
+  }
   // Use this to setup your expectations.
   std::shared_ptr<MockS3BucketMetadata> mock_bucket_metadata;
 };
@@ -79,6 +84,14 @@ class MockS3ObjectMetadataFactory : public S3ObjectMetadataFactory {
 
   std::shared_ptr<S3ObjectMetadata> create_object_metadata_obj(
       std::shared_ptr<S3RequestObject> req,
+      struct m0_uint128 indx_oid = {0ULL, 0ULL}) override {
+    mock_object_metadata->set_object_list_index_oid(indx_oid);
+    return mock_object_metadata;
+  }
+
+  std::shared_ptr<S3ObjectMetadata> create_object_metadata_obj(
+      std::shared_ptr<S3RequestObject> req, const std::string& str_bucket_name,
+      const std::string& str_object_name,
       struct m0_uint128 indx_oid = {0ULL, 0ULL}) override {
     mock_object_metadata->set_object_list_index_oid(indx_oid);
     return mock_object_metadata;
@@ -312,6 +325,13 @@ class MockS3GlobalBucketIndexMetadataFactory
 
   std::shared_ptr<S3GlobalBucketIndexMetadata>
   create_s3_global_bucket_index_metadata(std::shared_ptr<S3RequestObject> req)
+      override {
+    return mock_global_bucket_index_metadata;
+  }
+
+  std::shared_ptr<S3GlobalBucketIndexMetadata>
+  create_s3_global_bucket_index_metadata(std::shared_ptr<S3RequestObject> req,
+                                         const std::string& str_bucket_name)
       override {
     return mock_global_bucket_index_metadata;
   }

--- a/ut/mock_s3_request_object.h
+++ b/ut/mock_s3_request_object.h
@@ -76,6 +76,7 @@ class MockS3RequestObject : public S3RequestObject {
   MOCK_METHOD1(get_header_value, std::string(std::string key));
   MOCK_METHOD1(is_header_present, bool(const std::string &key));
   MOCK_METHOD0(get_audit_info, S3AuditInfo &());
+  MOCK_METHOD(std::string, get_headers_copysource, (), (override));
 };
 
 #endif

--- a/ut/s3_copy_object_action_test.cc
+++ b/ut/s3_copy_object_action_test.cc
@@ -1,0 +1,408 @@
+/*
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+#include "mock_s3_factory.h"
+#include "s3_copy_object_action.h"
+#include "s3_ut_common.h"
+#include "s3_test_utils.h"
+
+using ::testing::AtLeast;
+using ::testing::Invoke;
+using ::testing::ReturnRef;
+
+#define CREATE_SOURCE_BUCKET_METADATA                                  \
+  do {                                                                 \
+    EXPECT_CALL(*(ptr_mock_bucket_meta_factory->mock_bucket_metadata), \
+                load(_, _)).Times(AtLeast(1));                         \
+    action_under_test->fetch_source_bucket_info();                     \
+  } while (0)
+
+#define CREATE_SOURCE_OBJECT_METADATA                                  \
+  do {                                                                 \
+    CREATE_SOURCE_BUCKET_METADATA;                                     \
+    EXPECT_CALL(*(ptr_mock_bucket_meta_factory->mock_bucket_metadata), \
+                get_object_list_index_oid())                           \
+        .Times(1)                                                      \
+        .WillOnce(Return(object_list_indx_oid));                       \
+    EXPECT_CALL(*(ptr_mock_bucket_meta_factory->mock_bucket_metadata), \
+                get_objects_version_list_index_oid())                  \
+        .Times(1)                                                      \
+        .WillOnce(Return(objects_version_list_idx_oid));               \
+    EXPECT_CALL(*(ptr_mock_object_meta_factory->mock_object_metadata), \
+                load(_, _)).Times(AtLeast(1));                         \
+    action_under_test->fetch_source_object_info();                     \
+  } while (0)
+
+#define CREATE_DESTINATION_BUCKET_METADATA                             \
+  do {                                                                 \
+    EXPECT_CALL(*(ptr_mock_bucket_meta_factory->mock_bucket_metadata), \
+                load(_, _)).Times(AtLeast(1));                         \
+    action_under_test->fetch_bucket_info();                            \
+  } while (0)
+
+class S3CopyObjectActionTest : public testing::Test {
+ protected:
+  S3CopyObjectActionTest() {
+    S3Option::get_instance()->disable_auth();
+    evhtp_request_t *req = NULL;
+    EvhtpInterface *evhtp_obj_ptr = new EvhtpWrapper();
+
+    oid = {0x1ffff, 0x1ffff};
+    object_list_indx_oid = {0x11ffff, 0x1ffff};
+    objects_version_list_idx_oid = {0x1ffff, 0x11fff};
+    zero_oid_idx = {0ULL, 0ULL};
+
+    destination_bucket_name = "detination-bucket";
+    destination_object_name = "destination-object";
+    layout_id =
+        S3MotrLayoutMap::get_instance()->get_best_layout_for_object_size();
+    call_count_one = 0;
+
+    ptr_mock_s3_motr_api = std::make_shared<MockS3Motr>();
+    EXPECT_CALL(*ptr_mock_s3_motr_api, m0_h_ufid_next(_))
+        .WillRepeatedly(Invoke(dummy_helpers_ufid_next));
+
+    ptr_mock_request =
+        std::make_shared<MockS3RequestObject>(req, evhtp_obj_ptr);
+    std::map<std::string, std::string> input_headers;
+    input_headers["Authorization"] = "1";
+    EXPECT_CALL(*ptr_mock_request, get_in_headers_copy()).Times(1).WillOnce(
+        ReturnRef(input_headers));
+
+    EXPECT_CALL(*ptr_mock_request, get_bucket_name())
+        .WillRepeatedly(ReturnRef(destination_bucket_name));
+
+    EXPECT_CALL(*ptr_mock_request, get_object_name())
+        .Times(AtLeast(1))
+        .WillOnce(ReturnRef(destination_object_name));
+
+    ptr_mock_bucket_meta_factory =
+        std::make_shared<MockS3BucketMetadataFactory>(ptr_mock_request);
+
+    ptr_mock_object_meta_factory =
+        std::make_shared<MockS3ObjectMetadataFactory>(ptr_mock_request,
+                                                      ptr_mock_s3_motr_api);
+
+    ptr_mock_motr_writer_factory = std::make_shared<MockS3MotrWriterFactory>(
+        ptr_mock_request, oid, ptr_mock_s3_motr_api);
+
+    ptr_mock_motr_reader_factory = std::make_shared<MockS3MotrReaderFactory>(
+        ptr_mock_request, oid, layout_id);
+
+    ptr_mock_motr_kvs_writer_factory =
+        std::make_shared<MockS3MotrKVSWriterFactory>(ptr_mock_request,
+                                                     ptr_mock_s3_motr_api);
+
+    action_under_test.reset(new S3CopyObjectAction(
+        ptr_mock_request, ptr_mock_s3_motr_api, ptr_mock_bucket_meta_factory,
+        ptr_mock_object_meta_factory, ptr_mock_motr_writer_factory,
+        ptr_mock_motr_reader_factory, ptr_mock_motr_kvs_writer_factory));
+  }
+
+  std::shared_ptr<MockS3RequestObject> ptr_mock_request;
+  std::shared_ptr<MockS3Motr> ptr_mock_s3_motr_api;
+  std::shared_ptr<MockS3BucketMetadataFactory> ptr_mock_bucket_meta_factory;
+  std::shared_ptr<MockS3ObjectMetadataFactory> ptr_mock_object_meta_factory;
+  std::shared_ptr<MockS3MotrReaderFactory> ptr_mock_motr_reader_factory;
+  std::shared_ptr<MockS3MotrWriterFactory> ptr_mock_motr_writer_factory;
+  std::shared_ptr<MockS3MotrKVSWriterFactory> ptr_mock_motr_kvs_writer_factory;
+
+  std::shared_ptr<S3CopyObjectAction> action_under_test;
+
+  int call_count_one;
+  struct m0_uint128 oid;
+  struct m0_uint128 objects_version_list_idx_oid;
+  struct m0_uint128 object_list_indx_oid;
+  struct m0_uint128 zero_oid_idx;
+  int layout_id;
+  std::string destination_bucket_name, destination_object_name;
+
+ public:
+  void func_callback_one() { call_count_one += 1; }
+};
+
+TEST_F(S3CopyObjectActionTest, GetSourceBucketAndObjectSuccess) {
+  EXPECT_CALL(*ptr_mock_request, get_headers_copysource()).Times(1).WillOnce(
+      Return("my-source-bucket/my-source-object"));
+
+  action_under_test->get_source_bucket_and_object();
+
+  ASSERT_STREQ("my-source-bucket",
+               action_under_test->source_bucket_name.c_str());
+  ASSERT_STREQ("my-source-object",
+               action_under_test->source_object_name.c_str());
+}
+
+TEST_F(S3CopyObjectActionTest, GetSourceBucketAndObjectFailure) {
+  EXPECT_CALL(*ptr_mock_request, get_headers_copysource()).Times(1).WillOnce(
+      Return("my-source-bucket-my-source-object"));
+
+  action_under_test->get_source_bucket_and_object();
+
+  ASSERT_STREQ("", action_under_test->source_bucket_name.c_str());
+  ASSERT_STREQ("", action_under_test->source_object_name.c_str());
+}
+
+TEST_F(S3CopyObjectActionTest, FetchSourceBucketInfo) {
+  CREATE_SOURCE_BUCKET_METADATA;
+  EXPECT_TRUE(action_under_test->source_bucket_metadata != NULL);
+}
+
+TEST_F(S3CopyObjectActionTest, FetchSourceBucketInfoFailedMissing) {
+  CREATE_SOURCE_BUCKET_METADATA;
+
+  EXPECT_CALL(*(ptr_mock_bucket_meta_factory->mock_bucket_metadata),
+              get_state())
+      .Times(1)
+      .WillOnce(Return(S3BucketMetadataState::missing));
+
+  EXPECT_CALL(*ptr_mock_request, set_out_header_value(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(*ptr_mock_request, send_response(404, _)).Times(1);
+
+  action_under_test->fetch_source_bucket_info_failed();
+
+  EXPECT_STREQ("NoSuchBucket", action_under_test->get_s3_error_code().c_str());
+}
+
+TEST_F(S3CopyObjectActionTest, FetchSourceBucketInfoFailedFailedToLaunch) {
+  CREATE_SOURCE_BUCKET_METADATA;
+
+  EXPECT_CALL(*(ptr_mock_bucket_meta_factory->mock_bucket_metadata),
+              get_state())
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(S3BucketMetadataState::failed_to_launch));
+
+  EXPECT_CALL(*ptr_mock_request, set_out_header_value(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(*ptr_mock_request, send_response(503, _)).Times(1);
+
+  action_under_test->fetch_source_bucket_info_failed();
+
+  EXPECT_STREQ("ServiceUnavailable",
+               action_under_test->get_s3_error_code().c_str());
+}
+
+TEST_F(S3CopyObjectActionTest, FetchSourceBucketInfoFailedInternalError) {
+  CREATE_SOURCE_BUCKET_METADATA;
+
+  EXPECT_CALL(*(ptr_mock_bucket_meta_factory->mock_bucket_metadata),
+              get_state())
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(S3BucketMetadataState::failed));
+
+  EXPECT_CALL(*ptr_mock_request, set_out_header_value(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(*ptr_mock_request, send_response(500, _)).Times(1);
+
+  action_under_test->fetch_source_bucket_info_failed();
+
+  EXPECT_STREQ("InternalError", action_under_test->get_s3_error_code().c_str());
+}
+
+TEST_F(S3CopyObjectActionTest, FetchSourceObjectInfoListIndexGood) {
+  CREATE_SOURCE_OBJECT_METADATA;
+
+  EXPECT_TRUE(action_under_test->source_object_metadata != NULL);
+}
+
+TEST_F(S3CopyObjectActionTest, FetchSourceObjectInfoListIndexNull) {
+  CREATE_SOURCE_BUCKET_METADATA;
+
+  EXPECT_CALL(*(ptr_mock_bucket_meta_factory->mock_bucket_metadata),
+              get_object_list_index_oid())
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(zero_oid_idx));
+
+  EXPECT_CALL(*(ptr_mock_bucket_meta_factory->mock_bucket_metadata),
+              get_objects_version_list_index_oid())
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(zero_oid_idx));
+
+  EXPECT_CALL(*ptr_mock_request, set_out_header_value(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(*ptr_mock_request, send_response(404, _)).Times(1);
+
+  action_under_test->fetch_source_object_info();
+
+  EXPECT_STREQ("NoSuchKey", action_under_test->get_s3_error_code().c_str());
+}
+
+TEST_F(S3CopyObjectActionTest, FetchSourceObjectInfoSuccessGreaterThan5GB) {
+  CREATE_SOURCE_OBJECT_METADATA;
+  EXPECT_CALL(*(ptr_mock_object_meta_factory->mock_object_metadata),
+              get_content_length())
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(MaxCopyObjectSourceSize + 1));
+
+  EXPECT_CALL(*ptr_mock_request, set_out_header_value(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(*ptr_mock_request, send_response(400, _)).Times(1);
+
+  action_under_test->fetch_source_object_info_success();
+
+  EXPECT_STREQ("InvalidRequest",
+               action_under_test->get_s3_error_code().c_str());
+}
+
+TEST_F(S3CopyObjectActionTest, FetchSourceObjectInfoSuccessLessThan5GB) {
+  CREATE_SOURCE_OBJECT_METADATA;
+
+  EXPECT_CALL(*(ptr_mock_object_meta_factory->mock_object_metadata),
+              get_content_length())
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(MaxCopyObjectSourceSize - 1));
+
+  action_under_test->clear_tasks();
+  ACTION_TASK_ADD_OBJPTR(action_under_test,
+                         S3CopyObjectActionTest::func_callback_one, this);
+
+  action_under_test->fetch_source_object_info_success();
+
+  EXPECT_EQ(1, call_count_one);
+}
+
+TEST_F(S3CopyObjectActionTest, ValidateCopyObjectRequestSourceBucketEmpty) {
+  EXPECT_CALL(*ptr_mock_request, get_headers_copysource()).Times(1).WillOnce(
+      Return("sourcebucketsourceobject"));
+  EXPECT_CALL(*ptr_mock_request, set_out_header_value(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(*ptr_mock_request, send_response(400, _)).Times(1);
+
+  action_under_test->validate_copyobject_request();
+
+  EXPECT_STREQ("InvalidArgument",
+               action_under_test->get_s3_error_code().c_str());
+}
+
+TEST_F(S3CopyObjectActionTest,
+       ValidateCopyObjectRequestSourceAndDestinationSame) {
+  std::string destination_bucket = "my-bucket";
+  std::string destination_object = "my-object";
+
+  EXPECT_CALL(*ptr_mock_request, get_headers_copysource()).Times(1).WillOnce(
+      Return("my-bucket/my-object"));
+
+  EXPECT_CALL(*ptr_mock_request, get_bucket_name())
+      .Times(AtLeast(1))
+      .WillRepeatedly(ReturnRef(destination_bucket));
+
+  EXPECT_CALL(*ptr_mock_request, get_object_name())
+      .Times(AtLeast(1))
+      .WillRepeatedly(ReturnRef(destination_object));
+
+  EXPECT_CALL(*ptr_mock_request, set_out_header_value(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(*ptr_mock_request, send_response(400, _)).Times(1);
+
+  action_under_test->validate_copyobject_request();
+
+  ASSERT_STREQ("my-bucket", action_under_test->source_bucket_name.c_str());
+  ASSERT_STREQ("my-object", action_under_test->source_object_name.c_str());
+  EXPECT_EQ(action_under_test->s3_copy_action_state,
+            S3CopyObjectActionState::validationFailed);
+  EXPECT_STREQ("InvalidRequest",
+               action_under_test->get_s3_error_code().c_str());
+}
+
+TEST_F(S3CopyObjectActionTest, ValidateCopyObjectRequestSuccess) {
+  std::string destination_bucket = "my-destination-bucket";
+
+  EXPECT_CALL(*ptr_mock_request, get_headers_copysource()).Times(1).WillOnce(
+      Return("my-source-bucket/my-source-object"));
+
+  EXPECT_CALL(*ptr_mock_request, get_bucket_name())
+      .Times(AtLeast(1))
+      .WillRepeatedly(ReturnRef(destination_bucket));
+
+  EXPECT_CALL(*ptr_mock_request, get_object_name()).Times(0);
+
+  EXPECT_CALL(*(ptr_mock_bucket_meta_factory->mock_bucket_metadata), load(_, _))
+      .Times(AtLeast(1));
+
+  action_under_test->validate_copyobject_request();
+
+  EXPECT_TRUE(action_under_test->source_bucket_metadata != NULL);
+}
+
+TEST_F(S3CopyObjectActionTest,
+       FetchDestinationBucketInfoFailedMetadataMissing) {
+  CREATE_DESTINATION_BUCKET_METADATA;
+  EXPECT_CALL(*(ptr_mock_bucket_meta_factory->mock_bucket_metadata),
+              get_state())
+      .WillRepeatedly(Return(S3BucketMetadataState::missing));
+
+  EXPECT_CALL(*ptr_mock_request, set_out_header_value(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(*ptr_mock_request, send_response(404, _)).Times(1);
+
+  action_under_test->fetch_bucket_info_failed();
+
+  EXPECT_STREQ("NoSuchBucket", action_under_test->get_s3_error_code().c_str());
+  EXPECT_TRUE(action_under_test->bucket_metadata != NULL);
+  EXPECT_TRUE(action_under_test->object_metadata == NULL);
+}
+
+TEST_F(S3CopyObjectActionTest, FetchDestinationBucketInfoFailedFailedToLaunch) {
+  CREATE_DESTINATION_BUCKET_METADATA;
+  EXPECT_CALL(*(ptr_mock_bucket_meta_factory->mock_bucket_metadata),
+              get_state())
+      .WillRepeatedly(Return(S3BucketMetadataState::failed_to_launch));
+
+  EXPECT_CALL(*ptr_mock_request, set_out_header_value(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(*ptr_mock_request, send_response(503, _)).Times(1);
+
+  action_under_test->fetch_bucket_info_failed();
+
+  EXPECT_STREQ("ServiceUnavailable",
+               action_under_test->get_s3_error_code().c_str());
+  EXPECT_TRUE(action_under_test->bucket_metadata != NULL);
+  EXPECT_TRUE(action_under_test->object_metadata == NULL);
+}
+
+TEST_F(S3CopyObjectActionTest, FetchDestinationBucketInfoFailedInternalError) {
+  CREATE_DESTINATION_BUCKET_METADATA;
+  EXPECT_CALL(*(ptr_mock_bucket_meta_factory->mock_bucket_metadata),
+              get_state())
+      .WillRepeatedly(Return(S3BucketMetadataState::failed));
+
+  EXPECT_CALL(*ptr_mock_request, set_out_header_value(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(*ptr_mock_request, send_response(500, _)).Times(1);
+
+  action_under_test->fetch_bucket_info_failed();
+
+  EXPECT_STREQ("InternalError", action_under_test->get_s3_error_code().c_str());
+  EXPECT_TRUE(action_under_test->bucket_metadata != NULL);
+  EXPECT_TRUE(action_under_test->object_metadata == NULL);
+}
+
+TEST_F(S3CopyObjectActionTest, FetchDestinationObjectInfoFailed) {
+  call_count_one = 0;
+  action_under_test->clear_tasks();
+  ACTION_TASK_ADD_OBJPTR(action_under_test,
+                         S3CopyObjectActionTest::func_callback_one, this);
+
+  action_under_test->fetch_object_info_failed();
+
+  EXPECT_EQ(1, call_count_one);
+}
+
+TEST_F(S3CopyObjectActionTest, FetchDestinationObjectInfoSuccess) {
+  call_count_one = 0;
+  action_under_test->clear_tasks();
+  ACTION_TASK_ADD_OBJPTR(action_under_test,
+                         S3CopyObjectActionTest::func_callback_one, this);
+
+  action_under_test->fetch_object_info_success();
+
+  EXPECT_EQ(1, call_count_one);
+}

--- a/ut/s3_delete_bucket_action_test.cc
+++ b/ut/s3_delete_bucket_action_test.cc
@@ -125,12 +125,23 @@ TEST_F(S3DeleteBucketActionTest, FetchFirstObjectMetadataPresent) {
   EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata), get_state())
       .WillOnce(Return(S3BucketMetadataState::present));
 
-  // set the OID
-  action_under_test->bucket_metadata->set_object_list_index_oid(oid);
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),
+              get_object_list_index_oid())
+      .Times(1)
+      .WillOnce(Return(oid));
+
+  struct m0_uint128 version_list_oid = {0x1ffff, 0x1ffff};
+
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),
+              get_objects_version_list_index_oid())
+      .Times(1)
+      .WillOnce(Return(version_list_oid));
 
   EXPECT_CALL(*(motr_kvs_reader_factory->mock_motr_kvs_reader),
               next_keyval(_, _, _, _, _, _)).Times(1);
+
   action_under_test->fetch_first_object_metadata();
+
   EXPECT_TRUE(action_under_test->motr_kv_reader != nullptr);
 }
 

--- a/ut/s3_delete_multiple_objects_action_test.cc
+++ b/ut/s3_delete_multiple_objects_action_test.cc
@@ -281,8 +281,11 @@ TEST_F(S3DeleteMultipleObjectsActionTest,
 TEST_F(S3DeleteMultipleObjectsActionTest,
        FetchObjectInfoWhenBucketAndObjIndexPresent) {
   CREATE_BUCKET_METADATA;
-  bucket_meta_factory->mock_bucket_metadata->set_object_list_index_oid(
-      object_list_indx_oid);
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),
+              get_object_list_index_oid())
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(object_list_indx_oid));
+
   EXPECT_CALL(*mock_request, get_header_value(_))
       .WillOnce(Return("vxQpICn70jvA6+9R0/d5iA=="));
   // Clear tasks so validate_request_body calls mocked next
@@ -318,8 +321,11 @@ TEST_F(S3DeleteMultipleObjectsActionTest,
   std::vector<std::string> missing_key = {"SampleDocument2.txt"};
   CREATE_BUCKET_METADATA;
 
-  bucket_meta_factory->mock_bucket_metadata->set_object_list_index_oid(
-      object_list_indx_oid);
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),
+              get_object_list_index_oid())
+      .Times(1)
+      .WillOnce(Return(object_list_indx_oid));
+
   EXPECT_CALL(*mock_request, get_header_value(_))
       .WillOnce(Return("vxQpICn70jvA6+9R0/d5iA=="));
   // Clear tasks so validate_request_body calls mocked next
@@ -379,10 +385,15 @@ TEST_F(S3DeleteMultipleObjectsActionTest,
 
   CREATE_BUCKET_METADATA;
 
-  bucket_meta_factory->mock_bucket_metadata->set_object_list_index_oid(
-      object_list_indx_oid);
-  bucket_meta_factory->mock_bucket_metadata->set_objects_version_list_index_oid(
-      objects_version_list_indx_oid);
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),
+              get_object_list_index_oid())
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(object_list_indx_oid));
+
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),
+              get_objects_version_list_index_oid())
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(objects_version_list_indx_oid));
 
   // mock kv reader/writer
   action_under_test->motr_kv_reader =
@@ -430,11 +441,15 @@ TEST_F(S3DeleteMultipleObjectsActionTest, FetchObjectsInfoSuccessful) {
       std::make_pair("testkey2", std::make_pair(0, "dummyobjinfoplaceholder")));
 
   CREATE_BUCKET_METADATA;
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),
+              get_object_list_index_oid())
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(object_list_indx_oid));
 
-  bucket_meta_factory->mock_bucket_metadata->set_object_list_index_oid(
-      object_list_indx_oid);
-  bucket_meta_factory->mock_bucket_metadata->set_objects_version_list_index_oid(
-      objects_version_list_indx_oid);
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),
+              get_objects_version_list_index_oid())
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(objects_version_list_indx_oid));
 
   // mock kv reader/writer
   action_under_test->motr_kv_reader =
@@ -618,8 +633,11 @@ TEST_F(S3DeleteMultipleObjectsActionTest,
   my_keys.clear();
   CREATE_BUCKET_METADATA;
 
-  bucket_meta_factory->mock_bucket_metadata->set_object_list_index_oid(
-      object_list_indx_oid);
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),
+              get_object_list_index_oid())
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(object_list_indx_oid));
+
   EXPECT_CALL(*mock_request, get_header_value(_))
       .WillOnce(Return("vxQpICn70jvA6+9R0/d5iA=="));
   // Clear tasks so validate_request_body calls mocked next

--- a/ut/s3_delete_object_action_test.cc
+++ b/ut/s3_delete_object_action_test.cc
@@ -41,20 +41,24 @@ using ::testing::AtLeast;
     action_under_test->fetch_bucket_info();                               \
   } while (0)
 
-#define CREATE_OBJECT_METADATA                                                \
-  do {                                                                        \
-    CREATE_BUCKET_METADATA;                                                   \
-    bucket_meta_factory->mock_bucket_metadata->set_object_list_index_oid(     \
-        object_list_indx_oid);                                                \
-    bucket_meta_factory->mock_bucket_metadata                                 \
-        ->set_objects_version_list_index_oid(objects_version_list_index_oid); \
-    EXPECT_CALL(*(mock_request), http_verb())                                 \
-        .WillOnce(Return(S3HttpVerb::GET));                                   \
-    EXPECT_CALL(*(mock_request), get_operation_code())                        \
-        .WillOnce(Return(S3OperationCode::tagging));                          \
-    EXPECT_CALL(*(object_meta_factory->mock_object_metadata), load(_, _))     \
-        .Times(AtLeast(1));                                                   \
-    action_under_test->fetch_object_info();                                   \
+#define CREATE_OBJECT_METADATA                                            \
+  do {                                                                    \
+    CREATE_BUCKET_METADATA;                                               \
+    EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),             \
+                get_object_list_index_oid())                              \
+        .Times(AtLeast(1))                                                \
+        .WillRepeatedly(Return(object_list_indx_oid));                    \
+    EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),             \
+                get_objects_version_list_index_oid())                     \
+        .Times(AtLeast(1))                                                \
+        .WillRepeatedly(Return(objects_version_list_index_oid));          \
+    EXPECT_CALL(*(mock_request), http_verb())                             \
+        .WillOnce(Return(S3HttpVerb::GET));                               \
+    EXPECT_CALL(*(mock_request), get_operation_code())                    \
+        .WillOnce(Return(S3OperationCode::tagging));                      \
+    EXPECT_CALL(*(object_meta_factory->mock_object_metadata), load(_, _)) \
+        .Times(AtLeast(1));                                               \
+    action_under_test->fetch_object_info();                               \
   } while (0)
 
 class S3DeleteObjectActionTest : public testing::Test {

--- a/ut/s3_get_object_action_test.cc
+++ b/ut/s3_get_object_action_test.cc
@@ -41,20 +41,24 @@ using ::testing::AtLeast;
     action_under_test->fetch_bucket_info();                               \
   } while (0)
 
-#define CREATE_OBJECT_METADATA                                                \
-  do {                                                                        \
-    CREATE_BUCKET_METADATA;                                                   \
-    bucket_meta_factory->mock_bucket_metadata->set_object_list_index_oid(     \
-        object_list_indx_oid);                                                \
-    bucket_meta_factory->mock_bucket_metadata                                 \
-        ->set_objects_version_list_index_oid(objects_version_list_index_oid); \
-    EXPECT_CALL(*(object_meta_factory->mock_object_metadata), load(_, _))     \
-        .Times(AtLeast(1));                                                   \
-    EXPECT_CALL(*(ptr_mock_request), http_verb())                             \
-        .WillOnce(Return(S3HttpVerb::GET));                                   \
-    EXPECT_CALL(*(ptr_mock_request), get_operation_code())                    \
-        .WillOnce(Return(S3OperationCode::tagging));                          \
-    action_under_test->fetch_object_info();                                   \
+#define CREATE_OBJECT_METADATA                                            \
+  do {                                                                    \
+    CREATE_BUCKET_METADATA;                                               \
+    EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),             \
+                get_object_list_index_oid())                              \
+        .Times(AtLeast(1))                                                \
+        .WillRepeatedly(Return(object_list_indx_oid));                    \
+    EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),             \
+                get_objects_version_list_index_oid())                     \
+        .Times(AtLeast(1))                                                \
+        .WillRepeatedly(Return(objects_version_list_index_oid));          \
+    EXPECT_CALL(*(object_meta_factory->mock_object_metadata), load(_, _)) \
+        .Times(AtLeast(1));                                               \
+    EXPECT_CALL(*(ptr_mock_request), http_verb())                         \
+        .WillOnce(Return(S3HttpVerb::GET));                               \
+    EXPECT_CALL(*(ptr_mock_request), get_operation_code())                \
+        .WillOnce(Return(S3OperationCode::tagging));                      \
+    action_under_test->fetch_object_info();                               \
   } while (0)
 
 static bool test_read_object_data_success(size_t num_of_blocks,
@@ -225,10 +229,15 @@ TEST_F(S3GetObjectActionTest, FetchObjectInfoWhenBucketAndObjIndexPresent) {
 
   EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata), get_state())
       .WillRepeatedly(Return(S3BucketMetadataState::present));
-  bucket_meta_factory->mock_bucket_metadata->set_object_list_index_oid(
-      object_list_indx_oid);
-  bucket_meta_factory->mock_bucket_metadata->set_objects_version_list_index_oid(
-      objects_version_list_index_oid);
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),
+              get_object_list_index_oid())
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(object_list_indx_oid));
+
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),
+              get_objects_version_list_index_oid())
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(objects_version_list_index_oid));
 
   EXPECT_CALL(*(object_meta_factory->mock_object_metadata), load(_, _))
       .Times(AtLeast(1));

--- a/ut/s3_global_bucket_index_metadata_test.cc
+++ b/ut/s3_global_bucket_index_metadata_test.cc
@@ -50,14 +50,14 @@ using ::testing::_;
             ->create_motr_kvs_reader(request_mock, s3_motr_api_mock);      \
   } while (0)
 
-#define CREATE_ACTION_UNDER_TEST_OBJ                                 \
-  do {                                                               \
-    request_mock->set_account_name(account_name);                    \
-    request_mock->set_account_id(account_id);                        \
-    global_bucket_idx_metadata_under_test_ptr =                      \
-        std::make_shared<S3GlobalBucketIndexMetadata>(               \
-            request_mock, s3_motr_api_mock, motr_kvs_reader_factory, \
-            motr_kvs_writer_factory);                                \
+#define CREATE_ACTION_UNDER_TEST_OBJ                                     \
+  do {                                                                   \
+    request_mock->set_account_name(account_name);                        \
+    request_mock->set_account_id(account_id);                            \
+    global_bucket_idx_metadata_under_test_ptr =                          \
+        std::make_shared<S3GlobalBucketIndexMetadata>(                   \
+            request_mock, "", s3_motr_api_mock, motr_kvs_reader_factory, \
+            motr_kvs_writer_factory);                                    \
   } while (0)
 
 class S3GlobalBucketIndexMetadataTest : public testing::Test {

--- a/ut/s3_head_object_action_test.cc
+++ b/ut/s3_head_object_action_test.cc
@@ -38,18 +38,22 @@ using ::testing::AtLeast;
     action_under_test->fetch_bucket_info();                               \
   } while (0)
 
-#define CREATE_OBJECT_METADATA                                                \
-  do {                                                                        \
-    CREATE_BUCKET_METADATA;                                                   \
-    bucket_meta_factory->mock_bucket_metadata->set_object_list_index_oid(     \
-        object_list_indx_oid);                                                \
-    bucket_meta_factory->mock_bucket_metadata                                 \
-        ->set_objects_version_list_index_oid(objects_version_list_index_oid); \
-    EXPECT_CALL(*(object_meta_factory->mock_object_metadata), load(_, _))     \
-        .Times(AtLeast(1));                                                   \
-    EXPECT_CALL(*(mock_request), http_verb())                                 \
-        .WillOnce(Return(S3HttpVerb::HEAD));                                  \
-    action_under_test->fetch_object_info();                                   \
+#define CREATE_OBJECT_METADATA                                            \
+  do {                                                                    \
+    CREATE_BUCKET_METADATA;                                               \
+    EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),             \
+                get_object_list_index_oid())                              \
+        .Times(AtLeast(1))                                                \
+        .WillRepeatedly(Return(object_list_indx_oid));                    \
+    EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),             \
+                get_objects_version_list_index_oid())                     \
+        .Times(AtLeast(1))                                                \
+        .WillRepeatedly(Return(objects_version_list_index_oid));          \
+    EXPECT_CALL(*(object_meta_factory->mock_object_metadata), load(_, _)) \
+        .Times(AtLeast(1));                                               \
+    EXPECT_CALL(*(mock_request), http_verb())                             \
+        .WillOnce(Return(S3HttpVerb::HEAD));                              \
+    action_under_test->fetch_object_info();                               \
   } while (0)
 
 class S3HeadObjectActionTest : public testing::Test {

--- a/ut/s3_object_action_base_test.cc
+++ b/ut/s3_object_action_base_test.cc
@@ -192,10 +192,15 @@ TEST_F(S3ObjectActionTest, FetchObjectInfoFailed) {
 TEST_F(S3ObjectActionTest, FetchObjectInfoSuccess) {
   CREATE_BUCKET_METADATA;
   CREATE_OBJECT_METADATA;
-  action_under_test_ptr->bucket_metadata->set_object_list_index_oid(
-      object_list_indx_oid);
-  action_under_test_ptr->bucket_metadata->set_objects_version_list_index_oid(
-      objects_version_list_index_oid);
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),
+              get_object_list_index_oid())
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(object_list_indx_oid));
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),
+              get_objects_version_list_index_oid())
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(objects_version_list_index_oid));
+
   EXPECT_CALL(*(object_meta_factory->mock_object_metadata), load(_, _))
       .Times(AtLeast(1));
   EXPECT_CALL(*(request_mock), http_verb()).WillOnce(Return(S3HttpVerb::GET));

--- a/ut/s3_put_chunk_upload_object_action_test.cc
+++ b/ut/s3_put_chunk_upload_object_action_test.cc
@@ -43,18 +43,22 @@ using ::testing::DefaultValue;
     action_under_test->fetch_bucket_info();                               \
   } while (0)
 
-#define CREATE_OBJECT_METADATA                                                \
-  do {                                                                        \
-    CREATE_BUCKET_METADATA;                                                   \
-    bucket_meta_factory->mock_bucket_metadata->set_object_list_index_oid(     \
-        object_list_indx_oid);                                                \
-    bucket_meta_factory->mock_bucket_metadata                                 \
-        ->set_objects_version_list_index_oid(objects_version_list_index_oid); \
-    EXPECT_CALL(*(object_meta_factory->mock_object_metadata), load(_, _))     \
-        .Times(AtLeast(1));                                                   \
-    EXPECT_CALL(*(mock_request), http_verb())                                 \
-        .WillOnce(Return(S3HttpVerb::PUT));                                   \
-    action_under_test->fetch_object_info();                                   \
+#define CREATE_OBJECT_METADATA                                            \
+  do {                                                                    \
+    CREATE_BUCKET_METADATA;                                               \
+    EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),             \
+                get_object_list_index_oid())                              \
+        .Times(AtLeast(1))                                                \
+        .WillRepeatedly(Return(object_list_indx_oid));                    \
+    EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),             \
+                get_objects_version_list_index_oid())                     \
+        .Times(AtLeast(1))                                                \
+        .WillRepeatedly(Return(objects_version_list_index_oid));          \
+    EXPECT_CALL(*(object_meta_factory->mock_object_metadata), load(_, _)) \
+        .Times(AtLeast(1));                                               \
+    EXPECT_CALL(*(mock_request), http_verb())                             \
+        .WillOnce(Return(S3HttpVerb::PUT));                               \
+    action_under_test->fetch_object_info();                               \
   } while (0)
 
 class S3PutChunkUploadObjectActionTestBase : public testing::Test {

--- a/ut/s3_put_object_action_test.cc
+++ b/ut/s3_put_object_action_test.cc
@@ -62,18 +62,22 @@ using ::testing::DefaultValue;
     action_under_test->fetch_bucket_info();                               \
   } while (0)
 
-#define CREATE_OBJECT_METADATA                                              \
-  do {                                                                      \
-    CREATE_BUCKET_METADATA;                                                 \
-    bucket_meta_factory->mock_bucket_metadata->set_object_list_index_oid(   \
-        object_list_indx_oid);                                              \
-    bucket_meta_factory->mock_bucket_metadata                               \
-        ->set_objects_version_list_index_oid(objects_version_list_idx_oid); \
-    EXPECT_CALL(*(object_meta_factory->mock_object_metadata), load(_, _))   \
-        .Times(AtLeast(1));                                                 \
-    EXPECT_CALL(*(ptr_mock_request), http_verb())                           \
-        .WillOnce(Return(S3HttpVerb::PUT));                                 \
-    action_under_test->fetch_object_info();                                 \
+#define CREATE_OBJECT_METADATA                                            \
+  do {                                                                    \
+    CREATE_BUCKET_METADATA;                                               \
+    EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),             \
+                get_object_list_index_oid())                              \
+        .Times(AtLeast(1))                                                \
+        .WillRepeatedly(Return(object_list_indx_oid));                    \
+    EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),             \
+                get_objects_version_list_index_oid())                     \
+        .Times(AtLeast(1))                                                \
+        .WillRepeatedly(Return(objects_version_list_idx_oid));            \
+    EXPECT_CALL(*(object_meta_factory->mock_object_metadata), load(_, _)) \
+        .Times(AtLeast(1));                                               \
+    EXPECT_CALL(*(ptr_mock_request), http_verb())                         \
+        .WillOnce(Return(S3HttpVerb::PUT));                               \
+    action_under_test->fetch_object_info();                               \
   } while (0)
 
 class S3PutObjectActionTest : public testing::Test {


### PR DESCRIPTION
**Test cases executed:**

1. Non-Existing destination bucket (Error thrown: NoSuchBucket)
2. Non-Existing source bucket (Error thrown: NoSuchBucket)
3. Non-Existing source object (Error thrown: NoSuchKey)
4. Source Object Size greater than 5GB (Error thrown: InvalidArgument)
5. Wrong input (No separator b/w buxket name and object name) to "x-amz-copy-source" header. (Error thrown: InvalidArgument)
6. Source and Destination same (Error thrown: InvalidRequest)
 
