### PR TITLE
EOS-15481: Dynamic log level changes

### DIFF
--- a/s3backgrounddelete/s3backgroundconsumer.service
+++ b/s3backgrounddelete/s3backgroundconsumer.service
@@ -25,7 +25,7 @@ Environment="PYTHONPATH=/usr/lib/python3.6/site-packages/"
 Type=simple
 ExecStart=/opt/seagate/cortx/s3/s3backgrounddelete/s3backgroundconsumer
 ExecStop=/bin/kill -TERM $MAINPID
-ExecReload=/bin/kill -USR1 $MAINPID
+ExecReload=/bin/kill -HUP $MAINPID
 TimeoutSec=300
 # Other restart options: always, on-abort, etc
 

--- a/s3backgrounddelete/s3backgroundconsumer.service
+++ b/s3backgrounddelete/s3backgroundconsumer.service
@@ -25,6 +25,7 @@ Environment="PYTHONPATH=/usr/lib/python3.6/site-packages/"
 Type=simple
 ExecStart=/opt/seagate/cortx/s3/s3backgrounddelete/s3backgroundconsumer
 ExecStop=/bin/kill -TERM $MAINPID
+ExecReload=/bin/kill -USR1 $MAINPID
 TimeoutSec=300
 # Other restart options: always, on-abort, etc
 

--- a/s3backgrounddelete/s3backgrounddelete/cortx_s3_signal.py
+++ b/s3backgrounddelete/s3backgrounddelete/cortx_s3_signal.py
@@ -46,4 +46,4 @@ class DynamicConfigHandler(object):
         sighupArg.config = CORTXS3Config()
         sighupArg.logger.setLevel(sighupArg.config.get_file_log_level())
 
-        sighupArg.logger.error("Logging level has been changed")
+        sighupArg.logger.info("Logging level has been changed")

--- a/s3backgrounddelete/s3backgrounddelete/cortx_s3_signal.py
+++ b/s3backgrounddelete/s3backgrounddelete/cortx_s3_signal.py
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+"""
+This class implements the signal handler that is used for
+dynamically changing config parameters
+"""
+#!/usr/bin/python3.6
+
+import os
+import traceback
+import logging
+import datetime
+import signal
+from logging import handlers
+from functools import partial
+
+from s3backgrounddelete.cortx_s3_config import CORTXS3Config
+
+class DynamicConfigHandler(object):
+    """Signal handler class for dynamically changing config parameters"""
+
+    def __init__(self,objectx):
+        """Init the signal handler"""
+        sighupArg=objectx
+        signal.signal(signal.SIGHUP,partial(self.sighup_handler_callback, sighupArg))
+
+    def sighup_handler_callback(self, sighupArg, signum, frame):
+        """Reload the configuration"""
+        sighupArg.config = CORTXS3Config()
+        sighupArg.logger.setLevel(sighupArg.config.get_file_log_level())
+
+        sighupArg.logger.error("Logging level has been changed")

--- a/s3backgrounddelete/s3backgrounddelete/object_recovery_processor.py
+++ b/s3backgrounddelete/s3backgrounddelete/object_recovery_processor.py
@@ -32,7 +32,7 @@ from logging import handlers
 
 from s3backgrounddelete.object_recovery_queue import ObjectRecoveryRabbitMq
 from s3backgrounddelete.cortx_s3_config import CORTXS3Config
-
+from s3backgrounddelete.cortx_s3_signal import DynamicConfigHandler
 
 class ObjectRecoveryProcessor(object):
     """Provides consumer for object recovery"""
@@ -43,7 +43,7 @@ class ObjectRecoveryProcessor(object):
         self.config = CORTXS3Config()
         self.create_logger_directory()
         self.create_logger()
-        signal.signal(signal.SIGHUP,self.sighup_handler_callback)
+        self.signal = DynamicConfigHandler(self)
         self.logger.info("Initialising the Object Recovery Processor")
 
     def consume(self):
@@ -107,19 +107,6 @@ class ObjectRecoveryProcessor(object):
             except BaseException:
                 self.logger.error(
                     "Unable to create log directory at " + self._logger_directory)
