### PR TITLE
 [splunk fix] EOS-15368:s3: Update error code for empty authorization header

### DIFF
--- a/auth/server/src/main/java/com/seagates3/authentication/ClientRequestParser.java
+++ b/auth/server/src/main/java/com/seagates3/authentication/ClientRequestParser.java
@@ -42,8 +42,8 @@ public class ClientRequestParser {
             = "AWS [A-Za-z0-9-_]+:[a-zA-Z0-9+/=]+";
     private static final String AWS_V4_AUTHRORIAZATION_PATTERN
             = "AWS4-HMAC-SHA256[\\w\\W]+";
-    private ResponseGenerator responseGenerator
-            = new ResponseGenerator();
+    private
+     ResponseGenerator responseGenerator = new ResponseGenerator();
     private final static Logger LOGGER =
             LoggerFactory.getLogger(ClientRequestParser.class.getName());
     private static final Pattern ACCESS_KEY_PATTERN  = Pattern.compile("[\\w-]+");
@@ -94,7 +94,10 @@ public class ClientRequestParser {
 
         if (authorizationHeader == null ||
             authorizationHeader.replaceAll("\\s+", "").isEmpty()) {
-            return null;
+
+          ServerResponse serverResponse =
+              new ResponseGenerator().AccessDenied();
+          throw new InvalidArgumentException(serverResponse);
         }
         ClientRequestParser clientRequestParser = new ClientRequestParser();
 

--- a/auth/server/src/test/java/com/seagates3/authentication/ClientRequestParserTest.java
+++ b/auth/server/src/test/java/com/seagates3/authentication/ClientRequestParserTest.java
@@ -33,6 +33,8 @@ import java.util.TreeMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.api.mockito.mockpolicies.Slf4jMockPolicy;
 import org.powermock.core.classloader.annotations.MockPolicy;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
@@ -44,14 +46,17 @@ import com.seagates3.aws.AWSV2RequestHelper;
 import com.seagates3.aws.AWSV4RequestHelper;
 import com.seagates3.exception.InvalidAccessKeyException;
 import com.seagates3.exception.InvalidArgumentException;
+import com.seagates3.response.ServerResponse;
+import com.seagates3.response.generator.ResponseGenerator;
 
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 
 @PowerMockIgnore({"javax.management.*"}) @RunWith(PowerMockRunner.class)
-    @PrepareForTest(AuthServerConfig.class)
+    @PrepareForTest({AuthServerConfig.class, ClientRequestParser.class})
     @MockPolicy(Slf4jMockPolicy.class) public class ClientRequestParserTest {
 
     private FullHttpRequest httpRequest;
@@ -102,34 +107,67 @@ import io.netty.handler.codec.http.HttpVersion;
         ClientRequestParser.parse(httpRequest, null);
     }
 
-    @Test
-    public void parseTest_AuthenticateUser_AuthorizationHeaderNull() throws InvalidAccessKeyException,
-            InvalidArgumentException {
+    @Test(
+        expected =
+            InvalidArgumentException
+                .class) public void parseTest_AuthenticateUser_AuthorizationHeaderNull()
+        throws Exception {
 
         requestBody.put("Action", "AuthenticateUser");
+        ServerResponse serverResponse = mock(ServerResponse.class);
+        serverResponse.setResponseStatus(HttpResponseStatus.FORBIDDEN);
+        serverResponse.setResponseBody("Access Denied.");
+        ResponseGenerator mockResponseGenerator = mock(ResponseGenerator.class);
+        PowerMockito.whenNew(ResponseGenerator.class)
+            .withNoArguments()
+            .thenReturn(mockResponseGenerator);
+        Mockito.when(mockResponseGenerator.AccessDenied())
+            .thenReturn(serverResponse);
 
-        assertNull(ClientRequestParser.parse(httpRequest, requestBody));
+        ClientRequestParser.parse(httpRequest, requestBody);
     }
 
-    @Test
-    public void parseTest_AuthorizeUser_AuthorizationHeaderNull() throws InvalidAccessKeyException,
-            InvalidArgumentException{
+    @Test(
+        expected =
+            InvalidArgumentException
+                .class) public void parseTest_AuthorizeUser_AuthorizationHeaderNull()
+        throws Exception {
 
         requestBody.put("Action", "AuthorizeUser");
+        ServerResponse serverResponse = mock(ServerResponse.class);
+        serverResponse.setResponseStatus(HttpResponseStatus.FORBIDDEN);
+        serverResponse.setResponseBody("Access Denied.");
+        ResponseGenerator mockResponseGenerator = mock(ResponseGenerator.class);
+        PowerMockito.whenNew(ResponseGenerator.class)
+            .withNoArguments()
+            .thenReturn(mockResponseGenerator);
+        Mockito.when(mockResponseGenerator.AccessDenied())
+            .thenReturn(serverResponse);
 
-        assertNull(ClientRequestParser.parse(httpRequest, requestBody));
+        ClientRequestParser.parse(httpRequest, requestBody);
     }
 
-    @Test
-    public void parseTest_OtherAction_AuthorizationHeaderNull() throws InvalidAccessKeyException,
-            InvalidArgumentException {
+    @Test(
+        expected =
+            InvalidArgumentException
+                .class) public void parseTest_OtherAction_AuthorizationHeaderNull()
+        throws Exception {
         requestBody.put("Action", "OtherAction");
         FullHttpRequest fullHttpRequest
                 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
         fullHttpRequest.headers().add("XYZ", "");
         when(httpRequest.headers()).thenReturn(fullHttpRequest.headers());
+        ServerResponse serverResponse = mock(ServerResponse.class);
+        serverResponse.setResponseStatus(HttpResponseStatus.FORBIDDEN);
+        serverResponse.setResponseBody("Access Denied.");
+        ResponseGenerator mockResponseGenerator = mock(ResponseGenerator.class);
+        PowerMockito.whenNew(ResponseGenerator.class)
+            .withNoArguments()
+            .thenReturn(mockResponseGenerator);
+        Mockito.when(mockResponseGenerator.AccessDenied())
+            .thenReturn(serverResponse);
 
-        assertNull(ClientRequestParser.parse(httpRequest, requestBody));
+        ClientRequestParser.parse(httpRequest, requestBody);
     }
 
     @Test

--- a/st/clitests/auth_spec_signcalc_test_data.yaml
+++ b/st/clitests/auth_spec_signcalc_test_data.yaml
@@ -211,7 +211,7 @@ test9:
     req-headers:
         Content-type: application/x-www-form-urlencoded
         Accept: text/plain
-    output: '<?xml version="1.0" encoding="UTF-8" standalone="no"?><ErrorResponse xmlns="https://iam.seagate.com/doc/2010-05-08/"><Error><Code>InvalidArgument</Code><Message>AuthorizationHeaderMalformed</Message></Error><RequestId>0000</RequestId></ErrorResponse>'
+    output: '<?xml version="1.0" encoding="UTF-8" standalone="no"?><ErrorResponse xmlns="https://iam.seagate.com/doc/2010-05-08/"><Error><Code>AccessDenied</Code><Message>Access Denied.</Message></Error><RequestId>0000</RequestId></ErrorResponse>'
 
 test10:
     test-title: Authenticate user using AWS Signature Version 4


### PR DESCRIPTION
fix Splunk failures for handling empty authorization header in Authserver request,
test case : 
  s3tests.functional.test_headers.test_bucket_create_bad_authorization_empty
  s3tests.functional.test_headers.test_object_create_bad_authorization_empty

**Old behavior** :
For Authorization request, if Auth server receives empty authorization header then we are returning "AuthorizationHeaderMalformed" response with 400 status code.

**New behavior** :
If aws receives empty authorization request then it will throw "Forbidden" response with 403 as status code

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>