### PR TITLE
EOS-15332: S3 unable to URL decode 'continuation-token'.

### DIFF
--- a/server/s3_object_list_response.cc
+++ b/server/s3_object_list_response.cc
@@ -63,6 +63,7 @@ std::string S3ObjectListResponse::get_response_format_key_value(
   }
   return format_key_value;
 }
+
 void S3ObjectListResponse::set_object_name(std::string name) {
   object_name = get_response_format_key_value(name);
 }
@@ -103,8 +104,13 @@ void S3ObjectListResponse::set_response_is_truncated(bool flag) {
   response_is_truncated = flag;
 }
 
-void S3ObjectListResponse::set_next_marker_key(std::string next) {
-  next_marker_key = get_response_format_key_value(next);
+void S3ObjectListResponse::set_next_marker_key(std::string next,
+                                               bool url_encode) {
+  if (url_encode) {
+    next_marker_key = get_response_format_key_value(next);
+  } else {
+    next_marker_key = next;
+  }
 }
 
 void S3ObjectListResponse::set_next_marker_uploadid(std::string next) {
@@ -175,7 +181,7 @@ std::string& S3ObjectListResponse::get_upload_id() { return upload_id; }
 std::string S3ObjectListResponse::get_next_marker_key() {
   std::string raw_value;
   if (encoding_type == "url") {
-    char* decoded_str = evhttp_uridecode(next_marker_key.c_str(), 1, NULL);
+    char* decoded_str = evhttp_uridecode(next_marker_key.c_str(), 0, NULL);
     raw_value = decoded_str;
     free(decoded_str);
   } else {

--- a/server/s3_object_list_response.h
+++ b/server/s3_object_list_response.h
@@ -83,7 +83,7 @@ class S3ObjectListResponse {
   void set_max_uploads(std::string count);
   void set_max_parts(std::string count);
   void set_response_is_truncated(bool flag);
-  void set_next_marker_key(std::string next);
+  void set_next_marker_key(std::string next, bool url_encode = true);
   void set_next_marker_uploadid(std::string next);
   std::string& get_object_name();
   bool is_response_truncated() { return response_is_truncated; }
@@ -94,6 +94,7 @@ class S3ObjectListResponse {
     }
     return keys;
   }
+  std::string get_encoding_type() { return encoding_type; }
 
   void add_object(std::shared_ptr<S3ObjectMetadata> object);
   void add_part(std::shared_ptr<S3PartMetadata> part);


### PR DESCRIPTION
During validation of List Object V2 request, S3 server is found to be not removing the URL encoded characters (e.g, %2F, %2B) from  'continuation-token'. The reason is unknown. Due to this, there was no removal of '%2F' and '%2B' characters from 'continuation-token', leading to further failure in base64 decoding of 'continuation-token', and thus, the object listing code enumerates from start key of the bucket, instead of from 'continuation-token'
 - Added code to explicitly perform URL decoding of 'continuation-token'.

Signed-off-by: ‘Dattaprasad <dattaprasad.govekar@seagate.com>