-
-    def sighup_handler_callback(self, signum, frame):
-        """This signal handler is used to signal that 
-        configuration parameters have been changed
-        For now, the support is only for dynamically
-        changing the logging level"""
-
-        """Reload the configuration"""
-        self.config = CORTXS3Config()
-        self.logger.setLevel(self.config.get_file_log_level())
-
-        self.logger.error("Logging level has been changed")
-        return
 
 if __name__ == "__main__":
     PROCESSOR = ObjectRecoveryProcessor()

--- a/s3backgrounddelete/s3backgrounddelete/object_recovery_processor.py
+++ b/s3backgrounddelete/s3backgrounddelete/object_recovery_processor.py
@@ -118,7 +118,7 @@ class ObjectRecoveryProcessor(object):
         self.config = CORTXS3Config()
         self.logger.setLevel(self.config.get_file_log_level())
 
-        self.logger.error("Logging level has been changed to " + self.config.get_file_log_level())
+        self.logger.error("Logging level has been changed")
         return
 
 if __name__ == "__main__":

--- a/s3backgrounddelete/s3backgrounddelete/object_recovery_processor.py
+++ b/s3backgrounddelete/s3backgrounddelete/object_recovery_processor.py
@@ -43,7 +43,7 @@ class ObjectRecoveryProcessor(object):
         self.config = CORTXS3Config()
         self.create_logger_directory()
         self.create_logger()
-        signal.signal(signal.SIGUSR1,self.sigusr_handler_callback)
+        signal.signal(signal.SIGHUP,self.sighup_handler_callback)
         self.logger.info("Initialising the Object Recovery Processor")
 
     def consume(self):
@@ -108,7 +108,7 @@ class ObjectRecoveryProcessor(object):
                 self.logger.error(
                     "Unable to create log directory at " + self._logger_directory)
 
-    def sigusr_handler_callback(self, signum, frame):
+    def sighup_handler_callback(self, signum, frame):
         """This signal handler is used to signal that 
         configuration parameters have been changed
         For now, the support is only for dynamically

--- a/s3backgrounddelete/s3backgrounddelete/object_recovery_scheduler.py
+++ b/s3backgrounddelete/s3backgrounddelete/object_recovery_scheduler.py
@@ -38,6 +38,7 @@ from s3backgrounddelete.object_recovery_queue import ObjectRecoveryRabbitMq
 from s3backgrounddelete.cortx_s3_config import CORTXS3Config
 from s3backgrounddelete.cortx_s3_index_api import CORTXS3IndexApi
 from s3backgrounddelete.IEMutil import IEMutil
+from s3backgrounddelete.cortx_s3_signal import DynamicConfigHandler
 
 class ObjectRecoveryScheduler(object):
     """Scheduler which will add key value to rabbitmq message queue."""
@@ -48,7 +49,7 @@ class ObjectRecoveryScheduler(object):
         self.config = CORTXS3Config()
         self.create_logger_directory()
         self.create_logger()
-        signal.signal(signal.SIGHUP,self.sighup_handler_callback) 
+        self.signal = DynamicConfigHandler(self)
         self.logger.info("Initialising the Object Recovery Scheduler")
 
     @staticmethod
@@ -59,19 +60,6 @@ class ObjectRecoveryScheduler(object):
         timeDelta = now - date_time_obj
         timeDeltaInMns = math.floor(timeDelta.total_seconds()/60)
         return (timeDeltaInMns >= OlderInMins)
-
-    def sighup_handler_callback(self, signum, frame):
-        """This signal handler is used to signal that 
-        configuration parameters have been changed
-        For now, the support is only for dynamically
-        changing the logging level"""
-
-        """Reload the configuration"""
-        self.config = CORTXS3Config()
-        self.logger.setLevel(self.config.get_file_log_level())
-	
-        self.logger.error("Logging level has been changed")
-        return
 
     def add_kv_to_queue(self, marker = None):
         """Add object key value to object recovery queue."""

--- a/s3backgrounddelete/s3backgrounddelete/object_recovery_scheduler.py
+++ b/s3backgrounddelete/s3backgrounddelete/object_recovery_scheduler.py
@@ -70,7 +70,7 @@ class ObjectRecoveryScheduler(object):
         self.config = CORTXS3Config()
         self.logger.setLevel(self.config.get_file_log_level())
 	
-        self.logger.error("Logging level has been changed to" + self.config.get_file_log_level())
+        self.logger.error("Logging level has been changed")
         return
 
     def add_kv_to_queue(self, marker = None):

--- a/s3backgrounddelete/s3backgrounddelete/object_recovery_scheduler.py
+++ b/s3backgrounddelete/s3backgrounddelete/object_recovery_scheduler.py
@@ -48,7 +48,7 @@ class ObjectRecoveryScheduler(object):
         self.config = CORTXS3Config()
         self.create_logger_directory()
         self.create_logger()
-        signal.signal(signal.SIGUSR1,self.sigusr_handler_callback) 
+        signal.signal(signal.SIGHUP,self.sighup_handler_callback) 
         self.logger.info("Initialising the Object Recovery Scheduler")
 
     @staticmethod
@@ -60,7 +60,7 @@ class ObjectRecoveryScheduler(object):
         timeDeltaInMns = math.floor(timeDelta.total_seconds()/60)
         return (timeDeltaInMns >= OlderInMins)
 
-    def sigusr_handler_callback(self, signum, frame):
+    def sighup_handler_callback(self, signum, frame):
         """This signal handler is used to signal that 
         configuration parameters have been changed
         For now, the support is only for dynamically

--- a/s3backgrounddelete/s3backgrounddelete/object_recovery_scheduler.py
+++ b/s3backgrounddelete/s3backgrounddelete/object_recovery_scheduler.py
@@ -70,8 +70,7 @@ class ObjectRecoveryScheduler(object):
         self.config = CORTXS3Config()
         self.logger.setLevel(self.config.get_file_log_level())
 	
-        self.logger.info("ERROR level is info")
-        self.logger.error("Error level is ERROR")
+        self.logger.error("Logging level has been changed to" + self.config.get_file_log_level())
         return
 
     def add_kv_to_queue(self, marker = None):

--- a/s3backgrounddelete/s3backgroundproducer.service
+++ b/s3backgrounddelete/s3backgroundproducer.service
@@ -24,6 +24,7 @@ Description=S3 Background Producer for stale oid cleanup
 Type=simple
 ExecStart=/opt/seagate/cortx/s3/s3backgrounddelete/s3backgroundproducer
 ExecStop=/bin/kill -TERM $MAINPID
+ExecReload=/bin/kill -USR1 $MAINPID
 TimeoutSec=300
 # Other restart options: always, on-abort, etc
 

--- a/s3backgrounddelete/s3backgroundproducer.service
+++ b/s3backgrounddelete/s3backgroundproducer.service
@@ -24,7 +24,7 @@ Description=S3 Background Producer for stale oid cleanup
 Type=simple
 ExecStart=/opt/seagate/cortx/s3/s3backgrounddelete/s3backgroundproducer
 ExecStop=/bin/kill -TERM $MAINPID
-ExecReload=/bin/kill -USR1 $MAINPID
+ExecReload=/bin/kill -HUP $MAINPID
 TimeoutSec=300
 # Other restart options: always, on-abort, etc
 


### PR DESCRIPTION
## Problem Statement
_[EOS-15481](https://jts.seagate.com/browse/EOS-15481):_
_Change dynamic log level in s3 background delete_

## Problem Description
1) s3 background service files need to accommodate reload command, when reload command is given (systemctl reload <service name>) it will send SIGUSR1signal to background process. s3 background process when receives this signal, need to read all modifiable parameters from its config file

2) Tried to use SIGHUP signal, but system daemon seems to handle this signal itself and reloads.It does not pass this signal to the registered handler.

## Solution Overview
_1) Change s3backgroundproducer config file to support reload option_
_2) Change object_recovery_scheduler.py to add signal handler for USR1_

## Unit Test Cases
_1) systemctl start s3backgroundproducer_
     Ensure s3backgroundproducer service is up and running by checking _systemctl status s3backgroundproducer_
_2) systemctl reload s3backgroundproducer_
_3) Check /var/log/seagate/s3/s3backgrounddelete/object_recovery_scheduler.log_
_4) Verify that the log level matches the one provided in config.yaml_


