### PR TITLE
EOS-15436:S3:Reducing the footprint of log files.

### DIFF
--- a/auth/resources/authencryptcli-log4j2.xml
+++ b/auth/resources/authencryptcli-log4j2.xml
@@ -33,7 +33,7 @@
 
         <RollingFile name="ROLLINGFILE" fileName="${baseDir}/encryptcli.log"
                      filePattern="${baseDir}/$${date:yyyy-MM-dd}/app-%d{yyyy-MM-dd-HH}.log.gz">
-            <PatternLayout pattern="%d %p %C{1.} [%t] %m%n"/>
+            <PatternLayout pattern="%d %p %C{1.} %m%n"/>
             <Policies>
                 <SizeBasedTriggeringPolicy size="20 MB"/>
             </Policies>

--- a/auth/resources/authserver-log4j2.xml
+++ b/auth/resources/authserver-log4j2.xml
@@ -42,7 +42,7 @@
 
         <RollingFile name="ROLLINGFILE" fileName="${baseDir}/app.log"
                      filePattern="${baseDir}/$${date:yyyy-MM-dd}/app-%d{yyyy-MM-dd-HH}.log.gz">
-            <PatternLayout pattern="%d %p [ReqId:%X{ReqId}] %C{1.} [%t] %m%n"/>
+            <PatternLayout pattern="%d %p [ReqId:%X{SReqId}] %C{1.} %m%n"/>
             <Policies>
                 <SizeBasedTriggeringPolicy size="20 MB"/>
             </Policies>

--- a/auth/server/src/main/java/com/seagates3/authorization/Authorizer.java
+++ b/auth/server/src/main/java/com/seagates3/authorization/Authorizer.java
@@ -147,7 +147,7 @@ class Authorizer {
       LOGGER.error("ACL authorization request validation failed");
       return serverResponse;
     }
-    LOGGER.info("ACL authorization request is validated successfully");
+    LOGGER.info("ACL authorization Success");
 
     if (isAclAuthorizationRequired) {
       serverResponse = isAclAuthorized(requestor, requestBody);

--- a/auth/server/src/main/java/com/seagates3/authserver/AuthServerConfig.java
+++ b/auth/server/src/main/java/com/seagates3/authserver/AuthServerConfig.java
@@ -351,6 +351,13 @@ public class AuthServerConfig {
      */
    public
     static void setReqId(String reqId) { MDC.put("ReqId", reqId); }
+
+    /**
+ * Set Request ID
+ */
+   public
+    static void setStripedReqId(String reqId) { MDC.put("SReqId", reqId); }
+
     /**
      * Get Request ID
      */
@@ -363,6 +370,20 @@ public class AuthServerConfig {
       }
       return reqId;
     }
+
+    /**
+     * Get Request ID
+     */
+   public
+    static String getStripedReqId() {
+      String sreqId = MDC.get("SReqId");
+      if (sreqId == null) {
+        // Set to some dummy value for Unit tests where Req Id is not set
+        sreqId = "0000";
+      }
+      return sreqId;
+    }
+
    public
     static List<String> getS3InternalAccounts() {
       List<String> internalAccountsList = new ArrayList<>();

--- a/auth/server/src/main/java/com/seagates3/authserver/AuthServerGetHandler.java
+++ b/auth/server/src/main/java/com/seagates3/authserver/AuthServerGetHandler.java
@@ -92,6 +92,15 @@ class AuthServerGetHandler {
       AuthServerConfig.setReqId(BinaryUtil.getAlphaNumericUUID());
     }
 
+    String stripped_request_id = AuthServerConfig.getReqId();
+    AuthServerConfig.setStripedReqId(stripped_request_id);
+    LOGGER.info("Generating Stripped ReqId");
+
+    if (stripped_request_id.length() > 12) {
+      AuthServerConfig.setStripedReqId(
+          stripped_request_id.substring(stripped_request_id.length() - 12));
+    }
+
     if (httpRequest.uri().startsWith("/static")) {
       Path staticFilePath =
           Paths.get(AuthServerConstants.RESOURCE_DIR, httpRequest.uri());
@@ -150,7 +159,7 @@ class AuthServerGetHandler {
           HttpVersion.HTTP_1_1, requestResponse.getResponseStatus(),
           Unpooled.wrappedBuffer(responseBody.getBytes("UTF-8")));
 
-      LOGGER.info("Sending HTTP Response code [" + response.status() + "]");
+      LOGGER.info("HTTP Response [" + response.status() + "]");
     }
     catch (UnsupportedEncodingException ex) {
       LOGGER.error("UTF-8 encoding is not supported.");

--- a/auth/server/src/main/java/com/seagates3/authserver/AuthServerPostHandler.java
+++ b/auth/server/src/main/java/com/seagates3/authserver/AuthServerPostHandler.java
@@ -72,6 +72,15 @@ public class AuthServerPostHandler {
           AuthServerConfig.setReqId(BinaryUtil.getAlphaNumericUUID());
         }
 
+        String stripped_request_id = AuthServerConfig.getReqId();
+        AuthServerConfig.setStripedReqId(stripped_request_id);
+        LOGGER.info("Generating Stripped ReqId");
+
+        if (stripped_request_id.length() > 10) {
+          AuthServerConfig.setStripedReqId(
+              stripped_request_id.substring(stripped_request_id.length() - 12));
+        }
+
         if (httpRequest.uri().startsWith("/saml")) {
             LOGGER.debug("Calling SAML WebSSOControler.");
             FullHttpResponse response = new SAMLWebSSOController(requestBody)
@@ -114,7 +123,7 @@ public class AuthServerPostHandler {
 
     private void returnHTTPResponse(FullHttpResponse response) {
 
-       LOGGER.info("Sending HTTP Response code [" + response.status() + "]");
+       LOGGER.info("HTTP Response [" + response.status() + "]");
 
         if (!keepAlive) {
             ctx.write(response).addListener(ChannelFutureListener.CLOSE);

--- a/auth/server/src/main/java/com/seagates3/controller/IAMController.java
+++ b/auth/server/src/main/java/com/seagates3/controller/IAMController.java
@@ -80,7 +80,7 @@ class IAMController {
   ServerResponse serve(FullHttpRequest httpRequest,
                        Map<String, String> requestBody) {
     String requestAction = requestBody.get("Action");
-    LOGGER.info("Requested action is  - " + requestAction);
+    LOGGER.info("Action  - " + requestAction);
     ClientRequestToken clientRequestToken = null;
     Requestor requestor = null;
     ServerResponse serverResponse;

--- a/server/action_base.h
+++ b/server/action_base.h
@@ -131,6 +131,7 @@ class Action {
 
  protected:
   std::string request_id;
+  std::string stripped_request_id;
   // ADDB action type id.  See s3_addb.h for details on ADDB.  Should not be
   // used directly, use get_addb_action_type_id() instead.
   enum S3AddbActionTypeId addb_action_type_id;

--- a/server/addb-codegen.py
+++ b/server/addb-codegen.py
@@ -307,7 +307,7 @@ def generate_s3_cc_file(out_file_name, classes, enums, headers):
 static std::unordered_map<std::type_index, enum S3AddbActionTypeId> gs_addb_map;
 
 int s3_addb_init() {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   // Sorry for the format, this had to be done this way to pass
   // git-clang-format check.
 """)

--- a/server/event_utils.cc
+++ b/server/event_utils.cc
@@ -23,7 +23,7 @@
 
 void RecurringEventBase::libevent_callback(evutil_socket_t fd, short event,
                                            void *arg) {
-  s3_log(S3_LOG_DEBUG, "", "Entering");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry", __func__);
   RecurringEventBase *evt_base = static_cast<RecurringEventBase *>(arg);
   if (evt_base) {
     evt_base->action_callback();
@@ -31,8 +31,8 @@ void RecurringEventBase::libevent_callback(evutil_socket_t fd, short event,
 }
 
 int RecurringEventBase::add_evtimer(struct timeval &tv) {
-  s3_log(S3_LOG_DEBUG, "", "Entering with sec=%" PRIu32 " usec=%" PRIu32,
-         (uint32_t)tv.tv_sec, (uint32_t)tv.tv_usec);
+  s3_log(S3_LOG_DEBUG, "", "%s Entry with sec=%" PRIu32 " usec=%" PRIu32,
+         __func__, (uint32_t)tv.tv_sec, (uint32_t)tv.tv_usec);
   if (!event_obj) {
     return -EINVAL;
   }
@@ -52,7 +52,7 @@ int RecurringEventBase::add_evtimer(struct timeval &tv) {
 }
 
 void RecurringEventBase::del_evtimer() {
-  s3_log(S3_LOG_DEBUG, "", "Entering");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry", __func__);
   if (evt && event_obj) {
     event_obj->del_event(evt);
     event_obj->free_event(evt);

--- a/server/motr_action_base.cc
+++ b/server/motr_action_base.cc
@@ -28,12 +28,14 @@ MotrAction::MotrAction(std::shared_ptr<MotrRequestObject> req,
                        std::shared_ptr<S3AuthClientFactory> auth_factory,
                        bool skip_auth)
     : Action(req, check_shutdown, auth_factory, skip_auth), request(req) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   auth_client->do_skip_authorization();
   setup_steps();
 }
 
-MotrAction::~MotrAction() { s3_log(S3_LOG_DEBUG, request_id, "Destructor\n"); }
+MotrAction::~MotrAction() {
+  s3_log(S3_LOG_DEBUG, request_id, "%s\n", __func__);
+}
 
 void MotrAction::setup_steps() {
   s3_log(S3_LOG_DEBUG, request_id, "Setup the action\n");
@@ -47,7 +49,7 @@ void MotrAction::setup_steps() {
 }
 
 void MotrAction::check_authorization() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   if ((request->get_account_name() == BACKGROUND_STALE_OBJECT_DELETE_ACCOUNT) ||
       (request->get_account_name() == S3RECOVERY_ACCOUNT)) {
     next();
@@ -60,6 +62,6 @@ void MotrAction::check_authorization() {
       request->respond_error(error_code);
     }
     done();
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   }
 }

--- a/server/motr_api_handler.h
+++ b/server/motr_api_handler.h
@@ -42,6 +42,7 @@ class MotrAPIHandler {
   std::shared_ptr<MotrAPIHandler> _get_self_ref() { return self_ref; }
   std::shared_ptr<Action> _get_action() { return action; }
   std::string request_id;
+  std::string stripped_request_id;
 
  private:
   std::shared_ptr<MotrAPIHandler> self_ref;
@@ -51,13 +52,14 @@ class MotrAPIHandler {
                  MotrOperationCode op_code)
       : request(req), operation_code(op_code) {
     request_id = request->get_request_id();
+    stripped_request_id = request->get_stripped_request_id();
   }
   virtual ~MotrAPIHandler() {}
 
   virtual void create_action() = 0;
 
   virtual void dispatch() {
-    s3_log(S3_LOG_DEBUG, request_id, "Entering");
+    s3_log(S3_LOG_DEBUG, request_id, "%s Entry", __func__);
 
     if (action) {
       action->manage_self(action);
@@ -67,7 +69,7 @@ class MotrAPIHandler {
     }
     i_am_done();
 
-    s3_log(S3_LOG_DEBUG, "", "Exiting");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   }
 
   // Self destructing object.

--- a/server/motr_api_handler_factory.cc
+++ b/server/motr_api_handler_factory.cc
@@ -26,8 +26,9 @@ std::shared_ptr<MotrAPIHandler> MotrAPIHandlerFactory::create_api_handler(
     MotrOperationCode op_code) {
   std::shared_ptr<MotrAPIHandler> handler;
   std::string request_id = request->get_request_id();
+  std::string stripped_request_id = request->get_stripped_request_id();
   request->set_operation_code(op_code);
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   switch (api_type) {
     case MotrApiType::index:
       s3_log(S3_LOG_DEBUG, request_id, "api_type = MotrApiType::index\n");
@@ -56,6 +57,6 @@ std::shared_ptr<MotrAPIHandler> MotrAPIHandlerFactory::create_api_handler(
            request->get_http_verb_str(request->http_verb()));
     handler->create_action();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return handler;
 }

--- a/server/motr_common.cc
+++ b/server/motr_common.cc
@@ -47,7 +47,7 @@ extern pthread_t global_tid_objop;
 extern pthread_t global_tid_indexop;
 
 int init_motr(void) {
-  s3_log(S3_LOG_INFO, "", "Entering!\n");
+  s3_log(S3_LOG_INFO, "", "%s Entry\n", __func__);
   int rc;
   S3Option *option_instance = S3Option::get_instance();
   /* MOTR_DEFAULT_EP, MOTR_DEFAULT_HA_ADDR*/
@@ -130,10 +130,10 @@ int init_motr(void) {
 }
 
 void fini_motr(void) {
-  s3_log(S3_LOG_INFO, "", "Entering!\n");
+  s3_log(S3_LOG_INFO, "", "%s Entry\n", __func__);
   m0_ufid_fini(&s3_ufid_generator);
   m0_client_fini(motr_instance, true);
-  s3_log(S3_LOG_INFO, "", "Exiting\n");
+  s3_log(S3_LOG_INFO, "", "%s Exit", __func__);
 }
 
 int create_new_instance_id(struct m0_uint128 *ufid) {

--- a/server/motr_delete_index_action.cc
+++ b/server/motr_delete_index_action.cc
@@ -31,10 +31,10 @@ MotrDeleteIndexAction::MotrDeleteIndexAction(
     std::shared_ptr<MotrRequestObject> req,
     std::shared_ptr<S3MotrKVSWriterFactory> motr_kvs_writer_factory)
     : MotrAction(req) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   motr_api = std::make_shared<ConcreteMotrAPI>();
 
-  s3_log(S3_LOG_INFO, request_id, "Motr API: Index delete.\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "Motr API: Index delete.\n");
 
   if (motr_kvs_writer_factory) {
     motr_kvs_writer_factory_ptr = motr_kvs_writer_factory;
@@ -54,7 +54,7 @@ void MotrDeleteIndexAction::setup_steps() {
 }
 
 void MotrDeleteIndexAction::validate_request() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   index_id = S3M0Uint128Helper::to_m0_uint128(request->get_index_id_lo(),
                                               request->get_index_id_hi());
@@ -69,7 +69,7 @@ void MotrDeleteIndexAction::validate_request() {
 }
 
 void MotrDeleteIndexAction::delete_index() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   motr_kv_writer =
       motr_kvs_writer_factory_ptr->create_motr_kvs_writer(request, motr_api);
@@ -81,17 +81,17 @@ void MotrDeleteIndexAction::delete_index() {
 
   // for shutdown testcases, check FI and set shutdown signal
   S3_CHECK_FI_AND_SET_SHUTDOWN_SIGNAL("delete_index_action_shutdown_fail");
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrDeleteIndexAction::delete_index_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrDeleteIndexAction::delete_index_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_kv_writer->get_state() == S3MotrKVSWriterOpState::missing) {
     s3_log(S3_LOG_DEBUG, request_id, "Index is missing.\n");
   } else if (motr_kv_writer->get_state() ==
@@ -103,11 +103,11 @@ void MotrDeleteIndexAction::delete_index_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrDeleteIndexAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -133,5 +133,5 @@ void MotrDeleteIndexAction::send_response_to_s3_client() {
   }
   S3_RESET_SHUTDOWN_SIGNAL;  // for shutdown testcases
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/motr_delete_key_value_action.cc
+++ b/server/motr_delete_key_value_action.cc
@@ -27,7 +27,7 @@ MotrDeleteKeyValueAction::MotrDeleteKeyValueAction(
     std::shared_ptr<S3MotrKVSWriterFactory> motr_kvs_writer_factory,
     std::shared_ptr<S3MotrKVSReaderFactory> motr_kvs_reader_factory)
     : MotrAction(req) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   if (motr_api) {
     s3_motr_api = motr_api;
   } else {
@@ -57,7 +57,7 @@ void MotrDeleteKeyValueAction::setup_steps() {
 }
 
 void MotrDeleteKeyValueAction::delete_key_value() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   index_id = S3M0Uint128Helper::to_m0_uint128(request->get_index_id_lo(),
                                               request->get_index_id_hi());
   // invalid oid
@@ -75,28 +75,28 @@ void MotrDeleteKeyValueAction::delete_key_value() {
         std::bind(&MotrDeleteKeyValueAction::delete_key_value_failed, this));
   }
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrDeleteKeyValueAction::delete_key_value_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrDeleteKeyValueAction::delete_key_value_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_kv_writer->get_state() == S3MotrKVSWriterOpState::missing) {
     next();
   } else {
     set_s3_error("InternalError");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrDeleteKeyValueAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (is_error_state() && !get_s3_error_code().empty()) {
     S3Error error(get_s3_error_code(), request->get_request_id(),
                   request->c_get_full_path());
@@ -117,5 +117,5 @@ void MotrDeleteKeyValueAction::send_response_to_s3_client() {
     request->send_response(S3HttpSuccess204);
   }
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/motr_delete_object_action.cc
+++ b/server/motr_delete_object_action.cc
@@ -27,7 +27,7 @@ MotrDeleteObjectAction::MotrDeleteObjectAction(
     std::shared_ptr<MotrRequestObject> req,
     std::shared_ptr<S3MotrWriterFactory> writer_factory)
     : MotrAction(std::move(req)) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
   if (writer_factory) {
     motr_writer_factory = std::move(writer_factory);
@@ -47,7 +47,7 @@ void MotrDeleteObjectAction::setup_steps() {
 }
 
 void MotrDeleteObjectAction::validate_request() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   oid = S3M0Uint128Helper::to_m0_uint128(request->get_object_oid_lo(),
                                          request->get_object_oid_hi());
@@ -67,11 +67,11 @@ void MotrDeleteObjectAction::validate_request() {
       next();
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrDeleteObjectAction::delete_object() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   motr_writer = motr_writer_factory->create_motr_writer(request, oid);
   motr_writer->delete_object(
@@ -79,17 +79,17 @@ void MotrDeleteObjectAction::delete_object() {
       std::bind(&MotrDeleteObjectAction::delete_object_failed, this),
       layout_id);
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrDeleteObjectAction::delete_object_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrDeleteObjectAction::delete_object_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // Object missing is treated as object deleted similar to S3 object delete.
   if (motr_writer->get_state() == S3MotrWiterOpState::missing) {
     s3_log(S3_LOG_DEBUG, request_id,
@@ -99,11 +99,11 @@ void MotrDeleteObjectAction::delete_object_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrDeleteObjectAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (is_error_state() && !get_s3_error_code().empty()) {
     S3Error error(get_s3_error_code(), request->get_request_id(),
                   request->c_get_full_path());
@@ -123,5 +123,5 @@ void MotrDeleteObjectAction::send_response_to_s3_client() {
     request->send_response(S3HttpSuccess204);
   }
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/motr_get_key_value_action.cc
+++ b/server/motr_get_key_value_action.cc
@@ -26,7 +26,7 @@ MotrGetKeyValueAction::MotrGetKeyValueAction(
     std::shared_ptr<MotrRequestObject> req, std::shared_ptr<MotrAPI> motr_api,
     std::shared_ptr<S3MotrKVSReaderFactory> motr_kvs_reader_factory)
     : MotrAction(req) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   if (motr_api) {
     s3_motr_api = motr_api;
   } else {
@@ -50,7 +50,7 @@ void MotrGetKeyValueAction::setup_steps() {
 }
 
 void MotrGetKeyValueAction::fetch_key_value() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   index_id = S3M0Uint128Helper::to_m0_uint128(request->get_index_id_lo(),
                                               request->get_index_id_hi());
@@ -67,17 +67,17 @@ void MotrGetKeyValueAction::fetch_key_value() {
         std::bind(&MotrGetKeyValueAction::fetch_key_value_failed, this));
   }
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrGetKeyValueAction::fetch_key_value_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrGetKeyValueAction::fetch_key_value_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_kv_reader->get_state() == S3MotrKVSReaderOpState::missing) {
     set_s3_error("NoSuchKey");
   } else if (motr_kv_reader->get_state() ==
@@ -89,11 +89,11 @@ void MotrGetKeyValueAction::fetch_key_value_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrGetKeyValueAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (is_error_state() && !get_s3_error_code().empty()) {
     S3Error error(get_s3_error_code(), request->get_request_id(),
                   request->c_get_full_path());
@@ -113,5 +113,5 @@ void MotrGetKeyValueAction::send_response_to_s3_client() {
     request->send_response(S3HttpSuccess200, motr_kv_reader->get_value());
   }
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/motr_head_index_action.cc
+++ b/server/motr_head_index_action.cc
@@ -27,7 +27,7 @@ MotrHeadIndexAction::MotrHeadIndexAction(
     std::shared_ptr<MotrRequestObject> req,
     std::shared_ptr<S3MotrKVSReaderFactory> motr_kvs_reader_factory)
     : MotrAction(std::move(req)) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   motr_api = std::make_shared<ConcreteMotrAPI>();
 
   if (motr_kvs_reader_factory) {
@@ -46,7 +46,7 @@ void MotrHeadIndexAction::setup_steps() {
 }
 
 void MotrHeadIndexAction::validate_request() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   index_id = S3M0Uint128Helper::to_m0_uint128(request->get_index_id_lo(),
                                               request->get_index_id_hi());
@@ -69,13 +69,13 @@ void MotrHeadIndexAction::check_index_exist() {
 }
 
 void MotrHeadIndexAction::check_index_exist_success() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrHeadIndexAction::check_index_exist_failure() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_kv_reader->get_state() == S3MotrKVSReaderOpState::missing) {
     s3_log(S3_LOG_DEBUG, request_id, "Index not found\n");
     set_s3_error("NoSuchIndex");
@@ -91,7 +91,7 @@ void MotrHeadIndexAction::check_index_exist_failure() {
 }
 
 void MotrHeadIndexAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (is_error_state() && !get_s3_error_code().empty()) {
     S3Error error(get_s3_error_code(), request->get_request_id(),
                   request->c_get_full_path());

--- a/server/motr_head_object_action.cc
+++ b/server/motr_head_object_action.cc
@@ -27,7 +27,7 @@ MotrHeadObjectAction::MotrHeadObjectAction(
     std::shared_ptr<MotrRequestObject> req,
     std::shared_ptr<S3MotrReaderFactory> reader_factory)
     : MotrAction(std::move(req)), layout_id(0) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   oid = {0ULL, 0ULL};
   if (reader_factory) {
     motr_reader_factory = std::move(reader_factory);
@@ -47,7 +47,7 @@ void MotrHeadObjectAction::setup_steps() {
 }
 
 void MotrHeadObjectAction::validate_request() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   oid = S3M0Uint128Helper::to_m0_uint128(request->get_object_oid_lo(),
                                          request->get_object_oid_hi());
   // invalid oid
@@ -67,11 +67,11 @@ void MotrHeadObjectAction::validate_request() {
       next();
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrHeadObjectAction::check_object_exist() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   motr_reader =
       motr_reader_factory->create_motr_reader(request, oid, layout_id);
@@ -80,17 +80,17 @@ void MotrHeadObjectAction::check_object_exist() {
       std::bind(&MotrHeadObjectAction::check_object_exist_success, this),
       std::bind(&MotrHeadObjectAction::check_object_exist_failure, this));
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrHeadObjectAction::check_object_exist_success() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrHeadObjectAction::check_object_exist_failure() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_reader->get_state() == S3MotrReaderOpState::missing) {
     s3_log(S3_LOG_DEBUG, request_id, "Object not found\n");
     set_s3_error("NoSuchKey");
@@ -103,11 +103,11 @@ void MotrHeadObjectAction::check_object_exist_failure() {
     set_s3_error("InternalError");
   }
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrHeadObjectAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (is_error_state() && !get_s3_error_code().empty()) {
     S3Error error(get_s3_error_code(), request->get_request_id(),
                   request->c_get_full_path());
@@ -128,5 +128,5 @@ void MotrHeadObjectAction::send_response_to_s3_client() {
     request->send_response(S3HttpSuccess200);
   }
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/motr_index_api_handler.cc
+++ b/server/motr_index_api_handler.cc
@@ -26,7 +26,7 @@
 #include "s3_stats.h"
 
 void MotrIndexAPIHandler::create_action() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "Operation code = %d\n", operation_code);
 
   switch (operation_code) {
@@ -62,5 +62,5 @@ void MotrIndexAPIHandler::create_action() {
       // should never be here.
       return;
   };  // switch operation_code
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/motr_keyvalue_api_handler.cc
+++ b/server/motr_keyvalue_api_handler.cc
@@ -26,7 +26,7 @@
 #include "s3_stats.h"
 
 void MotrKeyValueAPIHandler::create_action() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "Operation code = %d\n", operation_code);
 
   switch (operation_code) {
@@ -54,5 +54,5 @@ void MotrKeyValueAPIHandler::create_action() {
       // should never be here.
       return;
   };  // switch operation_code
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/motr_kv_list_response.cc
+++ b/server/motr_kv_list_response.cc
@@ -32,7 +32,7 @@ MotrKVListResponse::MotrKVListResponse(std::string encoding_type)
       max_keys(""),
       response_is_truncated(false),
       next_marker_key("") {
-  s3_log(S3_LOG_DEBUG, "", "Constructor\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Ctor\n", __func__);
 }
 
 void MotrKVListResponse::set_index_id(std::string name) { index_id = name; }

--- a/server/motr_kvs_listing_action.cc
+++ b/server/motr_kvs_listing_action.cc
@@ -34,10 +34,10 @@ MotrKVSListingAction::MotrKVSListingAction(
     std::shared_ptr<MotrRequestObject> req,
     std::shared_ptr<S3MotrKVSReaderFactory> motr_kvs_reader_factory)
     : MotrAction(req), last_key(""), fetch_successful(false) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   motr_api = std::make_shared<ConcreteMotrAPI>();
 
-  s3_log(S3_LOG_INFO, request_id, "Motr API: kvs list Service.\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "Motr API: kvs list Service.\n");
 
   if (motr_kvs_reader_factory) {
     motr_kvs_reader_factory_ptr = motr_kvs_reader_factory;
@@ -57,7 +57,7 @@ void MotrKVSListingAction::setup_steps() {
 }
 
 void MotrKVSListingAction::validate_request() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   index_id = S3M0Uint128Helper::to_m0_uint128(request->get_index_id_lo(),
                                               request->get_index_id_hi());
@@ -106,7 +106,7 @@ void MotrKVSListingAction::validate_request() {
 }
 
 void MotrKVSListingAction::get_next_key_value() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (motr_kv_reader == nullptr) {
     motr_kv_reader =
@@ -144,13 +144,13 @@ void MotrKVSListingAction::get_next_key_value() {
   // for shutdown testcases, check FI and set shutdown signal
   S3_CHECK_FI_AND_SET_SHUTDOWN_SIGNAL(
       "get_kvs_listing_action_get_next_key_value_shutdown_fail");
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrKVSListingAction::get_next_key_value_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (check_shutdown_and_rollback()) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   retry_count = 0;
@@ -223,7 +223,7 @@ void MotrKVSListingAction::get_next_key_value_successful() {
 }
 
 void MotrKVSListingAction::get_next_key_value_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_kv_reader->get_state() == S3MotrKVSReaderOpState::missing) {
     s3_log(S3_LOG_DEBUG, request_id, "No keys found in kv listing\n");
     fetch_successful = true;  // With no entries.
@@ -253,11 +253,11 @@ void MotrKVSListingAction::get_next_key_value_failed() {
     fetch_successful = false;
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrKVSListingAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -299,5 +299,5 @@ void MotrKVSListingAction::send_response_to_s3_client() {
   }
   S3_RESET_SHUTDOWN_SIGNAL;  // for shutdown testcases
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/motr_object_api_handler.cc
+++ b/server/motr_object_api_handler.cc
@@ -25,7 +25,7 @@
 #include "s3_stats.h"
 
 void MotrObjectAPIHandler::create_action() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "Operation code = %d\n", operation_code);
 
   switch (operation_code) {
@@ -49,5 +49,5 @@ void MotrObjectAPIHandler::create_action() {
       // should never be here.
       return;
   };  // switch operation_code
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/motr_put_key_value_action.cc
+++ b/server/motr_put_key_value_action.cc
@@ -27,7 +27,7 @@ MotrPutKeyValueAction::MotrPutKeyValueAction(
     std::shared_ptr<MotrRequestObject> req, std::shared_ptr<MotrAPI> motr_api,
     std::shared_ptr<S3MotrKVSWriterFactory> motr_kvs_writer_factory)
     : MotrAction(req) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   if (motr_api) {
     s3_motr_api = motr_api;
   } else {
@@ -51,7 +51,7 @@ void MotrPutKeyValueAction::setup_steps() {
 }
 
 void MotrPutKeyValueAction::read_and_validate_key_value() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   index_id = S3M0Uint128Helper::to_m0_uint128(request->get_index_id_lo(),
                                               request->get_index_id_hi());
@@ -79,28 +79,28 @@ void MotrPutKeyValueAction::read_and_validate_key_value() {
           );
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrPutKeyValueAction::put_key_value() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   motr_kv_writer->put_keyval(
       index_id, request->get_key_name(), json_value,
       std::bind(&MotrPutKeyValueAction::put_key_value_successful, this),
       std::bind(&MotrPutKeyValueAction::put_key_value_failed, this));
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrPutKeyValueAction::put_key_value_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrPutKeyValueAction::put_key_value_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_kv_writer->get_state() == S3MotrKVSWriterOpState::failed_to_launch) {
     s3_log(S3_LOG_ERROR, request_id,
            "Failed to retrive the key, due to pre launch failure\n");
@@ -109,11 +109,11 @@ void MotrPutKeyValueAction::put_key_value_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void MotrPutKeyValueAction::consume_incoming_content() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (request->is_s3_client_read_error()) {
     client_read_error();
   } else if (request->has_all_body_content()) {
@@ -129,11 +129,11 @@ void MotrPutKeyValueAction::consume_incoming_content() {
     // else just wait till entire body arrives. rare.
     request->resume();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 bool MotrPutKeyValueAction::is_valid_json(std::string json_str) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   Json::Value root;
   Json::Reader reader;
   bool parsingSuccessful = reader.parse(json_str.c_str(), root);
@@ -142,12 +142,12 @@ bool MotrPutKeyValueAction::is_valid_json(std::string json_str) {
     s3_log(S3_LOG_ERROR, request_id, "JSON string not valid.\n");
     return false;
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return true;
 }
 
 void MotrPutKeyValueAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (is_error_state() && !get_s3_error_code().empty()) {
     S3Error error(get_s3_error_code(), request->get_request_id(),
@@ -168,5 +168,5 @@ void MotrPutKeyValueAction::send_response_to_s3_client() {
     request->send_response(S3HttpSuccess200);
   }
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/motr_request_object.cc
+++ b/server/motr_request_object.cc
@@ -38,11 +38,11 @@ MotrRequestObject::MotrRequestObject(
     EventInterface* event_obj_ptr)
     : RequestObject(req, evhtp_obj_ptr, async_buf_factory, event_obj_ptr),
       motr_api_type(MotrApiType::unsupported) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 }
 
 MotrRequestObject::~MotrRequestObject() {
-  s3_log(S3_LOG_DEBUG, request_id, "Destructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s\n", __func__);
 }
 
 void MotrRequestObject::set_key_name(const std::string& key) { key_name = key; }

--- a/server/motr_uri.cc
+++ b/server/motr_uri.cc
@@ -31,6 +31,7 @@ MotrURI::MotrURI(std::shared_ptr<MotrRequestObject> req)
       operation_code(MotrOperationCode::none),
       motr_api_type(MotrApiType::unsupported) {
   request_id = request->get_request_id();
+  stripped_request_id = request->get_stripped_request_id();
   setup_operation_code();
 }
 
@@ -52,7 +53,7 @@ void MotrURI::setup_operation_code() {
 
 MotrPathStyleURI::MotrPathStyleURI(std::shared_ptr<MotrRequestObject> req)
     : MotrURI(req) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   std::string full_uri;
   const char* full_path = request->c_get_full_encoded_path();
   if (full_path) {

--- a/server/motr_uri.h
+++ b/server/motr_uri.h
@@ -48,6 +48,7 @@ class MotrURI {
   MotrApiType motr_api_type;
 
   std::string request_id;
+  std::string stripped_request_id;
 
  private:
   void setup_operation_code();

--- a/server/motr_uri_factory.cc
+++ b/server/motr_uri_factory.cc
@@ -23,7 +23,7 @@
 
 MotrURI* MotrUriFactory::create_uri_object(
     MotrUriType uri_type, std::shared_ptr<MotrRequestObject> request) {
-  s3_log(S3_LOG_DEBUG, request->get_request_id(), "Entering\n");
+  s3_log(S3_LOG_DEBUG, request->get_request_id(), "%s Entry\n", __func__);
 
   switch (uri_type) {
     case MotrUriType::path_style:
@@ -33,6 +33,6 @@ MotrURI* MotrUriFactory::create_uri_object(
     default:
       break;
   };
-  s3_log(S3_LOG_DEBUG, request->get_request_id(), "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request->get_request_id(), "%s Exit", __func__);
   return NULL;
 }

--- a/server/request_object.cc
+++ b/server/request_object.cc
@@ -72,7 +72,7 @@ extern "C" int consume_query_parameters(evhtp_kv_t* kvobj, void* arg) {
 }
 
 void s3_client_read_timeout_cb(evutil_socket_t fd, short event, void* arg) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
 
   RequestObject* request = static_cast<RequestObject*>(arg);
 
@@ -126,7 +126,11 @@ RequestObject::RequestObject(
 
   S3Uuid uuid;
   request_id = uuid.get_string_uuid();
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  // last 12 characters
+  stripped_request_id = std::string(request_id.end() - 12, request_id.end());
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
+  s3_log(S3_LOG_INFO, request_id, "stripped_request_id:%s\n",
+         stripped_request_id.c_str());
   request_timer.start();
 
   ADDB(S3_ADDB_REQUEST_ID, addb_request_id, *(const uint64_t*)(uuid.ptr()),
@@ -197,7 +201,7 @@ RequestObject::RequestObject(
       }
     }
   } else {
-    s3_log(S3_LOG_INFO, request_id, "s3 client is disconnected.\n");
+    s3_log(S3_LOG_INFO, stripped_request_id, "s3 client is disconnected.\n");
   }
 }
 
@@ -216,7 +220,7 @@ void RequestObject::initialise() {
 }
 
 RequestObject::~RequestObject() {
-  s3_log(S3_LOG_DEBUG, request_id, "Destructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s\n", __func__);
 
   if (ev_req) {
     ev_req->cbarg = NULL;
@@ -239,7 +243,7 @@ RequestObject::get_query_parameters() {
         in_query_params_copied = true;
       }
     } else {
-      s3_log(S3_LOG_INFO, request_id,
+      s3_log(S3_LOG_INFO, stripped_request_id,
              "s3 client is either disconnected or ev_req(NULL).\n");
     }
   }
@@ -259,7 +263,7 @@ void RequestObject::set_full_path(const char* full_path) {
 void RequestObject::set_start_client_request_read_timeout() {
   // Set the timer event, so that if data doesn't arrive from client within a
   // configured timeframe, then send error to client.
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   if (is_s3_client_read_error()) {
     return;
   }
@@ -280,7 +284,7 @@ void RequestObject::set_start_client_request_read_timeout() {
 }
 
 void RequestObject::stop_client_read_timer() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   if (client_read_timer_event != NULL) {
     if (event_obj->pending_event(client_read_timer_event, EV_TIMEOUT)) {
       s3_log(S3_LOG_DEBUG, request_id, "Deleting client read timer\n");
@@ -333,7 +337,7 @@ const char* RequestObject::c_get_full_encoded_path() {
       return ev_req->uri->path->full;
     }
   } else {
-    s3_log(S3_LOG_INFO, request_id, "s3 client is disconnected.\n");
+    s3_log(S3_LOG_INFO, stripped_request_id, "s3 client is disconnected.\n");
   }
   return NULL;
 }
@@ -360,7 +364,7 @@ std::map<std::string, std::string>& RequestObject::get_in_headers_copy() {
       evhtp_obj->http_kvs_for_each(ev_req->headers_in, consume_header, this);
       in_headers_copied = true;
     } else {
-      s3_log(S3_LOG_INFO, request_id,
+      s3_log(S3_LOG_INFO, stripped_request_id,
              "s3 client is either disconnected or ev_req(NULL).\n");
     }
   }
@@ -598,12 +602,12 @@ void RequestObject::set_email(const std::string& email_id) { email = email_id; }
 const std::string& RequestObject::get_email() { return email; }
 
 void RequestObject::notify_incoming_data(evbuf_t* buf) {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering with buf(%p)\n", buf);
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry with buf(%p)\n", __func__, buf);
   s3_log(S3_LOG_DEBUG, request_id, "pending_in_flight (before): %zu\n",
          pending_in_flight);
   if (buf == NULL) {
     // Very unlikely
-    s3_log(S3_LOG_WARN, request_id, "Exiting due to buf(NULL)\n");
+    s3_log(S3_LOG_WARN, request_id, "%s Exit due to buf(NULL)\n", __func__);
     return;
   }
   if (!S3MemoryProfile().free_memory_in_pool_above_threshold_limits()) {
@@ -622,11 +626,12 @@ void RequestObject::notify_incoming_data(evbuf_t* buf) {
       s3_log(S3_LOG_WARN, request_id,
              "Memory in pool is above threshold limits\n");
     }
-    s3_log(S3_LOG_DEBUG, nullptr, "Exiting\n");
+    s3_log(S3_LOG_DEBUG, nullptr, "%s Exit", __func__);
     return;
   }
   if (is_s3_client_read_error()) {
-    s3_log(S3_LOG_INFO, request_id, "Exiting due to some read error\n");
+    s3_log(S3_LOG_INFO, stripped_request_id, "%s Exit due to some read error\n",
+           __func__);
     evbuffer_free(buf);
     return;
   }
@@ -710,7 +715,7 @@ void RequestObject::notify_incoming_data(evbuf_t* buf) {
       // The class instance can be destroyed at this point!
     }
     if (f_s3_client_read_error) {
-      s3_log(S3_LOG_DEBUG, nullptr, "Exiting\n");
+      s3_log(S3_LOG_DEBUG, nullptr, "%s Exit", __func__);
       return;
     }
   } else if (!buffered_input->is_freezed() &&
@@ -726,13 +731,13 @@ void RequestObject::notify_incoming_data(evbuf_t* buf) {
     s3_log(S3_LOG_DEBUG, request_id, "Setting Read timeout for s3 client\n");
     set_start_client_request_read_timeout();
   }
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }
 
 void RequestObject::send_response(int code, std::string body) {
   if (!is_service_req_head) {
-    s3_log(S3_LOG_INFO, request_id, "Sending response as: [code:%d] [%s]\n",
-           code, body.c_str());
+    s3_log(S3_LOG_INFO, stripped_request_id,
+           "Sending response as: [code:%d] [%s]\n", code, body.c_str());
   }
 
   http_status = code;
@@ -742,7 +747,7 @@ void RequestObject::send_response(int code, std::string body) {
     s3_stats_inc("internal_error_count");
   }
   if (!client_connected()) {
-    s3_log(S3_LOG_INFO, request_id, "s3 client is disconnected.\n");
+    s3_log(S3_LOG_INFO, stripped_request_id, "s3 client is disconnected.\n");
     request_timer.stop();
     return;
   }
@@ -860,12 +865,12 @@ void RequestObject::respond_error(
     send_response(error.get_http_status_code(), response_xml);
   } else {
     request_timer.stop();
-    s3_log(S3_LOG_INFO, request_id, "s3 client is disconnected.\n");
+    s3_log(S3_LOG_INFO, stripped_request_id, "s3 client is disconnected.\n");
   }
 }
 
 void RequestObject::respond_unsupported_api() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   // For S3 request, if method is PUT and no bucket specified
   // then return NotImplemented, with http code 405
   S3RequestObject* s3_request = dynamic_cast<S3RequestObject*>(this);
@@ -876,18 +881,18 @@ void RequestObject::respond_unsupported_api() {
     respond_error("NotImplemented");
   }
   s3_stats_inc("unsupported_api_count");
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void RequestObject::respond_retry_after(int retry_after_in_secs) {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
 
   std::map<std::string, std::string> headers;
   headers["Retry-After"] = std::to_string(retry_after_in_secs);
 
   respond_error("ServiceUnavailable", headers);
 
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }
 
 bool RequestObject::is_header_present(const std::string& key) {

--- a/server/request_object.h
+++ b/server/request_object.h
@@ -80,6 +80,7 @@ class RequestObject {
   struct event* client_read_timer_event;
 
   std::string request_id;
+  std::string stripped_request_id;
   bool is_service_req_head;
 
   std::string error_code_str;
@@ -212,6 +213,7 @@ class RequestObject {
   void set_account_id(const std::string& id);
   const std::string& get_account_id();
   std::string get_request_id() const { return request_id; }
+  std::string get_stripped_request_id() const { return stripped_request_id; }
 
   S3RequestError get_request_error() const { return request_error; }
 
@@ -241,7 +243,7 @@ class RequestObject {
   // we dont flood with data coming from socket in user buffers.
   virtual void pause() {
     if (!client_connected()) {
-      s3_log(S3_LOG_INFO, request_id, "s3 client is disconnected.\n");
+      s3_log(S3_LOG_INFO, stripped_request_id, "s3 client is disconnected.\n");
       return;
     }
     if (is_s3_client_read_error()) {
@@ -262,7 +264,7 @@ class RequestObject {
 
   virtual void resume(bool set_read_timer = true) {
     if (!client_connected()) {
-      s3_log(S3_LOG_INFO, request_id, "s3 client is disconnected.\n");
+      s3_log(S3_LOG_INFO, stripped_request_id, "s3 client is disconnected.\n");
       return;
     }
     if (is_paused) {
@@ -281,7 +283,7 @@ class RequestObject {
   }
 
   void client_has_disconnected() {
-    s3_log(S3_LOG_INFO, request_id, "S3 Client disconnected.\n");
+    s3_log(S3_LOG_INFO, stripped_request_id, "S3 Client disconnected.\n");
     stop_client_read_timer();
     is_client_connected = false;
     if (ev_req) {

--- a/server/s3_abort_multipart_action.cc
+++ b/server/s3_abort_multipart_action.cc
@@ -39,13 +39,13 @@ S3AbortMultipartAction::S3AbortMultipartAction(
     std::shared_ptr<S3MotrKVSReaderFactory> motr_s3_kvs_reader_factory,
     std::shared_ptr<S3MotrKVSWriterFactory> kv_writer_factory)
     : S3BucketAction(std::move(req), std::move(bucket_meta_factory), false) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
   upload_id = request->get_query_string_value("uploadId");
   bucket_name = request->get_bucket_name();
   object_name = request->get_object_name();
 
-  s3_log(S3_LOG_INFO, request_id,
+  s3_log(S3_LOG_INFO, stripped_request_id,
          "S3 API: Abort Multipart API. Bucket[%s] \
          Object[%s] with UploadId[%s]\n",
          bucket_name.c_str(), object_name.c_str(), upload_id.c_str());
@@ -108,7 +108,7 @@ void S3AbortMultipartAction::setup_steps() {
 }
 
 void S3AbortMultipartAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_abort_mp_action_state = S3AbortMultipartActionState::validationFailed;
 
   S3BucketMetadataState bucket_metadata_state = bucket_metadata->get_state();
@@ -122,11 +122,11 @@ void S3AbortMultipartAction::fetch_bucket_info_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AbortMultipartAction::get_multipart_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::present) {
     multipart_oid = bucket_metadata->get_multipart_index_oid();
     if (multipart_oid.u_lo == 0ULL && multipart_oid.u_hi == 0ULL) {
@@ -146,11 +146,11 @@ void S3AbortMultipartAction::get_multipart_metadata() {
                     this));
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AbortMultipartAction::get_multipart_metadata_status() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (object_multipart_metadata->get_state() ==
       S3ObjectMetadataState::present) {
     if (object_multipart_metadata->get_upload_id() == upload_id) {
@@ -178,11 +178,11 @@ void S3AbortMultipartAction::get_multipart_metadata_status() {
     }
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AbortMultipartAction::add_object_oid_to_probable_dead_oid_list() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   struct m0_uint128 object_oid = object_multipart_metadata->get_oid();
 
   assert(object_oid.u_hi || object_oid.u_lo);
@@ -219,11 +219,11 @@ void S3AbortMultipartAction::add_object_oid_to_probable_dead_oid_list() {
       std::bind(&S3AbortMultipartAction::
                      add_object_oid_to_probable_dead_oid_list_failed,
                 this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AbortMultipartAction::add_object_oid_to_probable_dead_oid_list_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_abort_mp_action_state =
       S3AbortMultipartActionState::probableEntryRecordFailed;
 
@@ -233,29 +233,29 @@ void S3AbortMultipartAction::add_object_oid_to_probable_dead_oid_list_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AbortMultipartAction::delete_multipart_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   part_index_oid = object_multipart_metadata->get_part_index_oid();
   object_multipart_metadata->remove(
       std::bind(&S3AbortMultipartAction::delete_multipart_metadata_successful,
                 this),
       std::bind(&S3AbortMultipartAction::delete_multipart_metadata_failed,
                 this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AbortMultipartAction::delete_multipart_metadata_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_abort_mp_action_state = S3AbortMultipartActionState::uploadMetadataDeleted;
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AbortMultipartAction::delete_multipart_metadata_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_ERROR, request_id,
          "Object multipart meta data deletion failed\n");
   s3_abort_mp_action_state =
@@ -268,11 +268,11 @@ void S3AbortMultipartAction::delete_multipart_metadata_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AbortMultipartAction::delete_part_index_with_parts() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (part_index_oid.u_lo == 0ULL && part_index_oid.u_hi == 0ULL) {
     next();
   } else {
@@ -288,18 +288,18 @@ void S3AbortMultipartAction::delete_part_index_with_parts() {
         std::bind(&S3AbortMultipartAction::delete_part_index_with_parts_failed,
                   this));
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AbortMultipartAction::delete_part_index_with_parts_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_abort_mp_action_state = S3AbortMultipartActionState::partsListIndexDeleted;
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AbortMultipartAction::delete_part_index_with_parts_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_abort_mp_action_state =
       S3AbortMultipartActionState::partsListIndexDeleteFailed;
 
@@ -312,11 +312,11 @@ void S3AbortMultipartAction::delete_part_index_with_parts_failed() {
   s3_iem(LOG_ERR, S3_IEM_DELETE_IDX_FAIL, S3_IEM_DELETE_IDX_FAIL_STR,
          S3_IEM_DELETE_IDX_FAIL_JSON);
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AbortMultipartAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (is_error_state() && !get_s3_error_code().empty()) {
     S3Error error(get_s3_error_code(), request->get_request_id(),
                   request->get_object_uri());
@@ -337,11 +337,11 @@ void S3AbortMultipartAction::send_response_to_s3_client() {
     request->send_response(S3HttpSuccess200);
   }
   startcleanup();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AbortMultipartAction::startcleanup() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // Clear task list and setup cleanup task list
   clear_tasks();
   cleanup_started = true;
@@ -379,11 +379,11 @@ void S3AbortMultipartAction::startcleanup() {
     start();
   }
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AbortMultipartAction::mark_oid_for_deletion() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   assert(!oid_str.empty());
 
   probable_delete_rec->set_force_delete(true);
@@ -396,11 +396,11 @@ void S3AbortMultipartAction::mark_oid_for_deletion() {
                              oid_str, probable_delete_rec->to_json(),
                              std::bind(&S3AbortMultipartAction::next, this),
                              std::bind(&S3AbortMultipartAction::next, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AbortMultipartAction::delete_object() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // process to delete object
   if (!motr_writer) {
     motr_writer = motr_writer_factory->create_motr_writer(
@@ -410,11 +410,11 @@ void S3AbortMultipartAction::delete_object() {
       std::bind(&S3AbortMultipartAction::remove_probable_record, this),
       std::bind(&S3AbortMultipartAction::next, this),
       object_multipart_metadata->get_layout_id());
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AbortMultipartAction::remove_probable_record() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   assert(!oid_str.empty());
 
   if (s3_abort_mp_action_state ==
@@ -431,5 +431,5 @@ void S3AbortMultipartAction::remove_probable_record() {
   } else {
     next();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_account_delete_metadata_action.cc
+++ b/server/s3_account_delete_metadata_action.cc
@@ -31,7 +31,7 @@ S3AccountDeleteMetadataAction::S3AccountDeleteMetadataAction(
     std::shared_ptr<S3RequestObject> req, std::shared_ptr<MotrAPI> motr_api,
     std::shared_ptr<S3MotrKVSReaderFactory> kvs_reader_factory)
     : S3Action(req, true, nullptr, false, true) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   // get the account_id from uri
   account_id_from_uri = request->c_get_file_name();
 
@@ -60,7 +60,7 @@ void S3AccountDeleteMetadataAction::setup_steps() {
 }
 
 void S3AccountDeleteMetadataAction::validate_request() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // check for the account_id got from authentication response and account_id is
   // in uri same or not
   if (account_id_from_uri == request->get_account_id()) {
@@ -77,11 +77,11 @@ void S3AccountDeleteMetadataAction::validate_request() {
     set_s3_error("InvalidAccountForMgmtApi");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AccountDeleteMetadataAction::fetch_first_bucket_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   motr_kv_reader =
       motr_kvs_reader_factory->create_motr_kvs_reader(request, s3_motr_api);
   bucket_account_id_key_prefix = account_id_from_uri + "/";
@@ -93,11 +93,11 @@ void S3AccountDeleteMetadataAction::fetch_first_bucket_metadata() {
       std::bind(
           &S3AccountDeleteMetadataAction::fetch_first_bucket_metadata_failed,
           this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AccountDeleteMetadataAction::fetch_first_bucket_metadata_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   auto& kvps = motr_kv_reader->get_key_values();
   for (auto& kv : kvps) {
     // account_id_from_uri has buckets
@@ -113,11 +113,11 @@ void S3AccountDeleteMetadataAction::fetch_first_bucket_metadata_successful() {
     }
     break;
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AccountDeleteMetadataAction::fetch_first_bucket_metadata_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_kv_reader->get_state() == S3MotrKVSReaderOpState::missing) {
     s3_log(S3_LOG_DEBUG, request_id,
            "There is no bucket for the acocunt id: %s\n",
@@ -135,11 +135,11 @@ void S3AccountDeleteMetadataAction::fetch_first_bucket_metadata_failed() {
     set_s3_error("InternalError");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AccountDeleteMetadataAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -160,5 +160,5 @@ void S3AccountDeleteMetadataAction::send_response_to_s3_client() {
 
   S3_RESET_SHUTDOWN_SIGNAL;  // for shutdown testcases
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_action_base.cc
+++ b/server/s3_action_base.cc
@@ -30,11 +30,11 @@ S3Action::S3Action(std::shared_ptr<S3RequestObject> req, bool check_shutdown,
     : Action(req, check_shutdown, auth_factory, skip_auth),
       request(req),
       skip_authorization(skip_authorize) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   setup_steps();
 }
 
-S3Action::~S3Action() { s3_log(S3_LOG_DEBUG, request_id, "Destructor\n"); }
+S3Action::~S3Action() { s3_log(S3_LOG_DEBUG, request_id, "%s\n", __func__); }
 
 void S3Action::setup_steps() {
   s3_log(S3_LOG_DEBUG, request_id, "Setup the action\n");
@@ -56,20 +56,20 @@ void S3Action::load_metadata() { next(); }
 void S3Action::set_authorization_meta() { next(); }
 
 void S3Action::check_authorization() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   auth_client->check_authorization(
       std::bind(&S3Action::check_authorization_successful, this),
       std::bind(&S3Action::check_authorization_failed, this));
 }
 
 void S3Action::check_authorization_successful() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3Action::check_authorization_failed() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   if (request->client_connected()) {
     std::string error_code = auth_client->get_error_code();
     if (error_code == "InvalidAccessKeyId") {
@@ -93,5 +93,5 @@ void S3Action::check_authorization_failed() {
     request->respond_error(error_code);
   }
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_addb_plugin_auto.cc
+++ b/server/s3_addb_plugin_auto.cc
@@ -82,7 +82,7 @@
 static std::unordered_map<std::type_index, enum S3AddbActionTypeId> gs_addb_map;
 
 int s3_addb_init() {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   // Sorry for the format, this had to be done this way to pass
   // git-clang-format check.
   gs_addb_map[std::type_index(typeid(MotrDeleteIndexAction))] =

--- a/server/s3_api_handler.h
+++ b/server/s3_api_handler.h
@@ -42,6 +42,7 @@ class S3APIHandler {
   std::shared_ptr<S3APIHandler> _get_self_ref() { return self_ref; }
   std::shared_ptr<S3Action> _get_action() { return action; }
   std::string request_id;
+  std::string stripped_request_id;
 
  private:
   std::shared_ptr<S3APIHandler> self_ref;
@@ -50,13 +51,14 @@ class S3APIHandler {
   S3APIHandler(std::shared_ptr<S3RequestObject> req, S3OperationCode op_code)
       : request(req), operation_code(op_code) {
     request_id = request->get_request_id();
+    stripped_request_id = request->get_stripped_request_id();
   }
   virtual ~S3APIHandler() {}
 
   virtual void create_action() = 0;
 
   virtual void dispatch() {
-    s3_log(S3_LOG_DEBUG, request_id, "Entering");
+    s3_log(S3_LOG_DEBUG, request_id, "%s Entry", __func__);
 
     if (action) {
       action->manage_self(action);
@@ -66,7 +68,7 @@ class S3APIHandler {
     }
     i_am_done();
 
-    s3_log(S3_LOG_DEBUG, "", "Exiting");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   }
 
   // Self destructing object.

--- a/server/s3_api_handler_factory.cc
+++ b/server/s3_api_handler_factory.cc
@@ -26,8 +26,9 @@ std::shared_ptr<S3APIHandler> S3APIHandlerFactory::create_api_handler(
     S3OperationCode op_code) {
   std::shared_ptr<S3APIHandler> handler;
   std::string request_id = request->get_request_id();
+  std::string stripped_request_id = request->get_stripped_request_id();
   request->set_operation_code(op_code);
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   switch (api_type) {
     case S3ApiType::service:
       s3_log(S3_LOG_DEBUG, request_id, "api_type = S3ApiType::service\n");
@@ -58,6 +59,6 @@ std::shared_ptr<S3APIHandler> S3APIHandlerFactory::create_api_handler(
            request->get_http_verb_str(request->http_verb()));
     handler->create_action();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return handler;
 }

--- a/server/s3_async_buffer.cc
+++ b/server/s3_async_buffer.cc
@@ -24,11 +24,11 @@ S3AsyncBufferContainer::S3AsyncBufferContainer()
     : buffered_input_length(0),
       is_expecting_more(true),
       count_bufs_shared_for_read(0) {
-  s3_log(S3_LOG_DEBUG, "", "Constructor\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Ctor\n", __func__);
 }
 
 S3AsyncBufferContainer::~S3AsyncBufferContainer() {
-  s3_log(S3_LOG_DEBUG, "", "Destructor\n");
+  s3_log(S3_LOG_DEBUG, "", "%s\n", __func__);
   // clear buffered_input
   evbuf_t* buf = NULL;
   while (!buffered_input.empty()) {
@@ -46,12 +46,12 @@ bool S3AsyncBufferContainer::is_freezed() { return !is_expecting_more; }
 size_t S3AsyncBufferContainer::length() { return buffered_input_length; }
 
 void S3AsyncBufferContainer::add_content(evbuf_t* buf) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, "", "add_content with len %zu at address %p\n",
          evbuffer_get_length(buf), buf);
   buffered_input.push_back(buf);
   buffered_input_length += evbuffer_get_length(buf);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 // Call this to get at least expected_content_size of data buffers.
@@ -61,7 +61,7 @@ void S3AsyncBufferContainer::add_content(evbuf_t* buf) {
 // expected_content_size = -1 and all data is available, returns all buffers
 std::deque<std::tuple<void*, size_t> > S3AsyncBufferContainer::get_buffers_ref(
     size_t expected_content_size) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, "", "get_buffers_ref with expected_content_size = %zu\n",
          expected_content_size);
 
@@ -130,12 +130,12 @@ std::deque<std::tuple<void*, size_t> > S3AsyncBufferContainer::get_buffers_ref(
       free(vec_in);
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return data_items;
 }
 
 void S3AsyncBufferContainer::mark_size_of_data_consumed(size_t size_consumed) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, "", "mark_size_of_data_consumed size_consumed = %zu\n",
          size_consumed);
 
@@ -159,12 +159,12 @@ void S3AsyncBufferContainer::mark_size_of_data_consumed(size_t size_consumed) {
       }
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return;
 }
 
 std::string S3AsyncBufferContainer::get_content_as_string() {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   std::string content = "";
 
   if (is_freezed()) {
@@ -211,6 +211,6 @@ std::string S3AsyncBufferContainer::get_content_as_string() {
   }
   buffered_input_length = 0;  // Everything is returned.
   s3_log(S3_LOG_DEBUG, "", "Content size = %zu\n", content.length());
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return content;
 }

--- a/server/s3_async_buffer_opt.cc
+++ b/server/s3_async_buffer_opt.cc
@@ -27,7 +27,7 @@ S3AsyncBufferOptContainer::S3AsyncBufferOptContainer(size_t size_of_each_buf)
       is_expecting_more(true),
       count_bufs_shared_for_read(0),
       size_of_each_evbuf(size_of_each_buf) {
-  s3_log(S3_LOG_DEBUG, "", "Constructor with size_of_each_buf = %zu\n",
+  s3_log(S3_LOG_DEBUG, "", "%s Ctor with size_of_each_buf = %zu\n", __func__,
          size_of_each_buf);
 
   // Should be multiple of 4k (Motr requirement)
@@ -35,7 +35,7 @@ S3AsyncBufferOptContainer::S3AsyncBufferOptContainer(size_t size_of_each_buf)
 }
 
 S3AsyncBufferOptContainer::~S3AsyncBufferOptContainer() {
-  s3_log(S3_LOG_DEBUG, "", "Destructor\n");
+  s3_log(S3_LOG_DEBUG, "", "%s\n", __func__);
   // release all memory
   evbuf_t* buf = NULL;
   while (!ready_q.empty()) {
@@ -67,7 +67,7 @@ size_t S3AsyncBufferOptContainer::get_content_length() const {
 bool S3AsyncBufferOptContainer::add_content(evbuf_t* buf, bool is_first_buf,
                                             bool is_last_buf,
                                             bool is_put_request) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   if (!buf) {
     s3_log(S3_LOG_ERROR, "", "buf == NULL");
     return false;
@@ -100,7 +100,7 @@ bool S3AsyncBufferOptContainer::add_content(evbuf_t* buf, bool is_first_buf,
   }
   ready_q.push_back(buf);
   content_length += len;
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 
   return true;
 }
@@ -114,7 +114,7 @@ bool S3AsyncBufferOptContainer::add_content(evbuf_t* buf, bool is_first_buf,
 S3BufferSequence S3AsyncBufferOptContainer::get_buffers(
     size_t expected_content_size) {
 
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, "", "get_buffers with expected_content_size = %zu\n",
          expected_content_size);
 
@@ -178,7 +178,7 @@ S3BufferSequence S3AsyncBufferOptContainer::get_buffers(
 }
 
 void S3AsyncBufferOptContainer::flush_used_buffers() {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
 
   // assert(!processing_q.empty());
 
@@ -195,12 +195,12 @@ void S3AsyncBufferOptContainer::flush_used_buffers() {
   }
   s3_log(S3_LOG_DEBUG, "", "Freed evbuffer of len = %zu\n", size_consumed);
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return;
 }
 
 std::string S3AsyncBufferOptContainer::get_content_as_string() {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   std::string content = "";
 
   // We should not have returned any bufs out for processing.
@@ -249,6 +249,6 @@ std::string S3AsyncBufferOptContainer::get_content_as_string() {
   }
   content_length = 0;  // Everything is returned.
   s3_log(S3_LOG_DEBUG, "", "Content size = %zu\n", content.length());
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return content;
 }

--- a/server/s3_asyncop_context_base.cc
+++ b/server/s3_asyncop_context_base.cc
@@ -38,6 +38,7 @@ S3AsyncOpContextBase::S3AsyncOpContextBase(std::shared_ptr<RequestObject> req,
       s3_motr_api(motr_api ? std::move(motr_api)
                            : std::make_shared<ConcreteMotrAPI>()) {
   request_id = request->get_request_id();
+  stripped_request_id = request->get_stripped_request_id();
   ops_response.resize(ops_count);
 }
 

--- a/server/s3_asyncop_context_base.h
+++ b/server/s3_asyncop_context_base.h
@@ -69,6 +69,7 @@ class S3AsyncOpContextBase {
   std::shared_ptr<MotrAPI> s3_motr_api;
 
   std::string request_id;
+  std::string stripped_request_id;
 
  public:
   S3AsyncOpContextBase(std::shared_ptr<RequestObject> req,

--- a/server/s3_audit_info_logger.cc
+++ b/server/s3_audit_info_logger.cc
@@ -32,7 +32,7 @@ S3AuditInfoLoggerBase* S3AuditInfoLogger::audit_info_logger = nullptr;
 bool S3AuditInfoLogger::audit_info_logger_enabled = false;
 
 int S3AuditInfoLogger::init() {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   int ret = 0;
   audit_info_logger = nullptr;
   audit_info_logger_enabled = false;
@@ -101,7 +101,7 @@ int S3AuditInfoLogger::init() {
     ret = -1;
   }
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting ret %d\n", ret);
+  s3_log(S3_LOG_DEBUG, "", "%s Exit ret %d\n", __func__, ret);
   return ret;
 }
 
@@ -116,9 +116,9 @@ int S3AuditInfoLogger::save_msg(std::string const& cur_request_id,
 bool S3AuditInfoLogger::is_enabled() { return audit_info_logger_enabled; }
 
 void S3AuditInfoLogger::finalize() {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   delete audit_info_logger;
   audit_info_logger = nullptr;
   audit_info_logger_enabled = false;
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_audit_info_logger_kafka_web.cc
+++ b/server/s3_audit_info_logger_kafka_web.cc
@@ -29,7 +29,7 @@ S3AuditInfoLoggerKafkaWeb::S3AuditInfoLoggerKafkaWeb(evbase_t* p_base,
                                                      std::string host_ip,
                                                      uint16_t port,
                                                      std::string path) {
-  s3_log(S3_LOG_INFO, nullptr, "Constructor");
+  s3_log(S3_LOG_INFO, nullptr, "%s Ctor\n", __func__);
 
   std::map<std::string, std::string> headers;
   headers["Content-Type"] = "application/vnd.kafka.json.v2+json";
@@ -42,13 +42,13 @@ S3AuditInfoLoggerKafkaWeb::~S3AuditInfoLoggerKafkaWeb() = default;
 
 int S3AuditInfoLoggerKafkaWeb::save_msg(std::string const& request_id,
                                         std::string const& msg) {
-  s3_log(S3_LOG_INFO, request_id, "Entering");
+  s3_log(S3_LOG_INFO, request_id, "%s Entry", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "%s", msg.c_str());
 
   std::string fmt_msg =
       "{\"records\":[{\"key\":\"s3server\",\"value\":" + msg + "}]}";
   const bool fSucc = p_s3_post_queue->post(std::move(fmt_msg));
 
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
   return !fSucc;
 }

--- a/server/s3_audit_info_logger_log4cxx.cc
+++ b/server/s3_audit_info_logger_log4cxx.cc
@@ -55,8 +55,8 @@ S3AuditInfoLoggerLog4cxx::~S3AuditInfoLoggerLog4cxx() { l4c_logger_ptr = 0; }
 
 int S3AuditInfoLoggerLog4cxx::save_msg(std::string const &cur_request_id,
                                        std::string const &audit_logging_msg) {
-  s3_log(S3_LOG_DEBUG, cur_request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, cur_request_id, "%s Entry\n", __func__);
   LOG4CXX_INFO(l4c_logger_ptr, audit_logging_msg);
-  s3_log(S3_LOG_DEBUG, cur_request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, cur_request_id, "%s Exit", __func__);
   return 0;
 }

--- a/server/s3_audit_info_logger_rsyslog_tcp.cc
+++ b/server/s3_audit_info_logger_rsyslog_tcp.cc
@@ -26,10 +26,11 @@
 
 void S3AuditInfoLoggerRsyslogTcp::eventcb(struct bufferevent *bev, short events,
                                           void *ptr) {
-  s3_log(S3_LOG_DEBUG, "", "Entering event %d ptr %p\n", (int)events, ptr);
+  s3_log(S3_LOG_DEBUG, "", "%s Entry event %d ptr %p\n", __func__, (int)events,
+         ptr);
 
   if (ptr == nullptr) {
-    s3_log(S3_LOG_ERROR, "", "Exiting. Unexpected event param\n");
+    s3_log(S3_LOG_ERROR, "", "%s Exit. Unexpected event param\n", __func__);
     return;
   }
 
@@ -42,7 +43,8 @@ void S3AuditInfoLoggerRsyslogTcp::eventcb(struct bufferevent *bev, short events,
       evutil_socket_t fd = bufferevent_getfd(bev);
       int one = 1;
       if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one)) != 0) {
-        s3_log(S3_LOG_ERROR, "", "Exiting. setsockopt errno %d\n", errno);
+        s3_log(S3_LOG_ERROR, "", "%s Exit. setsockopt errno %d\n", __func__,
+               errno);
         self->curr_retry = self->max_retry + 1;
       }
     }
@@ -55,11 +57,11 @@ void S3AuditInfoLoggerRsyslogTcp::eventcb(struct bufferevent *bev, short events,
     }
   }
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AuditInfoLoggerRsyslogTcp::connect() {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
 
   ++curr_retry;
   if (curr_retry > max_retry) {
@@ -75,7 +77,7 @@ void S3AuditInfoLoggerRsyslogTcp::connect() {
     curr_retry = max_retry + 1;
   }
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 S3AuditInfoLoggerRsyslogTcp::S3AuditInfoLoggerRsyslogTcp(
@@ -93,10 +95,10 @@ S3AuditInfoLoggerRsyslogTcp::S3AuditInfoLoggerRsyslogTcp(
       base_event(base),
       base_dns(nullptr),
       connecting(false) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
 
   if (base == nullptr) {
-    s3_log(S3_LOG_ERROR, "", "Exiting. Base event is NULL\n");
+    s3_log(S3_LOG_ERROR, "", "%s Exit. Base event is NULL\n", __func__);
     throw std::invalid_argument("Base event is NULL");
   }
 
@@ -108,20 +110,20 @@ S3AuditInfoLoggerRsyslogTcp::S3AuditInfoLoggerRsyslogTcp(
   }
 
   if (socket_api == nullptr) {
-    s3_log(S3_LOG_ERROR, "", "Exiting. Socket API is NULL\n");
+    s3_log(S3_LOG_ERROR, "", "%s Exit. Socket API is NULL\n", __func__);
     throw std::runtime_error("Socket API is NULL");
   }
 
   bev =
       socket_api->bufferevent_socket_new(base_event, -1, BEV_OPT_CLOSE_ON_FREE);
   if (bev == nullptr) {
-    s3_log(S3_LOG_ERROR, "", "Exiting. Cannot create socket\n");
+    s3_log(S3_LOG_ERROR, "", "%s Exit. Cannot create socket\n", __func__);
     throw std::runtime_error("Cannot create socket");
   }
 
   base_dns = socket_api->evdns_base_new(base_event, 1);
   if (base_dns == nullptr) {
-    s3_log(S3_LOG_ERROR, "", "Exiting. Cannot create DNS rslv\n");
+    s3_log(S3_LOG_ERROR, "", "%s Exit. Cannot create DNS rslv\n", __func__);
     throw std::runtime_error("Cannot create DNS rslv");
   }
 
@@ -137,11 +139,11 @@ S3AuditInfoLoggerRsyslogTcp::S3AuditInfoLoggerRsyslogTcp(
                      message_id + " " + "-";
 
   connect();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 S3AuditInfoLoggerRsyslogTcp::~S3AuditInfoLoggerRsyslogTcp() {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   if (base_dns != nullptr) {
     socket_api->evdns_base_free(base_dns, 0);
     base_dns = nullptr;
@@ -155,16 +157,16 @@ S3AuditInfoLoggerRsyslogTcp::~S3AuditInfoLoggerRsyslogTcp() {
   }
   socket_api = nullptr;
   connecting = false;
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 int S3AuditInfoLoggerRsyslogTcp::save_msg(
     std::string const &cur_request_id, std::string const &audit_logging_msg) {
-  s3_log(S3_LOG_DEBUG, cur_request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, cur_request_id, "%s Entry\n", __func__);
 
   if (curr_retry > max_retry) {
-    s3_log(S3_LOG_ERROR, cur_request_id, "Exiting. Retries %d exceeds %d\n",
-           curr_retry, max_retry);
+    s3_log(S3_LOG_ERROR, cur_request_id, "%s Exit. Retries %d exceeds %d\n",
+           __func__, curr_retry, max_retry);
     return -1;
   }
 
@@ -173,11 +175,12 @@ int S3AuditInfoLoggerRsyslogTcp::save_msg(
   int ret =
       socket_api->evbuffer_add(output, msg_to_snd.c_str(), msg_to_snd.length());
   if (ret != 0) {
-    s3_log(S3_LOG_ERROR, cur_request_id, "Exiting. Cannot write to buffer\n");
+    s3_log(S3_LOG_ERROR, cur_request_id, "%s Exit. Cannot write to buffer\n",
+           __func__);
     curr_retry = max_retry + 1;
     return -1;
   }
 
-  s3_log(S3_LOG_DEBUG, cur_request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, cur_request_id, "%s Exit", __func__);
   return 0;
 }

--- a/server/s3_audit_info_logger_syslog.cc
+++ b/server/s3_audit_info_logger_syslog.cc
@@ -32,9 +32,9 @@ S3AuditInfoLoggerSyslog::~S3AuditInfoLoggerSyslog() {}
 
 int S3AuditInfoLoggerSyslog::save_msg(std::string const &cur_request_id,
                                       std::string const &audit_logging_msg) {
-  s3_log(S3_LOG_DEBUG, cur_request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, cur_request_id, "%s Entry\n", __func__);
   syslog(LOG_NOTICE, "%s%s", rsyslog_msg_filter.c_str(),
          audit_logging_msg.c_str());
-  s3_log(S3_LOG_DEBUG, cur_request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, cur_request_id, "%s Exit", __func__);
   return 0;
 }

--- a/server/s3_auth_client.cc
+++ b/server/s3_auth_client.cc
@@ -36,9 +36,9 @@
 void s3_auth_op_done_on_main_thread(evutil_socket_t, short events,
                                     void *user_data) {
   if (user_data == NULL) {
-    s3_log(S3_LOG_DEBUG, "", "Entering\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
     s3_log(S3_LOG_ERROR, "", "Input argument user_data is NULL\n");
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   struct user_event_context *user_context =
@@ -48,7 +48,9 @@ void s3_auth_op_done_on_main_thread(evutil_socket_t, short events,
     s3_log(S3_LOG_ERROR, "", "context pointer is NULL\n");
   }
   const auto request_id = context->get_request()->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  const auto stripped_request_id =
+      context->get_request()->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   struct event *s3user_event = (struct event *)user_context->user_event;
   if (s3user_event == NULL) {
     s3_log(S3_LOG_ERROR, request_id, "User event is NULL\n");
@@ -66,7 +68,7 @@ void s3_auth_op_done_on_main_thread(evutil_socket_t, short events,
   free(user_data);
   // Free user event
   if (s3user_event) event_free(s3user_event);
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }
 
 // Post success handler on main thread so that current auth callback stack can
@@ -76,7 +78,9 @@ void s3_auth_op_done_on_main_thread(evutil_socket_t, short events,
 void s3_auth_op_success(void *application_context, int rc) {
   S3AsyncOpContextBase *app_ctx = (S3AsyncOpContextBase *)application_context;
   const auto request_id = app_ctx->get_request()->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  const auto stripped_request_id =
+      app_ctx->get_request()->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "Error code = %d\n", rc);
   app_ctx->set_op_errno_for(0, rc);
   struct user_event_context *user_ctx =
@@ -92,7 +96,7 @@ void s3_auth_op_success(void *application_context, int rc) {
   S3PostToMainLoop((void *)user_ctx)(s3_auth_op_done_on_main_thread,
                                      request_id);
 #endif  // S3_GOOGLE_TEST
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }
 
 /* S3 Auth client callbacks */
@@ -106,7 +110,9 @@ extern "C" evhtp_res on_conn_err_callback(evhtp_connection_t *connection,
     return EVHTP_RES_OK;
   }
   const auto request_id = context->get_request()->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  const auto stripped_request_id =
+      context->get_request()->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   if (connection == NULL) {
     s3_log(S3_LOG_ERROR, request_id, "input connection is NULL\n");
     return EVHTP_RES_OK;
@@ -118,7 +124,7 @@ extern "C" evhtp_res on_conn_err_callback(evhtp_connection_t *connection,
   std::string errtype_str =
       S3CommonUtilities::evhtp_error_flags_description(errtype);
   if (connection->request) {
-    s3_log(S3_LOG_INFO, request_id, "Connection status = %d\n",
+    s3_log(S3_LOG_INFO, stripped_request_id, "Connection status = %d\n",
            connection->request->status);
   }
   s3_log(
@@ -147,7 +153,9 @@ extern "C" evhtp_res on_authorization_response(evhtp_request_t *req,
   unsigned int auth_resp_status = evhtp_request_status(req);
   S3AuthClientOpContext *context = (S3AuthClientOpContext *)arg;
   const auto request_id = context->get_request()->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  const auto stripped_request_id =
+      context->get_request()->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "auth_resp_status = %d\n", auth_resp_status);
 
   ADDB(S3_ADDB_AUTH_ID, context->get_request()->addb_request_id,
@@ -164,7 +172,7 @@ extern "C" evhtp_res on_authorization_response(evhtp_request_t *req,
     // Calling failed handler to do proper cleanup to avoid leaks
     // i.e cleanup of S3Request and respective action chain.
     context->on_failed_handler()();  // Invoke the handler.
-    s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+    s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
     return EVHTP_RES_OK;
   }
   size_t buffer_len = evbuffer_get_length(buf);
@@ -218,7 +226,7 @@ extern "C" evhtp_res on_authorization_response(evhtp_request_t *req,
   } else {
     context->on_failed_handler()();  // Invoke the handler.
   }
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
   return EVHTP_RES_OK;
 }
 
@@ -230,7 +238,9 @@ extern "C" evhtp_res on_aclvalidation_response(evhtp_request_t *req,
   S3AuthClientOpContext *context = static_cast<S3AuthClientOpContext *>(arg);
 
   const auto request_id = context->get_request()->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  const auto stripped_request_id =
+      context->get_request()->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   if (context->get_request()) {
     s3_log(S3_LOG_DEBUG, request_id, "auth_resp_status = %d\n",
            auth_resp_status);
@@ -296,7 +306,7 @@ extern "C" evhtp_res on_aclvalidation_response(evhtp_request_t *req,
   } else {
     context->on_failed_handler()();  // Invoke the handler.
   }
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
   return EVHTP_RES_OK;
 }
 
@@ -307,7 +317,9 @@ extern "C" evhtp_res on_policy_validation_response(evhtp_request_t *req,
   // S3AuthClientOpContext *context = (S3AuthClientOpContext *)arg;
   S3AuthClientOpContext *context = static_cast<S3AuthClientOpContext *>(arg);
   const auto request_id = context->get_request()->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  const auto stripped_request_id =
+      context->get_request()->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   if (context->get_request()) {
     s3_log(S3_LOG_DEBUG, request_id, "auth_resp_status = %d\n",
            auth_resp_status);
@@ -372,7 +384,7 @@ extern "C" evhtp_res on_policy_validation_response(evhtp_request_t *req,
   } else {
     context->on_failed_handler()();  // Invoke the handler.
   }
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
   return EVHTP_RES_OK;
 }
 
@@ -381,7 +393,9 @@ extern "C" evhtp_res on_auth_response(evhtp_request_t *req, evbuf_t *buf,
   unsigned int auth_resp_status;
   S3AuthClientOpContext *context = (S3AuthClientOpContext *)arg;
   const auto request_id = context->get_request()->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  const auto stripped_request_id =
+      context->get_request()->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
 
   if (s3_fi_is_enabled("fake_authentication_fail")) {
     auth_resp_status = S3HttpFailed401;
@@ -455,7 +469,7 @@ extern "C" evhtp_res on_auth_response(evhtp_request_t *req, evbuf_t *buf,
   } else {
     context->on_failed_handler()();  // Invoke the handler.
   }
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
   return EVHTP_RES_OK;
 }
 
@@ -465,7 +479,8 @@ extern "C" void timeout_cb_auth_retry(evutil_socket_t fd, short event,
       (struct event_auth_timeout_arg *)arg;
   S3AuthClient *auth_client = (S3AuthClient *)(timeout_arg->auth_client);
   const auto request_id = auth_client->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  const auto stripped_request_id = auth_client->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "Retring to connect to Auth server\n");
   ADDB(S3_ADDB_AUTH_ID, auth_client->get_request()->addb_request_id,
        ACTS_AUTH_OP_ON_TIMEOUT);
@@ -478,13 +493,15 @@ extern "C" void timeout_cb_auth_retry(evutil_socket_t fd, short event,
   }
   event_free(timeout_event);
   free(timeout_arg);
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }
 
 extern "C" void on_event_hook(evhtp_connection_t *conn, short events,
                               void *arg) {
   S3AuthClientOpContext *context = (S3AuthClientOpContext *)arg;
   const auto request_id = context->get_request()->get_request_id();
+  const auto stripped_request_id =
+      context->get_request()->get_stripped_request_id();
   s3_log(S3_LOG_DEBUG, request_id, "event (%x) EOF:%d ER:%d T:%d C:%d\n",
          (int)events, (int)!!(events & BEV_EVENT_EOF),
          (int)!!(events & BEV_EVENT_ERROR), (int)!!(events & BEV_EVENT_TIMEOUT),
@@ -514,6 +531,8 @@ extern "C" void on_event_hook(evhtp_connection_t *conn, short events,
 extern "C" void on_write_hook(evhtp_connection_t *conn, void *arg) {
   S3AuthClientOpContext *context = (S3AuthClientOpContext *)arg;
   const auto request_id = context->get_request()->get_request_id();
+  const auto stripped_request_id =
+      context->get_request()->get_stripped_request_id();
   s3_log(S3_LOG_DEBUG, request_id, "on socket write\n");
 
   ADDB(S3_ADDB_AUTH_ID, context->get_request()->addb_request_id,
@@ -523,6 +542,8 @@ extern "C" void on_write_hook(evhtp_connection_t *conn, void *arg) {
 extern "C" evhtp_res on_request_headers(evhtp_request_t *r, void *arg) {
   S3AuthClientOpContext *context = (S3AuthClientOpContext *)arg;
   const auto request_id = context->get_request()->get_request_id();
+  const auto stripped_request_id =
+      context->get_request()->get_stripped_request_id();
   s3_log(S3_LOG_DEBUG, request_id, "request headers read\n");
 
   ADDB(S3_ADDB_AUTH_ID, context->get_request()->addb_request_id,
@@ -535,10 +556,10 @@ extern "C" evhtp_res on_request_headers(evhtp_request_t *r, void *arg) {
 void S3AuthClientOpContext::set_auth_response_error(std::string error_code,
                                                     std::string error_message,
                                                     std::string request_id) {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   error_obj.reset(new S3AuthResponseError(
       std::move(error_code), std::move(error_message), std::move(request_id)));
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }
 
 S3AuthClient::S3AuthClient(std::shared_ptr<RequestObject> req,
@@ -551,7 +572,8 @@ S3AuthClient::S3AuthClient(std::shared_ptr<RequestObject> req,
       chunk_auth_aborted(false),
       skip_authorization(skip_authorization) {
   request_id = request->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  stripped_request_id = request->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   ADDB_AUTH(ACTS_AUTH_CLNT_CONSTRUCT);
   retry_count = 0;
   op_type = S3AuthClientOpType::authentication;
@@ -648,7 +670,7 @@ std::string S3AuthClient::get_error_code() {
 }
 
 bool S3AuthClient::setup_auth_request_body() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
 
   S3AuthClientOpType auth_request_type = get_op_type();
   std::string auth_request_body;
@@ -836,7 +858,7 @@ bool S3AuthClient::setup_auth_request_body() {
   evbuffer_add(req_body_buffer, auth_request_body.c_str(),
                auth_request_body.length());
 
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 
   return !auth_request_body.empty();
 }
@@ -854,7 +876,7 @@ void S3AuthClient::set_validate_acl(const std::string &validateacl) {
 }
 
 void S3AuthClient::setup_auth_request_headers() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   struct s3_auth_op_context *op_ctx = auth_context->get_auth_op_ctx();
   char sz_size[100] = {0};
   size_t out_len = evbuffer_get_length(req_body_buffer);
@@ -888,7 +910,7 @@ void S3AuthClient::setup_auth_request_headers() {
   evhtp_headers_add_header(auth_request->headers_out,
                            evhtp_header_new("Connection", "close", 1, 1));
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AuthClient::set_is_authheader_present(
@@ -918,7 +940,7 @@ void S3AuthClient::execute_authconnect_request(
 }
 
 void S3AuthClient::trigger_authentication() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
 
   ADDB_AUTH(ACTS_AUTH_CLNT_TRIGGER_AUTH);
 
@@ -980,20 +1002,20 @@ void S3AuthClient::trigger_authentication() {
   execute_authconnect_request(auth_ctx);
 
   at_exit_on_error.cancel();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 // Note: S3AuthClientOpContext should be created before calling this.
 // This is called by check_authentication and start_chunk_auth
 void S3AuthClient::trigger_authentication(std::function<void(void)> on_success,
                                           std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
 
   this->handler_on_success = on_success;
   this->handler_on_failed = on_failed;
 
   trigger_authentication();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AuthClient::validate_acl(std::function<void(void)> on_success,
@@ -1047,7 +1069,7 @@ void S3AuthClient::validate_acl(std::function<void(void)> on_success,
   }
   execute_authconnect_request(auth_ctx);
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AuthClient::validate_policy(std::function<void(void)> on_success,
@@ -1095,21 +1117,21 @@ void S3AuthClient::validate_policy(std::function<void(void)> on_success,
   }
   execute_authconnect_request(auth_ctx);
 
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }
 
 void S3AuthClient::policy_validation_successful() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   ADDB_AUTH(ACTS_AUTH_CLNT_VALIDATE_POLICY_SUCC);
   state = S3AuthClientOpState::authenticated;
   remember_auth_details_in_request();
   // prev_chunk_signature_from_auth = get_signature_from_response();
   this->handler_on_success();
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }
 
 void S3AuthClient::policy_validation_failed() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   ADDB_AUTH(ACTS_AUTH_CLNT_VALIDATE_POLICY_FAILED);
   S3AsyncOpStatus op_state = auth_context.get()->get_op_status_for(0);
   if (op_state == S3AsyncOpStatus::connection_failed) {
@@ -1132,11 +1154,11 @@ void S3AuthClient::policy_validation_failed() {
 
     this->handler_on_failed();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AuthClient::check_authorization() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   set_op_type(S3AuthClientOpType::authorization);
   state = S3AuthClientOpState::started;
   ADDB_AUTH(ACTS_AUTH_CLNT_CHK_AUTHZ_R);
@@ -1172,12 +1194,12 @@ void S3AuthClient::check_authorization() {
 
   execute_authconnect_request(auth_ctx);
 
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }
 
 void S3AuthClient::check_authorization(std::function<void(void)> on_success,
                                        std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   ADDB_AUTH(ACTS_AUTH_CLNT_CHK_AUTHZ);
   set_op_type(S3AuthClientOpType::authorization);
 
@@ -1232,16 +1254,16 @@ void S3AuthClient::check_authorization(std::function<void(void)> on_success,
   }
   execute_authconnect_request(auth_ctx);
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AuthClient::check_authorization_successful() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   ADDB_AUTH(ACTS_AUTH_CLNT_CHK_AUTHZ_SUCC);
   state = S3AuthClientOpState::authorized;
   retry_count = 0;
   this->handler_on_success();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 /*
@@ -1269,7 +1291,7 @@ void S3AuthClient::check_authorization_successful() {
  */
 
 void S3AuthClient::check_authorization_failed() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_ERROR, request_id, "Authorization failure\n");
   ADDB_AUTH(ACTS_AUTH_CLNT_CHK_AUTHZ_FAILED);
   S3AsyncOpStatus op_state = auth_context.get()->get_op_status_for(0);
@@ -1295,7 +1317,7 @@ void S3AuthClient::check_authorization_failed() {
   }
 
   // this->handler_on_failed();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AuthClient::check_authentication() {
@@ -1310,7 +1332,7 @@ void S3AuthClient::check_authentication() {
 
 void S3AuthClient::check_authentication(std::function<void(void)> on_success,
                                         std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   ADDB_AUTH(ACTS_AUTH_CLNT_CHK_AUTH);
   auth_context.reset(new S3AuthClientOpContext(
       request, std::bind(&S3AuthClient::check_authentication_successful, this),
@@ -1320,33 +1342,33 @@ void S3AuthClient::check_authentication(std::function<void(void)> on_success,
   set_op_type(S3AuthClientOpType::authentication);
 
   trigger_authentication(on_success, on_failed);
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }
 
 void S3AuthClient::check_authentication_successful() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   ADDB_AUTH(ACTS_AUTH_CLNT_CHK_AUTH_SUCC);
   state = S3AuthClientOpState::authenticated;
   retry_count = 0;
   remember_auth_details_in_request();
   prev_chunk_signature_from_auth = get_signature_from_response();
   this->handler_on_success();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AuthClient::check_aclvalidation_successful() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   ADDB_AUTH(ACTS_AUTH_CLNT_VALIDATE_ACL_SUCC);
   state = S3AuthClientOpState::authenticated;
   retry_count = 0;
   remember_auth_details_in_request();
   prev_chunk_signature_from_auth = get_signature_from_response();
   this->handler_on_success();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AuthClient::check_authentication_failed() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   ADDB_AUTH(ACTS_AUTH_CLNT_CHK_AUTH_FAILED);
   S3AsyncOpStatus op_state = auth_context.get()->get_op_status_for(0);
   if (op_state == S3AsyncOpStatus::connection_failed) {
@@ -1369,11 +1391,11 @@ void S3AuthClient::check_authentication_failed() {
     state = S3AuthClientOpState::unauthenticated;
     this->handler_on_failed();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AuthClient::check_aclvalidation_failed() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   ADDB_AUTH(ACTS_AUTH_CLNT_VALIDATE_ACL_FAILED);
   S3AsyncOpStatus op_state = auth_context.get()->get_op_status_for(0);
   if (op_state == S3AsyncOpStatus::connection_failed) {
@@ -1396,7 +1418,7 @@ void S3AuthClient::check_aclvalidation_failed() {
 
     this->handler_on_failed();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 // This is same as above but will cycle through with the
@@ -1404,7 +1426,7 @@ void S3AuthClient::check_aclvalidation_failed() {
 // to validate each chunk we receive.
 void S3AuthClient::init_chunk_auth_cycle(std::function<void(void)> on_success,
                                          std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   ADDB_AUTH(ACTS_AUTH_CLNT_CHUNK_AUTH_INIT);
   this->handler_on_success = on_success;
   this->handler_on_failed = on_failed;
@@ -1415,7 +1437,7 @@ void S3AuthClient::init_chunk_auth_cycle(std::function<void(void)> on_success,
 
   is_chunked_auth = true;
   set_op_type(S3AuthClientOpType::authentication);
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
   // trigger is done when sign and hash are available for any chunk
 }
 
@@ -1423,7 +1445,7 @@ void S3AuthClient::init_chunk_auth_cycle(std::function<void(void)> on_success,
 // and sha256(chunk-data) to be used in auth of chunk
 void S3AuthClient::add_checksum_for_chunk(std::string current_sign,
                                           std::string sha256_of_payload) {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   ADDB_AUTH(ACTS_AUTH_CLNT_CHUNK_ADD_CHKSUMM);
   chunk_validation_data.push(std::make_tuple(current_sign, sha256_of_payload));
   if (state != S3AuthClientOpState::started) {
@@ -1433,19 +1455,19 @@ void S3AuthClient::add_checksum_for_chunk(std::string current_sign,
     chunk_validation_data.pop();
     trigger_authentication(this->handler_on_success, this->handler_on_failed);
   }
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }
 
 void S3AuthClient::add_last_checksum_for_chunk(std::string current_sign,
                                                std::string sha256_of_payload) {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   last_chunk_added = true;
   add_checksum_for_chunk(current_sign, sha256_of_payload);
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }
 
 void S3AuthClient::chunk_auth_successful() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   ADDB_AUTH(ACTS_AUTH_CLNT_CHUNK_AUTH_SUCC);
   state = S3AuthClientOpState::authenticated;
   retry_count = 0;
@@ -1469,14 +1491,14 @@ void S3AuthClient::chunk_auth_successful() {
       trigger_authentication(this->handler_on_success, this->handler_on_failed);
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3AuthClient::chunk_auth_failed() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_ERROR, request_id, "Authentication failure\n");
   ADDB_AUTH(ACTS_AUTH_CLNT_CHUNK_AUTH_FAILED);
   state = S3AuthClientOpState::unauthenticated;
   this->handler_on_failed();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_auth_client.h
+++ b/server/s3_auth_client.h
@@ -76,12 +76,12 @@ class S3AuthClientOpContext : public S3AsyncOpContextBase {
         is_aclvalidation_successful(false),
         is_policyvalidation_successful(false),
         auth_response_xml("") {
-    s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+    s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
     ADDB_AUTH(ACTS_AUTH_OP_CTX_CONSTRUCT);
   }
 
   ~S3AuthClientOpContext() {
-    s3_log(S3_LOG_DEBUG, request_id, "Destructor\n");
+    s3_log(S3_LOG_DEBUG, request_id, "%s\n", __func__);
     ADDB_AUTH(ACTS_AUTH_OP_CTX_DESTRUCT);
     clear_op_context();
   }
@@ -91,7 +91,7 @@ class S3AuthClientOpContext : public S3AsyncOpContextBase {
                                std::string request_id);
 
   void set_auth_response_xml(const char* xml, bool success = true) {
-    s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+    s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
     auth_response_xml = xml;
     is_auth_successful = success;
     if (is_auth_successful) {
@@ -109,31 +109,31 @@ class S3AuthClientOpContext : public S3AsyncOpContextBase {
     } else {
       error_obj.reset(new S3AuthResponseError(auth_response_xml));
     }
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   }
 
   void set_aclvalidation_response_xml(const char* xml, bool success = true) {
-    s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+    s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
     is_aclvalidation_successful = success;
     auth_response_xml = xml;
     if (!success) {
       error_obj.reset(new S3AuthResponseError(auth_response_xml));
     }
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   }
 
   void set_policyvalidation_response_xml(const char* xml, bool success = true) {
-    s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+    s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
     is_policyvalidation_successful = success;
     auth_response_xml = xml;
     if (!success) {
       error_obj.reset(new S3AuthResponseError(auth_response_xml));
     }
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   }
 
   void set_authorization_response(const char* xml, bool success = true) {
-    s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+    s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
     authorization_response_xml = xml;
     is_authorization_successful = success;
     if (is_authorization_successful) {
@@ -157,7 +157,7 @@ class S3AuthClientOpContext : public S3AsyncOpContextBase {
     } else {
       error_obj.reset(new S3AuthResponseError(authorization_response_xml));
     }
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   }
 
   bool auth_successful() { return is_auth_successful; }
@@ -320,6 +320,7 @@ class S3AuthClient {
   std::shared_ptr<RequestObject> request;
   std::unique_ptr<S3AuthClientOpContext> auth_context;
   std::string request_id;
+  std::string stripped_request_id;
   std::string bucket_acl;
 
   // Used to report to caller
@@ -360,7 +361,7 @@ class S3AuthClient {
                bool skip_authorization = false);
 
   virtual ~S3AuthClient() {
-    s3_log(S3_LOG_DEBUG, request_id, "Destructor\n");
+    s3_log(S3_LOG_DEBUG, request_id, "%s\n", __func__);
     ADDB_AUTH(ACTS_AUTH_CLNT_DESTRUCT);
     if (state == S3AuthClientOpState::started && auth_context) {
       auth_context->unset_hooks();
@@ -369,6 +370,7 @@ class S3AuthClient {
 
   std::shared_ptr<RequestObject> get_request() { return request; }
   std::string get_request_id() { return request_id; }
+  std::string get_stripped_request_id() { return stripped_request_id; }
 
   S3AuthClientOpState get_state() { return state; }
 

--- a/server/s3_auth_context.cc
+++ b/server/s3_auth_context.cc
@@ -28,7 +28,7 @@ extern evhtp_ssl_ctx_t *g_ssl_auth_ctx;
 
 struct s3_auth_op_context *create_basic_auth_op_ctx(
     struct event_base *eventbase) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   S3Option *option_instance = S3Option::get_instance();
   struct s3_auth_op_context *ctx =
       (struct s3_auth_op_context *)calloc(1, sizeof(struct s3_auth_op_context));
@@ -45,7 +45,7 @@ struct s3_auth_op_context *create_basic_auth_op_ctx(
 
   ctx->auth_request = evhtp_request_new(NULL, ctx->evbase);
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return ctx;
 }
 

--- a/server/s3_auth_fake.cc
+++ b/server/s3_auth_fake.cc
@@ -29,7 +29,7 @@
 #include "s3_post_to_main_loop.h"
 
 void s3_auth_dummy_op_failed(evutil_socket_t, short events, void *user_data) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   evbuf_t *req_body_buffer = NULL;
   evhtp_request_t *req = NULL;
   std::string xml_error(
@@ -55,12 +55,12 @@ void s3_auth_dummy_op_failed(evutil_socket_t, short events, void *user_data) {
   // Free user event
   event_free((struct event *)user_context->user_event);
   free(user_data);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 int s3_auth_fake_evhtp_request(S3AuthClientOpType auth_request_type,
                                S3AuthClientOpContext *context) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
 
   if (auth_request_type == S3AuthClientOpType::authentication) {
     struct user_event_context *user_ctx = (struct user_event_context *)calloc(
@@ -71,6 +71,6 @@ int s3_auth_fake_evhtp_request(S3AuthClientOpType auth_request_type,
     // TODO: fake cb for authorization when server support is added
     s3_log(S3_LOG_FATAL, "", "Unrecognized S3AuthClientOpType \n");
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return 0;
 }

--- a/server/s3_auth_response_error.cc
+++ b/server/s3_auth_response_error.cc
@@ -27,7 +27,7 @@
 
 S3AuthResponseError::S3AuthResponseError(std::string xml)
     : xml_content(std::move(xml)) {
-  s3_log(S3_LOG_DEBUG, "", "Constructor\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Ctor\n", __func__);
   is_valid = parse_and_validate();
 }
 
@@ -38,7 +38,7 @@ S3AuthResponseError::S3AuthResponseError(std::string error_code_,
       error_code(std::move(error_code_)),
       error_message(std::move(error_message_)),
       request_id(std::move(request_id_)) {
-  s3_log(S3_LOG_DEBUG, "", "Constructor\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Ctor\n", __func__);
 }
 
 bool S3AuthResponseError::isOK() const { return is_valid; }

--- a/server/s3_auth_response_success.cc
+++ b/server/s3_auth_response_success.cc
@@ -23,7 +23,7 @@
 
 S3AuthResponseSuccess::S3AuthResponseSuccess(std::string &xml)
     : xml_content(xml), is_valid(false) {
-  s3_log(S3_LOG_DEBUG, "", "Constructor\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Ctor\n", __func__);
   alluserrequest = false;
   is_valid = parse_and_validate();
 }

--- a/server/s3_bucket_action_base.cc
+++ b/server/s3_bucket_action_base.cc
@@ -31,7 +31,7 @@ S3BucketAction::S3BucketAction(
     bool skip_auth)
     : S3Action(std::move(req), check_shutdown, std::move(auth_factory),
                skip_auth) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
   if (bucket_meta_factory) {
     bucket_metadata_factory = std::move(bucket_meta_factory);
@@ -41,11 +41,11 @@ S3BucketAction::S3BucketAction(
 }
 
 S3BucketAction::~S3BucketAction() {
-  s3_log(S3_LOG_DEBUG, request_id, "Destructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s\n", __func__);
 }
 
 void S3BucketAction::fetch_bucket_info() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (s3_fi_is_enabled("fail_fetch_bucket_info")) {
     s3_fi_enable_once("motr_kv_get_fail");
   }
@@ -72,9 +72,9 @@ void S3BucketAction::fetch_bucket_info_success() {
 void S3BucketAction::load_metadata() { fetch_bucket_info(); }
 
 void S3BucketAction::set_authorization_meta() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   auth_client->set_acl_and_policy(bucket_metadata->get_encoded_bucket_acl(),
                                   bucket_metadata->get_policy_as_json());
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_bucket_api_handler.cc
+++ b/server/s3_bucket_api_handler.cc
@@ -39,8 +39,8 @@
 #include "s3_delete_bucket_tagging_action.h"
 
 void S3BucketAPIHandler::create_action() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
-  s3_log(S3_LOG_INFO, request_id, "Action operation code = %d\n",
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
+  s3_log(S3_LOG_INFO, stripped_request_id, "Action operation code = %d\n",
          operation_code);
 
   switch (operation_code) {
@@ -334,5 +334,5 @@ void S3BucketAPIHandler::create_action() {
       // should never be here.
       return;
   };  // switch operation_code
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }

--- a/server/s3_bucket_metadata.cc
+++ b/server/s3_bucket_metadata.cc
@@ -74,7 +74,8 @@ S3BucketMetadata::S3BucketMetadata(
     std::shared_ptr<S3MotrKVSWriterFactory> motr_s3_kvs_writer_factory)
     : request(std::move(req)), json_parsing_error(false) {
   request_id = request->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor");
+  stripped_request_id = request->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
   initialize();
 
@@ -104,7 +105,8 @@ S3BucketMetadata::S3BucketMetadata(
     std::shared_ptr<S3MotrKVSWriterFactory> motr_s3_kvs_writer_factory)
     : request(std::move(req)), json_parsing_error(false) {
   request_id = request->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor");
+  stripped_request_id = request->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
   initialize(str_bucket_name);
 
@@ -214,14 +216,14 @@ void S3BucketMetadata::handle_collision(std::string base_index_name,
                                         std::string& salted_index_name,
                                         std::function<void()> callback) {
   if (collision_attempt_count < MAX_COLLISION_RETRY_COUNT) {
-    s3_log(S3_LOG_INFO, request_id,
+    s3_log(S3_LOG_INFO, stripped_request_id,
            "Index ID collision happened for index %s\n",
            salted_index_name.c_str());
     // Handle Collision
     regenerate_new_index_name(base_index_name, salted_index_name);
     collision_attempt_count++;
     if (collision_attempt_count > 5) {
-      s3_log(S3_LOG_INFO, request_id,
+      s3_log(S3_LOG_INFO, stripped_request_id,
              "Index ID collision happened %d times for index %s\n",
              collision_attempt_count, salted_index_name.c_str());
     }
@@ -351,7 +353,7 @@ std::string& S3BucketMetadata::get_policy_as_json() { return bucket_policy; }
 
 std::string S3BucketMetadata::get_tags_as_xml() {
 
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   std::string user_defined_tags;
   std::string tags_as_xml_str;
 
@@ -373,7 +375,7 @@ std::string S3BucketMetadata::get_tags_as_xml() {
         "</Tagging>";
   }
   s3_log(S3_LOG_DEBUG, request_id, "Tags xml: %s\n", tags_as_xml_str.c_str());
-  s3_log(S3_LOG_INFO, request_id, "Exiting\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Exit", __func__);
   return tags_as_xml_str;
 }
 

--- a/server/s3_bucket_metadata.h
+++ b/server/s3_bucket_metadata.h
@@ -103,6 +103,7 @@ class S3BucketMetadata {
   bool json_parsing_error;
 
   std::string request_id;
+  std::string stripped_request_id;
 
   void handle_collision(std::string base_index_name,
                         std::string& salted_index_name,

--- a/server/s3_bucket_metadata_v1.cc
+++ b/server/s3_bucket_metadata_v1.cc
@@ -41,7 +41,7 @@ S3BucketMetadataV1::S3BucketMetadataV1(
     : S3BucketMetadata(std::move(req), std::move(motr_api),
                        std::move(motr_s3_kvs_reader_factory),
                        std::move(motr_s3_kvs_writer_factory)) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
   if (s3_global_bucket_index_metadata_factory) {
     global_bucket_index_metadata_factory =
@@ -68,7 +68,7 @@ S3BucketMetadataV1::S3BucketMetadataV1(
                        std::move(motr_api),
                        std::move(motr_s3_kvs_reader_factory),
                        std::move(motr_s3_kvs_writer_factory)) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
   if (s3_global_bucket_index_metadata_factory) {
     global_bucket_index_metadata_factory =
@@ -101,7 +101,7 @@ void S3BucketMetadataV1::set_state(S3BucketMetadataState state) {
 // bucket_metadata_list_index_oid
 void S3BucketMetadataV1::load(std::function<void(void)> on_success,
                               std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_timer.start();
 
   this->handler_on_success = on_success;
@@ -109,11 +109,11 @@ void S3BucketMetadataV1::load(std::function<void(void)> on_success,
 
   fetch_global_bucket_account_id_info();
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::fetch_global_bucket_account_id_info() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (!global_bucket_index_metadata) {
     global_bucket_index_metadata =
@@ -127,21 +127,21 @@ void S3BucketMetadataV1::fetch_global_bucket_account_id_info() {
       std::bind(&S3BucketMetadataV1::fetch_global_bucket_account_id_info_failed,
                 this));
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::fetch_global_bucket_account_id_info_success() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   bucket_owner_account_id = global_bucket_index_metadata->get_account_id();
   // Now fetch real bucket metadata
   load_bucket_info();
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::fetch_global_bucket_account_id_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (global_bucket_index_metadata->get_state() ==
       S3GlobalBucketIndexMetadataState::missing) {
@@ -160,11 +160,11 @@ void S3BucketMetadataV1::fetch_global_bucket_account_id_info_failed() {
   }
   this->handler_on_failed();
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::load_bucket_info() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   motr_kv_reader =
       motr_kvs_reader_factory->create_motr_kvs_reader(request, s3_motr_api);
@@ -174,11 +174,11 @@ void S3BucketMetadataV1::load_bucket_info() {
       std::bind(&S3BucketMetadataV1::load_bucket_info_successful, this),
       std::bind(&S3BucketMetadataV1::load_bucket_info_failed, this));
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::load_bucket_info_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (this->from_json(motr_kv_reader->get_value()) != 0) {
     s3_log(S3_LOG_ERROR, request_id,
            "Json Parsing failed. Index oid ="
@@ -200,11 +200,11 @@ void S3BucketMetadataV1::load_bucket_info_successful() {
     state = S3BucketMetadataState::present;
     this->handler_on_success();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::load_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (json_parsing_error) {
     state = S3BucketMetadataState::failed;
@@ -221,14 +221,14 @@ void S3BucketMetadataV1::load_bucket_info_failed() {
   }
   this->handler_on_failed();
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 // Create {B1, A1} in global_bucket_list_index_oid, followed by {A1/B1, md} in
 // bucket_metadata_list_index_oid
 void S3BucketMetadataV1::save(std::function<void(void)> on_success,
                               std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   assert(state == S3BucketMetadataState::missing);
 
@@ -238,12 +238,12 @@ void S3BucketMetadataV1::save(std::function<void(void)> on_success,
   global_bucket_index_metadata.reset();
   save_global_bucket_account_id_info();
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::update(std::function<void(void)> on_success,
                                 std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   assert(state == S3BucketMetadataState::present);
 
@@ -252,11 +252,11 @@ void S3BucketMetadataV1::update(std::function<void(void)> on_success,
 
   save_bucket_info(false);
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::save_global_bucket_account_id_info() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (!global_bucket_index_metadata) {
     global_bucket_index_metadata =
         global_bucket_index_metadata_factory
@@ -277,22 +277,22 @@ void S3BucketMetadataV1::save_global_bucket_account_id_info() {
       std::bind(&S3BucketMetadataV1::save_global_bucket_account_id_info_failed,
                 this));
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::save_global_bucket_account_id_info_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   // update bucket_owner_account_id
   bucket_owner_account_id = global_bucket_index_metadata->get_account_id();
   collision_attempt_count = 0;
   create_object_list_index();
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::save_global_bucket_account_id_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   s3_log(S3_LOG_ERROR, request_id,
          "Saving of Bucket list index oid metadata failed\n");
@@ -304,11 +304,11 @@ void S3BucketMetadataV1::save_global_bucket_account_id_info_failed() {
   }
   this->handler_on_failed();
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::create_object_list_index() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (!motr_kv_writer) {
     motr_kv_writer =
         motr_kvs_writer_factory->create_motr_kvs_writer(request, s3_motr_api);
@@ -320,18 +320,18 @@ void S3BucketMetadataV1::create_object_list_index() {
       object_list_index_oid,
       std::bind(&S3BucketMetadataV1::create_object_list_index_successful, this),
       std::bind(&S3BucketMetadataV1::create_object_list_index_failed, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::create_object_list_index_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   collision_attempt_count = 0;
   create_multipart_list_index();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::create_object_list_index_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_kv_writer->get_state() == S3MotrKVSWriterOpState::exists) {
     // create_object_list_index is called when there is no bucket,
     // Hence if motr returned its present, then its due to collision.
@@ -343,11 +343,11 @@ void S3BucketMetadataV1::create_object_list_index_failed() {
     cleanup_on_create_err_global_bucket_account_id_info(
         motr_kv_writer->get_state());
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::create_multipart_list_index() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (!motr_kv_writer) {
     motr_kv_writer =
         motr_kvs_writer_factory->create_motr_kvs_writer(request, s3_motr_api);
@@ -361,17 +361,17 @@ void S3BucketMetadataV1::create_multipart_list_index() {
       std::bind(&S3BucketMetadataV1::create_multipart_list_index_successful,
                 this),
       std::bind(&S3BucketMetadataV1::create_multipart_list_index_failed, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::create_multipart_list_index_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   create_objects_version_list_index();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::create_multipart_list_index_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_kv_writer->get_state() == S3MotrKVSWriterOpState::exists) {
     // create_multipart_list_index is called when there is no bucket,
     // Hence if motr returned its present, then its due to collision.
@@ -383,11 +383,11 @@ void S3BucketMetadataV1::create_multipart_list_index_failed() {
     cleanup_on_create_err_global_bucket_account_id_info(
         motr_kv_writer->get_state());
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::create_objects_version_list_index() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (!motr_kv_writer) {
     motr_kv_writer =
         motr_kvs_writer_factory->create_motr_kvs_writer(request, s3_motr_api);
@@ -404,18 +404,18 @@ void S3BucketMetadataV1::create_objects_version_list_index() {
           this),
       std::bind(&S3BucketMetadataV1::create_objects_version_list_index_failed,
                 this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::create_objects_version_list_index_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   collision_attempt_count = 0;
   save_bucket_info(true);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::create_objects_version_list_index_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_kv_writer->get_state() == S3MotrKVSWriterOpState::exists) {
     // create_objects_version_list_index is called when there is no bucket,
     // Hence if motr returned its present then its due to collision.
@@ -429,11 +429,11 @@ void S3BucketMetadataV1::create_objects_version_list_index_failed() {
     cleanup_on_create_err_global_bucket_account_id_info(
         motr_kv_writer->get_state());
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::save_bucket_info(bool clean_glob_on_err) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   assert(!bucket_owner_account_id.empty());
   assert(!user_name.empty());
@@ -457,11 +457,11 @@ void S3BucketMetadataV1::save_bucket_info(bool clean_glob_on_err) {
       std::bind(&S3BucketMetadataV1::save_bucket_info_successful, this),
       std::bind(&S3BucketMetadataV1::save_bucket_info_failed, this));
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::save_bucket_info_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   // attempt to save the KV in replica bucket metadata index
   if (!motr_kv_writer) {
@@ -474,11 +474,11 @@ void S3BucketMetadataV1::save_bucket_info_successful() {
       std::bind(&S3BucketMetadataV1::save_replica, this),
       std::bind(&S3BucketMetadataV1::save_replica, this));
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::save_replica() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   // PUT Operation passes even if we failed to put KV in replica index.
   if (motr_kv_writer->get_state() != S3MotrKVSWriterOpState::created) {
@@ -490,11 +490,11 @@ void S3BucketMetadataV1::save_replica() {
   }
   this->handler_on_success();
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::save_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_ERROR, request_id, "Saving of Bucket metadata failed\n");
   auto kv_state = motr_kv_writer->get_state();
   if (!should_cleanup_global_idx) {
@@ -507,25 +507,25 @@ void S3BucketMetadataV1::save_bucket_info_failed() {
   } else {
     cleanup_on_create_err_global_bucket_account_id_info(kv_state);
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 // Delete {A1/B1} from bucket_metadata_list_index_oid followed by {B1, A1} from
 // global_bucket_list_index_oid
 void S3BucketMetadataV1::remove(std::function<void(void)> on_success,
                                 std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   this->handler_on_success = on_success;
   this->handler_on_failed = on_failed;
 
   assert(state == S3BucketMetadataState::present);
   remove_bucket_info();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::remove_bucket_info() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (!motr_kv_writer) {
     motr_kv_writer =
@@ -537,11 +537,11 @@ void S3BucketMetadataV1::remove_bucket_info() {
       std::bind(&S3BucketMetadataV1::remove_bucket_info_successful, this),
       std::bind(&S3BucketMetadataV1::remove_bucket_info_failed, this));
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::remove_bucket_info_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   // Attempt to remove KV from replica bucket metadata index
   if (!motr_kv_writer) {
@@ -554,11 +554,11 @@ void S3BucketMetadataV1::remove_bucket_info_successful() {
       std::bind(&S3BucketMetadataV1::remove_replica, this),
       std::bind(&S3BucketMetadataV1::remove_replica, this));
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::remove_replica() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   // delete KV from replia index is not fatal error
   if (motr_kv_writer->get_state() != S3MotrKVSWriterOpState::deleted) {
@@ -577,11 +577,11 @@ void S3BucketMetadataV1::remove_replica() {
     remove_global_bucket_account_id_info();
   }
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::remove_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_ERROR, request_id, "Removal of Bucket metadata failed\n");
   if (motr_kv_writer->get_state() == S3MotrKVSWriterOpState::failed_to_launch) {
     state = S3BucketMetadataState::failed_to_launch;
@@ -589,11 +589,11 @@ void S3BucketMetadataV1::remove_bucket_info_failed() {
     state = S3BucketMetadataState::failed;
   }
   this->handler_on_failed();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::remove_global_bucket_account_id_info() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   global_bucket_index_metadata->remove(
       std::bind(
           &S3BucketMetadataV1::remove_global_bucket_account_id_info_successful,
@@ -601,17 +601,17 @@ void S3BucketMetadataV1::remove_global_bucket_account_id_info() {
       std::bind(
           &S3BucketMetadataV1::remove_global_bucket_account_id_info_failed,
           this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::remove_global_bucket_account_id_info_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   this->handler_on_success();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::remove_global_bucket_account_id_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (global_bucket_index_metadata->get_state() ==
       S3GlobalBucketIndexMetadataState::failed_to_launch) {
     state = S3BucketMetadataState::failed_to_launch;
@@ -620,12 +620,12 @@ void S3BucketMetadataV1::remove_global_bucket_account_id_info_failed() {
   }
 
   this->handler_on_failed();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::cleanup_on_create_err_global_bucket_account_id_info(
     S3MotrKVSWriterOpState op_state) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (op_state == S3MotrKVSWriterOpState::failed_to_launch) {
     on_cleanup_state = S3BucketMetadataState::failed_to_launch;
   } else {
@@ -641,12 +641,12 @@ void S3BucketMetadataV1::cleanup_on_create_err_global_bucket_account_id_info(
           &S3BucketMetadataV1::
                cleanup_on_create_err_global_bucket_account_id_info_fini_cb,
           this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3BucketMetadataV1::
     cleanup_on_create_err_global_bucket_account_id_info_fini_cb() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_ERROR, request_id,
          "cleanup_on_create_err_global_bucket_account_id_info status %d\n",
          static_cast<int>(global_bucket_index_metadata->get_state()));
@@ -655,5 +655,5 @@ void S3BucketMetadataV1::
   state = on_cleanup_state;
 
   this->handler_on_failed();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_chunk_payload_parser.cc
+++ b/server/s3_chunk_payload_parser.cc
@@ -79,7 +79,7 @@ S3ChunkPayloadParser::S3ChunkPayloadParser()
       content_length(0),
       chunk_sig_key_q_const(S3_AWS_CHUNK_KEY),
       chunk_sig_key_char_state(S3_AWS_CHUNK_KEY) {
-  s3_log(S3_LOG_DEBUG, "", "Constructor\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Ctor\n", __func__);
 
   evbuf_t *spare_buffer = evbuffer_new();
   // Lets just preallocate space in evbuf to max we intend
@@ -91,7 +91,7 @@ S3ChunkPayloadParser::S3ChunkPayloadParser()
 }
 
 S3ChunkPayloadParser::~S3ChunkPayloadParser() {
-  s3_log(S3_LOG_DEBUG, "", "Destructor\n");
+  s3_log(S3_LOG_DEBUG, "", "%s\n", __func__);
   evbuf_t *buf = NULL;
   while (!spare_buffers.empty()) {
     buf = spare_buffers.front();

--- a/server/s3_copy_object_action.cc
+++ b/server/s3_copy_object_action.cc
@@ -44,8 +44,8 @@ S3CopyObjectAction::S3CopyObjectAction(
                             std::move(motrwriter_s3_factory),
                             std::move(kv_writer_factory)) {
 
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
-  s3_log(S3_LOG_INFO, request_id,
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
+  s3_log(S3_LOG_INFO, stripped_request_id,
          "S3 API: CopyObject. Destination: [%s], Source: [%s]\n",
          request->get_object_uri().c_str(),
          request->get_headers_copysource().c_str());
@@ -71,18 +71,18 @@ void S3CopyObjectAction::setup_steps() {
 }
 
 void S3CopyObjectAction::get_source_bucket_and_object() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   std::string source = request->get_headers_copysource();
   size_t separator_pos = source.find("/");
   if (separator_pos != std::string::npos) {
     source_bucket_name = source.substr(0, separator_pos);
     source_object_name = source.substr(separator_pos + 1);
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3CopyObjectAction::fetch_source_bucket_info() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "Fetch metadata of bucket: %s\n",
          source_bucket_name.c_str());
 
@@ -93,22 +93,22 @@ void S3CopyObjectAction::fetch_source_bucket_info() {
       std::bind(&S3CopyObjectAction::fetch_source_bucket_info_success, this),
       std::bind(&S3CopyObjectAction::fetch_source_bucket_info_failed, this));
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3CopyObjectAction::fetch_source_bucket_info_success() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "Found source bucket: [%s] metadata\n",
          source_bucket_name.c_str());
 
   // fetch source object metadata
   fetch_source_object_info();
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3CopyObjectAction::fetch_source_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   s3_put_action_state = S3PutObjectActionState::validationFailed;
 
@@ -127,11 +127,11 @@ void S3CopyObjectAction::fetch_source_bucket_info_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3CopyObjectAction::fetch_source_object_info() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "Found source bucket metadata\n");
   m0_uint128 source_object_list_oid =
       source_bucket_metadata->get_object_list_index_oid();
@@ -157,11 +157,11 @@ void S3CopyObjectAction::fetch_source_object_info() {
         std::bind(&S3CopyObjectAction::fetch_source_object_info_success, this),
         std::bind(&S3CopyObjectAction::fetch_source_object_info_failed, this));
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3CopyObjectAction::fetch_source_object_info_success() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id,
          "Successfully fetched source object metadata\n");
 
@@ -173,11 +173,11 @@ void S3CopyObjectAction::fetch_source_object_info_success() {
     total_data_to_stream = source_object_metadata->get_content_length();
     next();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3CopyObjectAction::fetch_source_object_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   s3_put_action_state = S3PutObjectActionState::validationFailed;
 
@@ -202,12 +202,12 @@ void S3CopyObjectAction::fetch_source_object_info_failed() {
     }
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 // Validate source bucket and object
 void S3CopyObjectAction::validate_copyobject_request() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   get_source_bucket_and_object();
 
   if (source_bucket_name.empty() || source_object_name.empty()) {
@@ -220,15 +220,15 @@ void S3CopyObjectAction::validate_copyobject_request() {
   } else {
     fetch_source_bucket_info();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 // Copy source object to destination object
 void S3CopyObjectAction::copy_object() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (!total_data_to_stream) {
-    s3_log(S3_LOG_DEBUG, request_id, "Source object is empty");
+    s3_log(S3_LOG_DEBUG, stripped_request_id, "Source object is empty");
     next();
     return;
   }
@@ -240,11 +240,11 @@ void S3CopyObjectAction::copy_object() {
   bytes_left_to_read = total_data_to_stream;
   read_data_block();
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3CopyObjectAction::read_data_block() {
-  s3_log(S3_LOG_INFO, request_id, "Entering");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   assert(!read_in_progress);
   assert(bytes_left_to_read > 0);
@@ -273,11 +273,13 @@ void S3CopyObjectAction::read_data_block() {
       send_response_to_s3_client();
     }
   }
-  s3_log(S3_LOG_DEBUG, NULL, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3CopyObjectAction::read_data_block_success() {
-  s3_log(S3_LOG_INFO, request_id, "Reading a part of data succeeded");
+
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
+  s3_log(S3_LOG_INFO, stripped_request_id, "Reading a part of data succeeded");
 
   assert(read_in_progress);
   read_in_progress = false;
@@ -293,10 +295,12 @@ void S3CopyObjectAction::read_data_block_success() {
   if (!write_in_progress) {
     write_data_block();
   }
-  s3_log(S3_LOG_DEBUG, NULL, "Exiting\n");
+
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3CopyObjectAction::read_data_block_failed() {
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_ERROR, request_id, "Failed to read object data from motr");
 
   assert(read_in_progress);
@@ -311,11 +315,12 @@ void S3CopyObjectAction::read_data_block_failed() {
   if (!write_in_progress) {
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, NULL, "Exiting\n");
+
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3CopyObjectAction::write_data_block() {
-  s3_log(S3_LOG_INFO, request_id, "Entering");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   assert(!write_in_progress);
   assert(bytes_left_to_read > 0);
@@ -366,11 +371,11 @@ void S3CopyObjectAction::write_data_block() {
   } else {
     write_in_progress = true;
   }
-  s3_log(S3_LOG_DEBUG, NULL, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3CopyObjectAction::write_data_block_success() {
-  s3_log(S3_LOG_INFO, request_id, "Entering");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   assert(write_in_progress);
   write_in_progress = false;
@@ -385,10 +390,12 @@ void S3CopyObjectAction::write_data_block_success() {
     s3_put_action_state = S3PutObjectActionState::writeComplete;
     next();
   }
-  s3_log(S3_LOG_DEBUG, NULL, "Exiting\n");
+
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3CopyObjectAction::write_data_block_failed() {
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_ERROR, request_id, "Failed to write object data to motr");
 
   assert(write_in_progress);
@@ -403,11 +410,12 @@ void S3CopyObjectAction::write_data_block_failed() {
   if (!read_in_progress) {
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, NULL, "Exiting\n");
+
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3CopyObjectAction::save_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   // for shutdown testcases, check FI and set shutdown signal
   S3_CHECK_FI_AND_SET_SHUTDOWN_SIGNAL("put_object_action_save_metadata_pass");
@@ -433,17 +441,19 @@ void S3CopyObjectAction::save_metadata() {
   new_object_metadata->save(
       std::bind(&S3CopyObjectAction::save_object_metadata_success, this),
       std::bind(&S3CopyObjectAction::save_object_metadata_failed, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3CopyObjectAction::save_object_metadata_success() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_put_action_state = S3PutObjectActionState::metadataSaved;
   next();
 }
 
 void S3CopyObjectAction::save_object_metadata_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
+
   s3_put_action_state = S3PutObjectActionState::metadataSaveFailed;
   if (new_object_metadata->get_state() ==
       S3ObjectMetadataState::failed_to_launch) {
@@ -469,7 +479,7 @@ std::string S3CopyObjectAction::get_response_xml() {
 }
 
 void S3CopyObjectAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (S3Option::get_instance()->is_getoid_enabled()) {
 
     request->set_out_header_value("x-stx-oid",
@@ -517,7 +527,7 @@ void S3CopyObjectAction::send_response_to_s3_client() {
 #ifndef S3_GOOGLE_TEST
   startcleanup();
 #endif  // S3_GOOGLE_TEST
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 bool S3CopyObjectAction::if_source_and_destination_same() {

--- a/server/s3_daemonize_server.cc
+++ b/server/s3_daemonize_server.cc
@@ -143,30 +143,30 @@ int S3Daemonize::delete_pidfile() {
   char pidstr_read[100];
   int rc;
   std::ifstream pidfile_read;
-  s3_log(S3_LOG_DEBUG, "", "Entering");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry", __func__);
   if (pidfilename == "") {
     s3_log(S3_LOG_ERROR, "", "pid filename %s doesn't exist\n",
            pidfilename.c_str());
-    s3_log(S3_LOG_DEBUG, "", "Exiting");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return 0;
   }
   pidfile_read.open(S3Daemonize::pidfilename);
   if (pidfile_read.fail()) {
     if (errno == 2) {
-      s3_log(S3_LOG_DEBUG, "", "Exiting");
+      s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
       return 0;
     } else {
       s3_log(S3_LOG_ERROR, "", "Failed to open pid file %s errno = %d\n",
              pidfilename.c_str(), errno);
     }
-    s3_log(S3_LOG_DEBUG, "", "Exiting");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return -1;
   }
   pidfile_read.getline(pidstr_read, 100);
   if (strlen(pidstr_read) == 0) {
     s3_log(S3_LOG_ERROR, "", "Pid doesn't exist within %s\n",
            pidfilename.c_str());
-    s3_log(S3_LOG_DEBUG, "", "Exiting");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return -1;
   }
   pidfile_read.close();
@@ -175,16 +175,16 @@ int S3Daemonize::delete_pidfile() {
         S3_LOG_WARN, "-",
         "The pid(%d) of process does match to the pid(%s) in the pid file %s\n",
         getpid(), pidstr_read, pidfilename.c_str());
-    s3_log(S3_LOG_DEBUG, "", "Exiting");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return -1;
   }
   rc = ::unlink(pidfilename.c_str());
   if (rc) {
     s3_log(S3_LOG_WARN, "", "File %s deletion failed\n", pidfilename.c_str());
-    s3_log(S3_LOG_DEBUG, "", "Exiting");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return rc;
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return 0;
 }
 

--- a/server/s3_delete_bucket_action.cc
+++ b/server/s3_delete_bucket_action.cc
@@ -36,9 +36,10 @@ S3DeleteBucketAction::S3DeleteBucketAction(
       last_key(""),
       is_bucket_empty(false),
       delete_successful(false) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
-  s3_log(S3_LOG_INFO, request_id, "S3 API: Delete Bucket API. Bucket[%s]\n",
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "S3 API: Delete Bucket API. Bucket[%s]\n",
          request->get_bucket_name().c_str());
 
   if (object_meta_factory) {
@@ -98,7 +99,7 @@ void S3DeleteBucketAction::setup_steps() {
 }
 
 void S3DeleteBucketAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   S3BucketMetadataState bucket_metadata_state = bucket_metadata->get_state();
   if (bucket_metadata_state == S3BucketMetadataState::failed_to_launch) {
     s3_log(S3_LOG_ERROR, request_id,
@@ -110,11 +111,11 @@ void S3DeleteBucketAction::fetch_bucket_info_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketAction::fetch_first_object_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   S3BucketMetadataState bucket_metadata_state = bucket_metadata->get_state();
   if (bucket_metadata_state == S3BucketMetadataState::present) {
     motr_kv_reader =
@@ -138,19 +139,19 @@ void S3DeleteBucketAction::fetch_first_object_metadata() {
                     this));
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketAction::fetch_first_object_metadata_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   is_bucket_empty = false;
   set_s3_error("BucketNotEmpty");
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketAction::fetch_first_object_metadata_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_kv_reader->get_state() == S3MotrKVSReaderOpState::missing) {
     s3_log(S3_LOG_DEBUG, request_id, "There is no object in bucket\n");
     is_bucket_empty = true;
@@ -168,11 +169,11 @@ void S3DeleteBucketAction::fetch_first_object_metadata_failed() {
     set_s3_error("ServiceUnavailable");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketAction::fetch_multipart_objects() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   struct m0_uint128 empty_indx_oid = {0ULL, 0ULL};
   struct m0_uint128 indx_oid = bucket_metadata->get_multipart_index_oid();
   // If the index oid is 0 then it implies there is no multipart metadata
@@ -192,7 +193,7 @@ void S3DeleteBucketAction::fetch_multipart_objects() {
 }
 
 void S3DeleteBucketAction::fetch_multipart_objects_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   std::string part_oids_str = "";
   struct m0_uint128 multipart_obj_oid;
   s3_log(S3_LOG_DEBUG, request_id, "Found multipart uploads listing\n");
@@ -253,7 +254,7 @@ void S3DeleteBucketAction::fetch_multipart_objects_successful() {
 }
 
 void S3DeleteBucketAction::delete_multipart_objects() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (multipart_object_oids.size() != 0) {
     motr_writer = motr_writer_factory->create_motr_writer(request);
     motr_writer->delete_objects(
@@ -265,11 +266,11 @@ void S3DeleteBucketAction::delete_multipart_objects() {
   } else {
     next();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketAction::delete_multipart_objects_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   int count = 0;
   int op_ret_code;
   bool atleast_one_error = false;
@@ -295,11 +296,11 @@ void S3DeleteBucketAction::delete_multipart_objects_successful() {
            S3_IEM_DELETE_OBJ_FAIL_JSON);
   }
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketAction::delete_multipart_objects_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   uint count = 0;
   int op_ret_code;
   bool atleast_one_error = false;
@@ -326,11 +327,11 @@ void S3DeleteBucketAction::delete_multipart_objects_failed() {
            S3_IEM_DELETE_OBJ_FAIL_JSON);
   }
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketAction::remove_part_indexes() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (part_oids.size() != 0) {
     motr_kv_writer =
         motr_kvs_writer_factory->create_motr_kvs_writer(request, s3_motr_api);
@@ -341,11 +342,11 @@ void S3DeleteBucketAction::remove_part_indexes() {
   } else {
     next();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketAction::remove_part_indexes_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   int i;
   int op_ret_code;
   bool partial_failure = false;
@@ -361,7 +362,7 @@ void S3DeleteBucketAction::remove_part_indexes_successful() {
            "Failed to delete some of the multipart part metadata\n");
   }
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   next();
 }
 
@@ -377,7 +378,7 @@ void S3DeleteBucketAction::remove_part_indexes_failed() {
 }
 
 void S3DeleteBucketAction::remove_multipart_index() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (multipart_present) {
     if (motr_kv_writer == nullptr) {
       motr_kv_writer =
@@ -390,7 +391,7 @@ void S3DeleteBucketAction::remove_multipart_index() {
   } else {
     next();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketAction::remove_multipart_index_failed() {
@@ -412,7 +413,7 @@ void S3DeleteBucketAction::remove_multipart_index_failed() {
 }
 
 void S3DeleteBucketAction::remove_object_list_index() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (object_list_index_oid.u_hi == 0ULL &&
       object_list_index_oid.u_lo == 0ULL) {
     next();
@@ -427,7 +428,7 @@ void S3DeleteBucketAction::remove_object_list_index() {
         std::bind(&S3DeleteBucketAction::remove_object_list_index_failed,
                   this));
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 /*
@@ -454,7 +455,7 @@ void S3DeleteBucketAction::remove_object_list_index() {
  */
 
 void S3DeleteBucketAction::remove_object_list_index_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_ERROR, request_id,
          "Failed to delete index, this will be stale in Motr: %" SCNx64
          " : %" SCNx64 "\n",
@@ -470,11 +471,11 @@ void S3DeleteBucketAction::remove_object_list_index_failed() {
   } else {
     next();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketAction::remove_objects_version_list_index() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (objects_version_list_index_oid.u_hi == 0ULL &&
       objects_version_list_index_oid.u_lo == 0ULL) {
     next();
@@ -491,11 +492,11 @@ void S3DeleteBucketAction::remove_objects_version_list_index() {
             &S3DeleteBucketAction::remove_objects_version_list_index_failed,
             this));
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketAction::remove_objects_version_list_index_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_ERROR, request_id,
          "Failed to delete index, this will be stale in Motr: %" SCNx64
          " : %" SCNx64 "\n",
@@ -512,26 +513,26 @@ void S3DeleteBucketAction::remove_objects_version_list_index_failed() {
   } else {
     next();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketAction::delete_bucket() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   bucket_metadata->remove(
       std::bind(&S3DeleteBucketAction::delete_bucket_successful, this),
       std::bind(&S3DeleteBucketAction::delete_bucket_failed, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketAction::delete_bucket_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   delete_successful = true;
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketAction::delete_bucket_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_ERROR, request_id, "Bucket deletion failed\n");
   delete_successful = false;
   if (bucket_metadata->get_state() == S3BucketMetadataState::missing) {
@@ -543,11 +544,11 @@ void S3DeleteBucketAction::delete_bucket_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // Trigger metadata read async operation with callback
   if (is_error_state() && !get_s3_error_code().empty()) {
     S3Error error(get_s3_error_code(), request->get_request_id(),
@@ -571,5 +572,5 @@ void S3DeleteBucketAction::send_response_to_s3_client() {
     request->send_response(error.get_http_status_code(), response_xml);
   }
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_delete_bucket_policy_action.cc
+++ b/server/s3_delete_bucket_policy_action.cc
@@ -26,9 +26,9 @@ S3DeleteBucketPolicyAction::S3DeleteBucketPolicyAction(
     std::shared_ptr<S3RequestObject> req,
     std::shared_ptr<S3BucketMetadataFactory> bucket_meta_factory)
     : S3BucketAction(std::move(req), std::move(bucket_meta_factory), false) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
-  s3_log(S3_LOG_INFO, request_id,
+  s3_log(S3_LOG_INFO, stripped_request_id,
          "S3 API: Delete Bucket Policy API. Bucket[%s]\n",
          request->get_bucket_name().c_str());
 
@@ -43,7 +43,7 @@ void S3DeleteBucketPolicyAction::setup_steps() {
 }
 
 void S3DeleteBucketPolicyAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   S3BucketMetadataState bucket_metadata_state = bucket_metadata->get_state();
   if (bucket_metadata_state == S3BucketMetadataState::failed_to_launch) {
     s3_log(S3_LOG_ERROR, request_id,
@@ -55,11 +55,11 @@ void S3DeleteBucketPolicyAction::fetch_bucket_info_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketPolicyAction::delete_bucket_policy() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::present) {
     std::string response_json = bucket_metadata->get_policy_as_json();
     if (response_json.empty()) {
@@ -75,17 +75,17 @@ void S3DeleteBucketPolicyAction::delete_bucket_policy() {
                     this));
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketPolicyAction::delete_bucket_policy_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketPolicyAction::delete_bucket_policy_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_ERROR, request_id, "Bucket policy deletion failed\n");
   if (bucket_metadata->get_state() == S3BucketMetadataState::failed_to_launch) {
     set_s3_error("ServiceUnavailable");
@@ -93,11 +93,11 @@ void S3DeleteBucketPolicyAction::delete_bucket_policy_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketPolicyAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // Trigger metadata read async operation with callback
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -116,5 +116,5 @@ void S3DeleteBucketPolicyAction::send_response_to_s3_client() {
     request->send_response(S3HttpSuccess204);
   }
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_delete_bucket_tagging_action.cc
+++ b/server/s3_delete_bucket_tagging_action.cc
@@ -26,9 +26,10 @@ S3DeleteBucketTaggingAction::S3DeleteBucketTaggingAction(
     std::shared_ptr<S3RequestObject> req,
     std::shared_ptr<S3BucketMetadataFactory> bucket_meta_factory)
     : S3BucketAction(std::move(req), std::move(bucket_meta_factory)) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
-  s3_log(S3_LOG_INFO, request_id, "S3 API: Delete Bucket Tagging. Bucket[%s]\n",
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "S3 API: Delete Bucket Tagging. Bucket[%s]\n",
          request->get_bucket_name().c_str());
 
   setup_steps();
@@ -43,7 +44,7 @@ void S3DeleteBucketTaggingAction::setup_steps() {
 }
 
 void S3DeleteBucketTaggingAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::failed_to_launch) {
     set_s3_error("ServiceUnavailable");
   } else if (bucket_metadata->get_state() == S3BucketMetadataState::missing) {
@@ -51,33 +52,33 @@ void S3DeleteBucketTaggingAction::fetch_bucket_info_failed() {
   } else {
     set_s3_error("InternalError");
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   send_response_to_s3_client();
 }
 
 void S3DeleteBucketTaggingAction::delete_bucket_tags() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   bucket_metadata->delete_bucket_tags();
   bucket_metadata->update(
       std::bind(&S3DeleteBucketTaggingAction::next, this),
       std::bind(&S3DeleteBucketTaggingAction::delete_bucket_tags_failed, this));
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteBucketTaggingAction::delete_bucket_tags_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::failed_to_launch) {
     set_s3_error("ServiceUnavailable");
   } else {
     set_s3_error("InternalError");
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   next();
 }
 
 void S3DeleteBucketTaggingAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -104,5 +105,5 @@ void S3DeleteBucketTaggingAction::send_response_to_s3_client() {
   }
 
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_delete_multiple_objects_action.cc
+++ b/server/s3_delete_multiple_objects_action.cc
@@ -41,9 +41,9 @@ S3DeleteMultipleObjectsAction::S3DeleteMultipleObjectsAction(
     : S3BucketAction(std::move(req), std::move(bucket_md_factory), false),
       delete_index_in_req(0),
       at_least_one_delete_successful(false) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
-  s3_log(S3_LOG_INFO, request_id,
+  s3_log(S3_LOG_INFO, stripped_request_id,
          "S3 API: Delete Multiple Objects API. Bucket[%s]\n",
          request->get_bucket_name().c_str());
 
@@ -84,7 +84,7 @@ S3DeleteMultipleObjectsAction::S3DeleteMultipleObjectsAction(
   motr_writer = motr_writer_factory->create_motr_writer(request);
 
   setup_steps();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteMultipleObjectsAction::setup_steps() {
@@ -98,7 +98,7 @@ void S3DeleteMultipleObjectsAction::setup_steps() {
 }
 
 void S3DeleteMultipleObjectsAction::validate_request() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (request->has_all_body_content()) {
     validate_request_body(request->get_full_body_content_as_string());
@@ -110,21 +110,21 @@ void S3DeleteMultipleObjectsAction::validate_request() {
         );
   }
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteMultipleObjectsAction::consume_incoming_content() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (request->is_s3_client_read_error()) {
     client_read_error();
   } else if (request->has_all_body_content()) {
     validate_request_body(request->get_full_body_content_as_string());
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteMultipleObjectsAction::validate_request_body(std::string content) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   MD5hash calc_md5;
   calc_md5.Update(content.c_str(), content.length());
   calc_md5.Finalize();
@@ -151,7 +151,7 @@ void S3DeleteMultipleObjectsAction::validate_request_body(std::string content) {
       send_response_to_s3_client();
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteMultipleObjectsAction::fetch_bucket_info_failed() {
@@ -170,7 +170,7 @@ void S3DeleteMultipleObjectsAction::fetch_bucket_info_failed() {
 }
 
 void S3DeleteMultipleObjectsAction::fetch_objects_info() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   object_list_index_oid = bucket_metadata->get_object_list_index_oid();
   if (object_list_index_oid.u_lo == 0ULL &&
       object_list_index_oid.u_hi == 0ULL) {
@@ -197,11 +197,11 @@ void S3DeleteMultipleObjectsAction::fetch_objects_info() {
       delete_index_in_req += keys_to_delete.size();
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteMultipleObjectsAction::fetch_objects_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_kv_reader->get_state() == S3MotrKVSReaderOpState::missing) {
     for (auto& key : keys_to_delete) {
       delete_objects_response.add_success(key);
@@ -215,11 +215,11 @@ void S3DeleteMultipleObjectsAction::fetch_objects_info_failed() {
     set_s3_error("InternalError");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteMultipleObjectsAction::fetch_objects_info_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   // Create a list of objects found to be deleted
 
@@ -274,11 +274,11 @@ void S3DeleteMultipleObjectsAction::fetch_objects_info_successful() {
   } else {
     add_object_oid_to_probable_dead_oid_list();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteMultipleObjectsAction::add_object_oid_to_probable_dead_oid_list() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   std::map<std::string, std::string> delete_list;
 
   for (const auto& obj : objects_metadata) {
@@ -316,23 +316,23 @@ void S3DeleteMultipleObjectsAction::add_object_oid_to_probable_dead_oid_list() {
       std::bind(&S3DeleteMultipleObjectsAction::
                      add_object_oid_to_probable_dead_oid_list_failed,
                 this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteMultipleObjectsAction::
     add_object_oid_to_probable_dead_oid_list_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_kv_writer->get_state() == S3MotrKVSWriterOpState::failed_to_launch) {
     set_s3_error("ServiceUnavailable");
   } else {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteMultipleObjectsAction::delete_objects_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   std::vector<std::string> keys;
   for (auto& obj : objects_metadata) {
     if (obj->get_state() != S3ObjectMetadataState::invalid) {
@@ -349,11 +349,11 @@ void S3DeleteMultipleObjectsAction::delete_objects_metadata() {
           this),
       std::bind(&S3DeleteMultipleObjectsAction::delete_objects_metadata_failed,
                 this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteMultipleObjectsAction::delete_objects_metadata_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   at_least_one_delete_successful = true;
   for (auto& obj : objects_metadata) {
     delete_objects_response.add_success(obj->get_object_name());
@@ -367,11 +367,11 @@ void S3DeleteMultipleObjectsAction::delete_objects_metadata_successful() {
   } else {
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteMultipleObjectsAction::delete_objects_metadata_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (motr_kv_writer->get_state() == S3MotrKVSWriterOpState::failed_to_launch) {
     s3_log(
@@ -401,11 +401,11 @@ void S3DeleteMultipleObjectsAction::delete_objects_metadata_failed() {
       send_response_to_s3_client();
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteMultipleObjectsAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (is_error_state() && !get_s3_error_code().empty()) {
     S3Error error(get_s3_error_code(), request->get_request_id(),
@@ -434,11 +434,11 @@ void S3DeleteMultipleObjectsAction::send_response_to_s3_client() {
   request->resume(false);
 
   cleanup();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteMultipleObjectsAction::cleanup() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (oids_to_delete.empty()) {
     cleanup_oid_from_probable_dead_oid_list();
@@ -455,17 +455,17 @@ void S3DeleteMultipleObjectsAction::cleanup() {
           std::bind(&S3DeleteMultipleObjectsAction::cleanup_failed, this));
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteMultipleObjectsAction::cleanup_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   cleanup_oid_from_probable_dead_oid_list();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteMultipleObjectsAction::cleanup_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_writer->get_state() == S3MotrWiterOpState::failed_to_launch) {
     s3_log(S3_LOG_ERROR, request_id,
            "delete_objects_failed called due to motr_entity_open failure\n");
@@ -485,11 +485,11 @@ void S3DeleteMultipleObjectsAction::cleanup_failed() {
     }
   }
   cleanup_oid_from_probable_dead_oid_list();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteMultipleObjectsAction::cleanup_oid_from_probable_dead_oid_list() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   std::vector<std::string> clean_valid_oid_from_probable_dead_object_list_index;
 
   // final probable_oid_list map will have valid object oids
@@ -506,5 +506,5 @@ void S3DeleteMultipleObjectsAction::cleanup_oid_from_probable_dead_oid_list() {
   } else {
     done();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_delete_multiple_objects_body.cc
+++ b/server/s3_delete_multiple_objects_body.cc
@@ -26,7 +26,7 @@
 
 S3DeleteMultipleObjectsBody::S3DeleteMultipleObjectsBody()
     : is_valid(false), quiet(false) {
-  s3_log(S3_LOG_DEBUG, "", "Constructor\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Ctor\n", __func__);
 }
 
 void S3DeleteMultipleObjectsBody::initialize(std::string &xml) {
@@ -37,7 +37,7 @@ void S3DeleteMultipleObjectsBody::initialize(std::string &xml) {
 bool S3DeleteMultipleObjectsBody::isOK() { return is_valid; }
 
 bool S3DeleteMultipleObjectsBody::parse_and_validate() {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   /* Sample body:
   <?xml version="1.0" encoding="UTF-8"?>
   <Delete>
@@ -150,6 +150,6 @@ bool S3DeleteMultipleObjectsBody::parse_and_validate() {
 
   is_valid = true;
   xmlFreeDoc(document);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return is_valid;
 }

--- a/server/s3_delete_object_tagging_action.cc
+++ b/server/s3_delete_object_tagging_action.cc
@@ -28,9 +28,9 @@ S3DeleteObjectTaggingAction::S3DeleteObjectTaggingAction(
     std::shared_ptr<S3ObjectMetadataFactory> object_meta_factory)
     : S3ObjectAction(std::move(req), std::move(bucket_meta_factory),
                      std::move(object_meta_factory)) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
-  s3_log(S3_LOG_INFO, request_id,
+  s3_log(S3_LOG_INFO, stripped_request_id,
          "S3 API: DeleteObjectTaggingAction. Bucket[%s] Object[%s]\n",
          request->get_bucket_name().c_str(),
          request->get_object_name().c_str());
@@ -46,7 +46,7 @@ void S3DeleteObjectTaggingAction::setup_steps() {
 }
 
 void S3DeleteObjectTaggingAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::missing) {
     set_s3_error("NoSuchBucket");
   } else if (bucket_metadata->get_state() ==
@@ -59,11 +59,11 @@ void S3DeleteObjectTaggingAction::fetch_bucket_info_failed() {
   }
 
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteObjectTaggingAction::fetch_object_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if ((object_list_oid.u_lo == 0ULL && object_list_oid.u_hi == 0ULL) ||
       (object_metadata->get_state() == S3ObjectMetadataState::missing)) {
     set_s3_error("NoSuchKey");
@@ -76,11 +76,11 @@ void S3DeleteObjectTaggingAction::fetch_object_info_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteObjectTaggingAction::delete_object_tags() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // bypass shutdown signal check for next task
   check_shutdown_signal_for_next_task(false);
   object_metadata->delete_object_tags();
@@ -90,7 +90,7 @@ void S3DeleteObjectTaggingAction::delete_object_tags() {
 }
 
 void S3DeleteObjectTaggingAction::delete_object_tags_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (object_metadata->get_state() == S3ObjectMetadataState::failed_to_launch) {
     s3_log(S3_LOG_ERROR, request_id,
            "Object metadata load operation failed due to pre launch failure\n");
@@ -99,11 +99,11 @@ void S3DeleteObjectTaggingAction::delete_object_tags_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DeleteObjectTaggingAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -122,6 +122,6 @@ void S3DeleteObjectTaggingAction::send_response_to_s3_client() {
   }
 
   S3_RESET_SHUTDOWN_SIGNAL;  // for shutdown testcases
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   done();
 }

--- a/server/s3_fake_motr_kvs.cc
+++ b/server/s3_fake_motr_kvs.cc
@@ -31,10 +31,10 @@ S3FakeMotrKvs::S3FakeMotrKvs() : in_mem_kv() {}
 
 int S3FakeMotrKvs::kv_read(struct m0_uint128 const &oid,
                            struct s3_motr_kvs_op_context const &kv) {
-  s3_log(S3_LOG_DEBUG, "", "Entering with oid %" SCNx64 " : %" SCNx64 "\n",
-         oid.u_hi, oid.u_lo);
+  s3_log(S3_LOG_DEBUG, "", "%s Entry with oid %" SCNx64 " : %" SCNx64 "\n",
+         __func__, oid.u_hi, oid.u_lo);
   if (in_mem_kv.count(oid) == 0) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting NOENT\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit NOENT\n", __func__);
     return -ENOENT;
   }
 
@@ -57,16 +57,16 @@ int S3FakeMotrKvs::kv_read(struct m0_uint128 const &oid,
            found_val.c_str());
   }
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting 0\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit 0\n", __func__);
   return 0;
 }
 
 int S3FakeMotrKvs::kv_next(struct m0_uint128 const &oid,
                            struct s3_motr_kvs_op_context const &kv) {
-  s3_log(S3_LOG_DEBUG, "", "Entering with oid %" SCNx64 " : %" SCNx64 "\n",
-         oid.u_hi, oid.u_lo);
+  s3_log(S3_LOG_DEBUG, "", "%s Entry with oid %" SCNx64 " : %" SCNx64 "\n",
+         __func__, oid.u_hi, oid.u_lo);
   if (in_mem_kv.count(oid) == 0) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting ENOENT\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit ENOENT\n", __func__);
     return -ENOENT;
   }
 
@@ -92,7 +92,8 @@ int S3FakeMotrKvs::kv_next(struct m0_uint128 const &oid,
       ++val_it;
     }
     if (val_it == std::end(obj_kv)) {
-      s3_log(S3_LOG_DEBUG, "", "Exiting k:>%s ENOENT\n", search_key.c_str());
+      s3_log(S3_LOG_DEBUG, "", "%s Exit k:>%s ENOENT\n", __func__,
+             search_key.c_str());
       return -ENOENT;
     }
     s3_log(S3_LOG_DEBUG, "", "Initial k:>%s found\n", search_key.c_str());
@@ -120,14 +121,14 @@ int S3FakeMotrKvs::kv_next(struct m0_uint128 const &oid,
     ++val_it;
   }
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting 0\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit 0\n", __func__);
   return 0;
 }
 
 int S3FakeMotrKvs::kv_write(struct m0_uint128 const &oid,
                             struct s3_motr_kvs_op_context const &kv) {
-  s3_log(S3_LOG_DEBUG, "", "Entering with oid %" SCNx64 " : %" SCNx64 "\n",
-         oid.u_hi, oid.u_lo);
+  s3_log(S3_LOG_DEBUG, "", "%s Entry with oid %" SCNx64 " : %" SCNx64 "\n",
+         __func__, oid.u_hi, oid.u_lo);
   KeyVal &obj_kv = in_mem_kv[oid];
 
   int cnt = kv.values->ov_vec.v_nr;
@@ -142,16 +143,16 @@ int S3FakeMotrKvs::kv_write(struct m0_uint128 const &oid,
            nval.c_str());
   }
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting 0\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit 0\n", __func__);
   return 0;
 }
 
 int S3FakeMotrKvs::kv_del(struct m0_uint128 const &oid,
                           struct s3_motr_kvs_op_context const &kv) {
-  s3_log(S3_LOG_DEBUG, "", "Entering with oid %" SCNx64 " : %" SCNx64 "\n",
-         oid.u_hi, oid.u_lo);
+  s3_log(S3_LOG_DEBUG, "", "%s Entry with oid %" SCNx64 " : %" SCNx64 "\n",
+         __func__, oid.u_hi, oid.u_lo);
   if (in_mem_kv.count(oid) == 0) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting NOENT\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit NOENT\n", __func__);
     return -ENOENT;
   }
 
@@ -168,6 +169,6 @@ int S3FakeMotrKvs::kv_del(struct m0_uint128 const &oid,
     s3_log(S3_LOG_DEBUG, "", "Del k:>%s -> %d\n", nkey.c_str(), kv.rcs[i]);
   }
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting 0\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit 0\n", __func__);
   return 0;
 }

--- a/server/s3_fake_motr_redis_kvs.cc
+++ b/server/s3_fake_motr_redis_kvs.cc
@@ -32,7 +32,7 @@
 std::unique_ptr<S3FakeMotrRedisKvs> S3FakeMotrRedisKvs::inst;
 
 void finalize_op(struct m0_op *op, op_stable_cb stable, op_failed_cb failed) {
-  s3_log(S3_LOG_DEBUG, "", "Entering");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry", __func__);
   if (!op) return;
 
   s3_redis_context_obj *redis_ctx = (s3_redis_context_obj *)op->op_datum;
@@ -50,7 +50,7 @@ void finalize_op(struct m0_op *op, op_stable_cb stable, op_failed_cb failed) {
 
   free(redis_ctx);
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 // key and val are delimited with zero byte
@@ -147,7 +147,7 @@ int redis_reply_check(redisAsyncContext *glob_redis_ctx,
 // privdata - user context
 void kv_read_cb(redisAsyncContext *glob_redis_ctx, void *async_redis_reply,
                 void *privdata) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   // during the destruction redisAsyncContext will be null
   // in this case do nothing and simply return
   if (!glob_redis_ctx) {
@@ -185,11 +185,11 @@ void kv_read_cb(redisAsyncContext *glob_redis_ctx, void *async_redis_reply,
 
   finalize_op(actx->op);
   free(actx);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3FakeMotrRedisKvs::kv_read(struct m0_op *op) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   struct s3_motr_context_obj *ctx = (struct s3_motr_context_obj *)op->op_datum;
   S3MotrKVSReaderContext *read_ctx =
       (S3MotrKVSReaderContext *)ctx->application_context;
@@ -223,7 +223,7 @@ void S3FakeMotrRedisKvs::kv_read(struct m0_op *op) {
     free(min_b.buf);
     free(max_b.buf);
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 // libhiredis callback for range command
@@ -232,7 +232,7 @@ void S3FakeMotrRedisKvs::kv_read(struct m0_op *op) {
 // privdata - user context
 void kv_next_cb(redisAsyncContext *glob_redis_ctx, void *async_redis_reply,
                 void *privdata) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   // during the destruction redisAsyncContext will be null
   // in this case do nothing and simply return
   if (!glob_redis_ctx) {
@@ -308,11 +308,11 @@ void kv_next_cb(redisAsyncContext *glob_redis_ctx, void *async_redis_reply,
 
   finalize_op(actx->op);
   free(actx);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3FakeMotrRedisKvs::kv_next(struct m0_op *op) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   struct s3_motr_context_obj *ctx = (struct s3_motr_context_obj *)op->op_datum;
   S3MotrKVSReaderContext *read_ctx =
       (S3MotrKVSReaderContext *)ctx->application_context;
@@ -361,7 +361,7 @@ void S3FakeMotrRedisKvs::kv_next(struct m0_op *op) {
       s3_log(S3_LOG_FATAL, "", "Redis command cannot be scheduled");
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 // libhiredis callback for write/delete command
@@ -370,7 +370,7 @@ void S3FakeMotrRedisKvs::kv_next(struct m0_op *op) {
 // privdata - user context
 void kv_status_cb(redisAsyncContext *glob_redis_ctx, void *async_redis_reply,
                   void *privdata) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   // during the destruction redisAsyncContext will be null
   // in this case do nothing and simply return
   if (!glob_redis_ctx) {
@@ -400,7 +400,7 @@ void kv_status_cb(redisAsyncContext *glob_redis_ctx, void *async_redis_reply,
 
   finalize_op(actx->op);
   free(actx);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 static void schedule_delete_key_op(redisAsyncContext *ac,
@@ -421,7 +421,7 @@ static void schedule_delete_key_op(redisAsyncContext *ac,
 }
 
 void S3FakeMotrRedisKvs::kv_write(struct m0_op *op) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   struct s3_motr_context_obj *ctx = (struct s3_motr_context_obj *)op->op_datum;
   S3AsyncMotrKVSWriterContext *write_ctx =
       (S3AsyncMotrKVSWriterContext *)ctx->application_context;
@@ -460,11 +460,11 @@ void S3FakeMotrRedisKvs::kv_write(struct m0_op *op) {
     }
     free(rkey.buf);
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3FakeMotrRedisKvs::kv_del(struct m0_op *op) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   struct s3_motr_context_obj *ctx = (struct s3_motr_context_obj *)op->op_datum;
   S3AsyncMotrKVSWriterContext *write_ctx =
       (S3AsyncMotrKVSWriterContext *)ctx->application_context;
@@ -487,5 +487,5 @@ void S3FakeMotrRedisKvs::kv_del(struct m0_op *op) {
         this->redis_ctx, op->op_entity->en_id, (char *)kv->keys->ov_buf[i],
         kv->keys->ov_vec.v_count[i], kv_status_cb, (void *)actx);
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_fake_motr_redis_kvs.h
+++ b/server/s3_fake_motr_redis_kvs.h
@@ -41,7 +41,7 @@ class S3FakeMotrRedisKvs {
   static std::unique_ptr<S3FakeMotrRedisKvs> inst;
 
   static void connect_cb(const redisAsyncContext *c, int status) {
-    s3_log(S3_LOG_DEBUG, "", "Entering");
+    s3_log(S3_LOG_DEBUG, "", "%s Entry", __func__);
     if (status != REDIS_OK) {
       auto opts = S3Option::get_instance();
       s3_log(S3_LOG_FATAL, "", "Redis@%s:%d connect error: %s",
@@ -49,12 +49,12 @@ class S3FakeMotrRedisKvs {
              c->errstr);
     }
 
-    s3_log(S3_LOG_DEBUG, "", "Exiting status %d", status);
+    s3_log(S3_LOG_DEBUG, "", "%s Exit status %d", __func__, status);
   }
 
  private:
   S3FakeMotrRedisKvs() {
-    s3_log(S3_LOG_DEBUG, "", "Entering");
+    s3_log(S3_LOG_DEBUG, "", "%s Entry", __func__);
     auto opts = S3Option::get_instance();
     redis_ctx = redisAsyncConnect(opts->get_redis_srv_addr().c_str(),
                                   opts->get_redis_srv_port());
@@ -64,7 +64,7 @@ class S3FakeMotrRedisKvs {
 
     redisLibeventAttach(redis_ctx, opts->get_eventbase());
     redisAsyncSetConnectCallback(redis_ctx, connect_cb);
-    s3_log(S3_LOG_DEBUG, "", "Exiting");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   }
 
   void close() {

--- a/server/s3_fi_api_handler.cc
+++ b/server/s3_fi_api_handler.cc
@@ -23,7 +23,7 @@
 #include "s3_put_fi_action.h"
 
 void S3FaultinjectionAPIHandler::create_action() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "Action operation code = %d\n",
          operation_code);
   switch (operation_code) {
@@ -42,5 +42,5 @@ void S3FaultinjectionAPIHandler::create_action() {
       // should never be here.
       return;
   };  // switch operation_code
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }

--- a/server/s3_get_bucket_acl_action.cc
+++ b/server/s3_get_bucket_acl_action.cc
@@ -26,9 +26,10 @@ S3GetBucketACLAction::S3GetBucketACLAction(
     std::shared_ptr<S3RequestObject> req,
     std::shared_ptr<S3BucketMetadataFactory> bucket_meta_factory)
     : S3BucketAction(std::move(req), std::move(bucket_meta_factory), false) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
-  s3_log(S3_LOG_INFO, request_id, "S3 API: Get Bucket Acl API. Bucket[%s]\n",
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "S3 API: Get Bucket Acl API. Bucket[%s]\n",
          request->get_bucket_name().c_str());
 
   setup_steps();
@@ -41,7 +42,7 @@ void S3GetBucketACLAction::setup_steps() {
 }
 
 void S3GetBucketACLAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::missing) {
     s3_log(S3_LOG_WARN, request_id, "Bucket not found\n");
     set_s3_error("NoSuchBucket");
@@ -55,11 +56,11 @@ void S3GetBucketACLAction::fetch_bucket_info_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GetBucketACLAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -92,5 +93,5 @@ void S3GetBucketACLAction::send_response_to_s3_client() {
   }
   S3_RESET_SHUTDOWN_SIGNAL;  // for shutdown testcases
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_get_bucket_action.cc
+++ b/server/s3_get_bucket_action.cc
@@ -42,8 +42,9 @@ S3GetBucketAction::S3GetBucketAction(
       fetch_successful(false),
       total_keys_visited(0),
       key_Count(0) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
-  s3_log(S3_LOG_INFO, request_id, "S3 API: Get Bucket(List Objects).\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "S3 API: Get Bucket(List Objects).\n");
 
   if (motr_api) {
     s3_motr_api = motr_api;
@@ -81,7 +82,7 @@ void S3GetBucketAction::setup_steps() {
   // ...
 }
 void S3GetBucketAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::missing) {
     set_s3_error("NoSuchBucket");
   } else if (bucket_metadata->get_state() ==
@@ -95,7 +96,7 @@ void S3GetBucketAction::fetch_bucket_info_failed() {
   send_response_to_s3_client();
 }
 void S3GetBucketAction::validate_request() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   object_list->set_bucket_name(request->get_bucket_name());
   request_prefix = request->get_query_string_value("prefix");
@@ -136,11 +137,11 @@ void S3GetBucketAction::validate_request() {
 void S3GetBucketAction::after_validate_request() { next(); }
 
 void S3GetBucketAction::get_next_objects() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // If client is disconnected (say, due to read timeout,
   // when the object listing takes substantial time), destroy action class
   if (!request->client_connected()) {
-    s3_log(S3_LOG_INFO, request_id,
+    s3_log(S3_LOG_INFO, stripped_request_id,
            "s3 client is disconnected. Terminating object listing request\n");
     S3_RESET_SHUTDOWN_SIGNAL;  // for shutdown testcases
     done();
@@ -198,13 +199,13 @@ void S3GetBucketAction::get_next_objects() {
   // for shutdown testcases, check FI and set shutdown signal
   S3_CHECK_FI_AND_SET_SHUTDOWN_SIGNAL(
       "get_bucket_action_get_next_objects_shutdown_fail");
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GetBucketAction::get_next_objects_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (check_shutdown_and_rollback()) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   retry_count = 0;
@@ -244,7 +245,7 @@ void S3GetBucketAction::get_next_objects_successful() {
             // Set length to zero to indicate truncation is false
             length = 0;
             s3_log(
-                S3_LOG_INFO, request_id,
+                S3_LOG_INFO, stripped_request_id,
                 "No further prefix match. Skipping further object listing\n");
             break;
           }
@@ -315,7 +316,7 @@ void S3GetBucketAction::get_next_objects_successful() {
           skip_no_further_prefix_match = true;
           // Set length to zero to indicate truncation is false
           length = 0;
-          s3_log(S3_LOG_INFO, request_id,
+          s3_log(S3_LOG_INFO, stripped_request_id,
                  "No further prefix match. Skipping further object listing\n");
           break;
         }
@@ -397,7 +398,7 @@ void S3GetBucketAction::get_next_objects_successful() {
           skip_no_further_prefix_match = true;
           // Set length to zero to indicate truncation is false
           length = 0;
-          s3_log(S3_LOG_INFO, request_id,
+          s3_log(S3_LOG_INFO, stripped_request_id,
                  "No further prefix match. Skipping further object listing\n");
           break;
         }
@@ -445,7 +446,7 @@ void S3GetBucketAction::get_next_objects_successful() {
 }
 
 void S3GetBucketAction::get_next_objects_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_kv_reader->get_state() == S3MotrKVSReaderOpState::missing) {
     s3_log(S3_LOG_DEBUG, request_id, "No Objects found in Object listing\n");
     fetch_successful = true;  // With no entries.
@@ -477,11 +478,11 @@ void S3GetBucketAction::get_next_objects_failed() {
     fetch_successful = false;
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GetBucketAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -512,7 +513,7 @@ void S3GetBucketAction::send_response_to_s3_client() {
     s3_log(S3_LOG_DEBUG, request_id, "Object list response_xml = %s\n",
            response_xml.c_str());
     // Total visited/touched keys in the bucket
-    s3_log(S3_LOG_INFO, request_id, "Total keys visited = %zu\n",
+    s3_log(S3_LOG_INFO, stripped_request_id, "Total keys visited = %zu\n",
            total_keys_visited);
     request->send_response(S3HttpSuccess200, response_xml);
   } else {
@@ -527,5 +528,5 @@ void S3GetBucketAction::send_response_to_s3_client() {
   }
   S3_RESET_SHUTDOWN_SIGNAL;  // for shutdown testcases
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_get_bucket_action_v2.cc
+++ b/server/s3_get_bucket_action_v2.cc
@@ -51,15 +51,16 @@ S3GetBucketActionV2::S3GetBucketActionV2(
     obfuscator = std::make_shared<S3CommonUtilities::S3XORObfuscator>();
   }
 
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
-  s3_log(S3_LOG_INFO, request_id, "S3 API: Get Bucket(List Objects V2).\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "S3 API: Get Bucket(List Objects V2).\n");
 }
 
 S3GetBucketActionV2::~S3GetBucketActionV2() {}
 
 void S3GetBucketActionV2::validate_request() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
-  s3_log(S3_LOG_INFO, request_id, "Validate ListObjects V2 request\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
+  s3_log(S3_LOG_INFO, stripped_request_id, "Validate ListObjects V2 request\n");
 
   std::shared_ptr<S3ObjectListResponseV2> obj_v2_list =
       std::dynamic_pointer_cast<S3ObjectListResponseV2>(object_list);
@@ -105,7 +106,7 @@ void S3GetBucketActionV2::after_validate_request() {
 }
 
 void S3GetBucketActionV2::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -147,7 +148,7 @@ void S3GetBucketActionV2::send_response_to_s3_client() {
       s3_log(S3_LOG_DEBUG, request_id, "Object list V2 response_xml = %s\n",
              response_xml.c_str());
       // Total visited/touched keys in the bucket
-      s3_log(S3_LOG_INFO, request_id, "Total keys visited = %zu\n",
+      s3_log(S3_LOG_INFO, stripped_request_id, "Total keys visited = %zu\n",
              total_keys_visited);
       request->send_response(S3HttpSuccess200, response_xml);
     }
@@ -163,5 +164,5 @@ void S3GetBucketActionV2::send_response_to_s3_client() {
   }
   S3_RESET_SHUTDOWN_SIGNAL;  // for shutdown testcases
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_get_bucket_location_action.cc
+++ b/server/s3_get_bucket_location_action.cc
@@ -26,8 +26,9 @@ S3GetBucketlocationAction::S3GetBucketlocationAction(
     std::shared_ptr<S3RequestObject> req,
     std::shared_ptr<S3BucketMetadataFactory> bucket_meta_factory)
     : S3BucketAction(std::move(req), std::move(bucket_meta_factory)) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
-  s3_log(S3_LOG_INFO, request_id, "S3 API: Get Bucket Location. Bucket[%s]\n",
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "S3 API: Get Bucket Location. Bucket[%s]\n",
          request->get_bucket_name().c_str());
 
   setup_steps();
@@ -40,7 +41,7 @@ void S3GetBucketlocationAction::setup_steps() {
 }
 
 void S3GetBucketlocationAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::missing) {
     s3_log(S3_LOG_WARN, request_id, "Bucket not found\n");
     set_s3_error("NoSuchBucket");
@@ -54,11 +55,11 @@ void S3GetBucketlocationAction::fetch_bucket_info_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GetBucketlocationAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -97,5 +98,5 @@ void S3GetBucketlocationAction::send_response_to_s3_client() {
   }
 
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_get_bucket_policy_action.cc
+++ b/server/s3_get_bucket_policy_action.cc
@@ -26,9 +26,10 @@ S3GetBucketPolicyAction::S3GetBucketPolicyAction(
     std::shared_ptr<S3RequestObject> req,
     std::shared_ptr<S3BucketMetadataFactory> bucket_meta_factory)
     : S3BucketAction(std::move(req), std::move(bucket_meta_factory), false) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
-  s3_log(S3_LOG_INFO, request_id, "S3 API: Get Bucket Policy. Bucket[%s]\n",
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "S3 API: Get Bucket Policy. Bucket[%s]\n",
          request->get_bucket_name().c_str());
 
   setup_steps();
@@ -42,17 +43,18 @@ void S3GetBucketPolicyAction::setup_steps() {
 }
 
 void S3GetBucketPolicyAction::check_metadata_missing_status() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   std::string response_json = bucket_metadata->get_policy_as_json();
   if (response_json.empty()) {
     set_s3_error("NoSuchBucketPolicy");
   }
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GetBucketPolicyAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering fetch_bucket_info_failed\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry fetch_bucket_info_failed\n",
+         __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::failed_to_launch) {
     s3_log(S3_LOG_ERROR, request_id,
            "Bucket metadata load operation failed due to pre launch failure\n");
@@ -66,11 +68,11 @@ void S3GetBucketPolicyAction::fetch_bucket_info_failed() {
            "Bucket metadata load operation failed due to internal error\n");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GetBucketPolicyAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -99,5 +101,5 @@ void S3GetBucketPolicyAction::send_response_to_s3_client() {
   }
 
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_get_bucket_tagging_action.cc
+++ b/server/s3_get_bucket_tagging_action.cc
@@ -26,9 +26,10 @@ S3GetBucketTaggingAction::S3GetBucketTaggingAction(
     std::shared_ptr<S3RequestObject> req,
     std::shared_ptr<S3BucketMetadataFactory> bucket_meta_factory)
     : S3BucketAction(std::move(req), std::move(bucket_meta_factory), false) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
-  s3_log(S3_LOG_INFO, request_id, "S3 API: Get Bucket Tagging. Bucket[%s]\n",
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "S3 API: Get Bucket Tagging. Bucket[%s]\n",
          request->get_bucket_name().c_str());
 
   setup_steps();
@@ -43,16 +44,17 @@ void S3GetBucketTaggingAction::setup_steps() {
 }
 
 void S3GetBucketTaggingAction::check_metadata_missing_status() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (!(bucket_metadata->check_bucket_tags_exists())) {
     set_s3_error("NoSuchTagSetError");
   }
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GetBucketTaggingAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering get_metadata_failed\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry get_metadata_failed\n",
+         __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::failed_to_launch) {
     s3_log(S3_LOG_ERROR, request_id,
            "Bucket metadata load operation failed due to pre launch failure\n");
@@ -66,11 +68,11 @@ void S3GetBucketTaggingAction::fetch_bucket_info_failed() {
            "Bucket metadata load operation failed due to internal error\n");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_INFO, "", "Exiting\n");
+  s3_log(S3_LOG_INFO, "", "%s Exit", __func__);
 }
 
 void S3GetBucketTaggingAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -92,6 +94,6 @@ void S3GetBucketTaggingAction::send_response_to_s3_client() {
     request->send_response(S3HttpSuccess200, response_xml);
   }
 
-  s3_log(S3_LOG_INFO, "", "Exiting\n");
+  s3_log(S3_LOG_INFO, "", "%s Exit", __func__);
   done();
 }

--- a/server/s3_get_multipart_bucket_action.cc
+++ b/server/s3_get_multipart_bucket_action.cc
@@ -38,9 +38,9 @@ S3GetMultipartBucketAction::S3GetMultipartBucketAction(
       return_list_size(0),
       fetch_successful(false),
       last_uploadid("") {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
-  s3_log(S3_LOG_INFO, request_id,
+  s3_log(S3_LOG_INFO, stripped_request_id,
          "S3 API: List Multipart Uploads. Bucket[%s]\n",
          request->get_bucket_name().c_str());
   if (motr_api) {
@@ -64,7 +64,7 @@ S3GetMultipartBucketAction::S3GetMultipartBucketAction(
 }
 
 void S3GetMultipartBucketAction::object_list_setup() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   request_marker_key = request->get_query_string_value("key-marker");
   if (!request_marker_key.empty()) {
     multipart_object_list.set_request_marker_key(request_marker_key);
@@ -109,7 +109,7 @@ void S3GetMultipartBucketAction::setup_steps() {
 }
 
 void S3GetMultipartBucketAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::missing) {
     set_s3_error("NoSuchBucket");
   } else if (bucket_metadata->get_state() ==
@@ -124,9 +124,9 @@ void S3GetMultipartBucketAction::fetch_bucket_info_failed() {
 }
 
 void S3GetMultipartBucketAction::get_next_objects() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (check_shutdown_and_rollback()) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   if (bucket_metadata->get_state() != S3BucketMetadataState::present) {
@@ -154,9 +154,9 @@ void S3GetMultipartBucketAction::get_next_objects() {
 }
 
 void S3GetMultipartBucketAction::get_next_objects_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (check_shutdown_and_rollback()) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   s3_log(S3_LOG_DEBUG, request_id, "Found multipart uploads listing\n");
@@ -263,7 +263,7 @@ void S3GetMultipartBucketAction::get_next_objects_successful() {
 }
 
 void S3GetMultipartBucketAction::get_next_objects_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_kv_reader->get_state() == S3MotrKVSReaderOpState::missing) {
     s3_log(S3_LOG_DEBUG, request_id, "No more multipart uploads listing\n");
     fetch_successful = true;  // With no entries.
@@ -279,11 +279,11 @@ void S3GetMultipartBucketAction::get_next_objects_failed() {
     fetch_successful = false;
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GetMultipartBucketAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -323,5 +323,5 @@ void S3GetMultipartBucketAction::send_response_to_s3_client() {
     request->send_response(error.get_http_status_code(), response_xml);
   }
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_get_multipart_part_action.cc
+++ b/server/s3_get_multipart_part_action.cc
@@ -39,7 +39,7 @@ S3GetMultipartPartAction::S3GetMultipartPartAction(
       return_list_size(0),
       fetch_successful(false),
       invalid_upload_id(false) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
   bucket_name = request->get_bucket_name();
   object_name = request->get_object_name();
@@ -51,7 +51,7 @@ S3GetMultipartPartAction::S3GetMultipartPartAction(
   }
   last_key = request_marker_key;  // as requested by user
 
-  s3_log(S3_LOG_INFO, request_id,
+  s3_log(S3_LOG_INFO, stripped_request_id,
          "S3 API: List Parts. Bucket[%s] Object[%s] for UploadId[%s]\
          from part-number-marker[%s] with max-parts[%s]\n",
          bucket_name.c_str(), object_name.c_str(), upload_id.c_str(),
@@ -115,7 +115,7 @@ void S3GetMultipartPartAction::setup_steps() {
 }
 
 void S3GetMultipartPartAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "Fetching bucket metadata failed\n");
   if (bucket_metadata->get_state() == S3BucketMetadataState::missing) {
     set_s3_error("NoSuchBucket");
@@ -130,7 +130,7 @@ void S3GetMultipartPartAction::fetch_bucket_info_failed() {
   send_response_to_s3_client();
 }
 void S3GetMultipartPartAction::get_multipart_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   S3BucketMetadataState bucket_state = bucket_metadata->get_state();
   if (bucket_state == S3BucketMetadataState::present) {
     multipart_oid = bucket_metadata->get_multipart_index_oid();
@@ -149,11 +149,11 @@ void S3GetMultipartPartAction::get_multipart_metadata() {
           std::bind(&S3GetMultipartPartAction::next, this));
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GetMultipartPartAction::get_key_object() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "Fetching part listing\n");
   S3ObjectMetadataState multipart_object_state =
       object_multipart_metadata->get_state();
@@ -181,10 +181,10 @@ void S3GetMultipartPartAction::get_key_object() {
 }
 
 void S3GetMultipartPartAction::get_key_object_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   std::string value;
   if (check_shutdown_and_rollback()) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   s3_log(S3_LOG_DEBUG, request_id, "Found part listing\n");
@@ -223,7 +223,7 @@ void S3GetMultipartPartAction::get_key_object_successful() {
 }
 
 void S3GetMultipartPartAction::get_key_object_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "Failed to do part listing\n");
   if (motr_kv_reader->get_state() == S3MotrKVSReaderOpState::missing) {
     fetch_successful = true;  // With no entries.
@@ -236,9 +236,9 @@ void S3GetMultipartPartAction::get_key_object_failed() {
 }
 
 void S3GetMultipartPartAction::get_next_objects() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (check_shutdown_and_rollback()) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   s3_log(S3_LOG_DEBUG, request_id, "Fetching next part listing\n");
@@ -264,9 +264,9 @@ void S3GetMultipartPartAction::get_next_objects() {
 }
 
 void S3GetMultipartPartAction::get_next_objects_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (check_shutdown_and_rollback()) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   s3_log(S3_LOG_DEBUG, request_id, "Found part listing\n");
@@ -319,7 +319,7 @@ void S3GetMultipartPartAction::get_next_objects_successful() {
 }
 
 void S3GetMultipartPartAction::get_next_objects_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_kv_reader->get_state() == S3MotrKVSReaderOpState::missing) {
     s3_log(S3_LOG_DEBUG, request_id, "Missing part listing\n");
     fetch_successful = true;  // With no entries.
@@ -335,11 +335,11 @@ void S3GetMultipartPartAction::get_next_objects_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GetMultipartPartAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -381,5 +381,5 @@ void S3GetMultipartPartAction::send_response_to_s3_client() {
     request->send_response(error.get_http_status_code(), response_xml);
   }
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_get_object_acl_action.cc
+++ b/server/s3_get_object_acl_action.cc
@@ -28,9 +28,9 @@ S3GetObjectACLAction::S3GetObjectACLAction(
     std::shared_ptr<S3ObjectMetadataFactory> object_meta_factory)
     : S3ObjectAction(std::move(req), std::move(bucket_meta_factory),
                      std::move(object_meta_factory)) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
-  s3_log(S3_LOG_INFO, request_id,
+  s3_log(S3_LOG_INFO, stripped_request_id,
          "S3 API: Get Object Acl. Bucket[%s] Object[%s]\n",
          request->get_bucket_name().c_str(),
          request->get_object_name().c_str());
@@ -45,7 +45,7 @@ void S3GetObjectACLAction::setup_steps() {
 }
 
 void S3GetObjectACLAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::missing) {
     set_s3_error("NoSuchBucket");
   } else if (bucket_metadata->get_state() ==
@@ -57,11 +57,11 @@ void S3GetObjectACLAction::fetch_bucket_info_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GetObjectACLAction::fetch_object_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if ((object_list_oid.u_lo == 0ULL && object_list_oid.u_hi == 0ULL) ||
       object_metadata->get_state() == S3ObjectMetadataState::missing) {
     s3_log(S3_LOG_DEBUG, request_id, "Object not found\n");
@@ -75,11 +75,11 @@ void S3GetObjectACLAction::fetch_object_info_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GetObjectACLAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -111,5 +111,5 @@ void S3GetObjectACLAction::send_response_to_s3_client() {
   }
   S3_RESET_SHUTDOWN_SIGNAL;
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_get_object_tagging_action.cc
+++ b/server/s3_get_object_tagging_action.cc
@@ -28,9 +28,9 @@ S3GetObjectTaggingAction::S3GetObjectTaggingAction(
     std::shared_ptr<S3ObjectMetadataFactory> object_meta_factory)
     : S3ObjectAction(std::move(req), std::move(bucket_meta_factory),
                      std::move(object_meta_factory)) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
-  s3_log(S3_LOG_INFO, request_id,
+  s3_log(S3_LOG_INFO, stripped_request_id,
          "S3 API: GetObjectTaggingAction. Bucket[%s] Object[%s]\n",
          request->get_bucket_name().c_str(),
          request->get_object_name().c_str());
@@ -45,7 +45,7 @@ void S3GetObjectTaggingAction::setup_steps() {
 }
 
 void S3GetObjectTaggingAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::missing) {
     set_s3_error("NoSuchBucket");
   } else if (bucket_metadata->get_state() ==
@@ -57,11 +57,11 @@ void S3GetObjectTaggingAction::fetch_bucket_info_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GetObjectTaggingAction::fetch_object_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if ((object_list_oid.u_lo == 0ULL && object_list_oid.u_hi == 0ULL) ||
       (object_metadata->get_state() == S3ObjectMetadataState::missing)) {
     s3_log(S3_LOG_DEBUG, request_id, "Object not found\n");
@@ -75,11 +75,11 @@ void S3GetObjectTaggingAction::fetch_object_info_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GetObjectTaggingAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
     S3Error error(get_s3_error_code(), request->get_request_id(),
@@ -99,6 +99,6 @@ void S3GetObjectTaggingAction::send_response_to_s3_client() {
     request->send_response(S3HttpSuccess200, response_xml);
   }
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   done();
 }

--- a/server/s3_get_service_action.cc
+++ b/server/s3_get_service_action.cc
@@ -35,10 +35,10 @@ S3GetServiceAction::S3GetServiceAction(
     std::shared_ptr<S3MotrKVSReaderFactory> motr_kvs_reader_factory,
     std::shared_ptr<S3BucketMetadataFactory> bucket_meta_factory)
     : S3Action(req), last_key(""), key_prefix(""), fetch_successful(false) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   s3_motr_api = std::make_shared<ConcreteMotrAPI>();
 
-  s3_log(S3_LOG_INFO, request_id, "S3 API: Get Service.\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "S3 API: Get Service.\n");
 
   if (bucket_meta_factory) {
     bucket_metadata_factory = bucket_meta_factory;
@@ -64,7 +64,7 @@ void S3GetServiceAction::setup_steps() {
 }
 
 void S3GetServiceAction::initialization() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (!is_authorizationheader_present) {
     set_s3_error("AccessDenied");
     s3_log(S3_LOG_ERROR, request_id, "missing authorization header\n");
@@ -77,15 +77,15 @@ void S3GetServiceAction::initialization() {
     // fetch the keys having account id as a prefix
     last_key = key_prefix;
     next();
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   }
 }
 
 void S3GetServiceAction::get_next_buckets() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (check_shutdown_and_rollback()) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
 
@@ -105,9 +105,9 @@ void S3GetServiceAction::get_next_buckets() {
 }
 
 void S3GetServiceAction::get_next_buckets_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (check_shutdown_and_rollback()) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   s3_log(S3_LOG_DEBUG, request_id, "Found buckets listing\n");
@@ -153,7 +153,7 @@ void S3GetServiceAction::get_next_buckets_successful() {
 }
 
 void S3GetServiceAction::get_next_buckets_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_kv_reader->get_state() == S3MotrKVSReaderOpState::missing) {
     s3_log(S3_LOG_DEBUG, request_id, "Buckets list is empty\n");
     fetch_successful = true;  // With no entries.
@@ -169,11 +169,11 @@ void S3GetServiceAction::get_next_buckets_failed() {
     fetch_successful = false;
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GetServiceAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -212,5 +212,5 @@ void S3GetServiceAction::send_response_to_s3_client() {
   }
   S3_RESET_SHUTDOWN_SIGNAL;  // for shutdown testcases
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_global_bucket_index_metadata.cc
+++ b/server/s3_global_bucket_index_metadata.cc
@@ -47,7 +47,8 @@ S3GlobalBucketIndexMetadata::S3GlobalBucketIndexMetadata(
     std::shared_ptr<S3MotrKVSWriterFactory> motr_s3_kvs_writer_factory)
     : request(req), json_parsing_error(false) {
   request_id = request->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor");
+  stripped_request_id = request->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
   initialize();
 
@@ -75,7 +76,8 @@ S3GlobalBucketIndexMetadata::S3GlobalBucketIndexMetadata(
     std::shared_ptr<S3MotrKVSWriterFactory> motr_s3_kvs_writer_factory)
     : request(req), json_parsing_error(false) {
   request_id = request->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor");
+  stripped_request_id = request->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
   initialize(str_bucket_name);
 
@@ -104,7 +106,7 @@ std::string S3GlobalBucketIndexMetadata::get_account_id() { return account_id; }
 
 void S3GlobalBucketIndexMetadata::load(std::function<void(void)> on_success,
                                        std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   this->handler_on_success = on_success;
   this->handler_on_failed = on_failed;
 
@@ -117,11 +119,11 @@ void S3GlobalBucketIndexMetadata::load(std::function<void(void)> on_success,
       global_bucket_list_index_oid, bucket_name,
       std::bind(&S3GlobalBucketIndexMetadata::load_successful, this),
       std::bind(&S3GlobalBucketIndexMetadata::load_failed, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GlobalBucketIndexMetadata::load_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (this->from_json(motr_kv_reader->get_value()) != 0) {
     s3_log(S3_LOG_ERROR, request_id,
@@ -138,11 +140,11 @@ void S3GlobalBucketIndexMetadata::load_successful() {
     state = S3GlobalBucketIndexMetadataState::present;
     this->handler_on_success();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GlobalBucketIndexMetadata::load_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (json_parsing_error) {
     state = S3GlobalBucketIndexMetadataState::failed;
@@ -159,12 +161,12 @@ void S3GlobalBucketIndexMetadata::load_failed() {
   }
 
   this->handler_on_failed();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GlobalBucketIndexMetadata::save(std::function<void(void)> on_success,
                                        std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   this->handler_on_success = on_success;
   this->handler_on_failed = on_failed;
@@ -178,11 +180,11 @@ void S3GlobalBucketIndexMetadata::save(std::function<void(void)> on_success,
       std::bind(&S3GlobalBucketIndexMetadata::save_successful, this),
       std::bind(&S3GlobalBucketIndexMetadata::save_failed, this));
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GlobalBucketIndexMetadata::save_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   state = S3GlobalBucketIndexMetadataState::saved;
 
@@ -196,11 +198,11 @@ void S3GlobalBucketIndexMetadata::save_successful() {
       std::bind(&S3GlobalBucketIndexMetadata::save_replica, this),
       std::bind(&S3GlobalBucketIndexMetadata::save_replica, this));
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GlobalBucketIndexMetadata::save_replica() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   // PUT Operation pass even if we failed to put KV in replica index.
   if (motr_kv_writer->get_state() != S3MotrKVSWriterOpState::created) {
@@ -212,11 +214,11 @@ void S3GlobalBucketIndexMetadata::save_replica() {
   }
   this->handler_on_success();
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GlobalBucketIndexMetadata::save_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_ERROR, request_id, "Saving of root bucket list index failed\n");
   if (motr_kv_writer->get_state() == S3MotrKVSWriterOpState::failed_to_launch) {
     state = S3GlobalBucketIndexMetadataState::failed_to_launch;
@@ -225,12 +227,12 @@ void S3GlobalBucketIndexMetadata::save_failed() {
   }
   this->handler_on_failed();
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GlobalBucketIndexMetadata::remove(std::function<void(void)> on_success,
                                          std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   this->handler_on_success = on_success;
   this->handler_on_failed = on_failed;
@@ -242,11 +244,11 @@ void S3GlobalBucketIndexMetadata::remove(std::function<void(void)> on_success,
       std::bind(&S3GlobalBucketIndexMetadata::remove_successful, this),
       std::bind(&S3GlobalBucketIndexMetadata::remove_failed, this));
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GlobalBucketIndexMetadata::remove_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   state = S3GlobalBucketIndexMetadataState::deleted;
 
@@ -260,11 +262,11 @@ void S3GlobalBucketIndexMetadata::remove_successful() {
       std::bind(&S3GlobalBucketIndexMetadata::remove_replica, this),
       std::bind(&S3GlobalBucketIndexMetadata::remove_replica, this));
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GlobalBucketIndexMetadata::remove_replica() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   // DELETE bucket operation pass even if we failed to remove KV
   // from replica index
@@ -278,11 +280,11 @@ void S3GlobalBucketIndexMetadata::remove_replica() {
   }
   this->handler_on_success();
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3GlobalBucketIndexMetadata::remove_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_ERROR, request_id, "Removal of bucket information failed\n");
 
   if (motr_kv_writer->get_state() == S3MotrKVSWriterOpState::failed_to_launch) {
@@ -292,12 +294,12 @@ void S3GlobalBucketIndexMetadata::remove_failed() {
   }
   this->handler_on_failed();
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 // Streaming to json
 std::string S3GlobalBucketIndexMetadata::to_json() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   Json::Value root;
 
   root["account_name"] = account_name;
@@ -313,7 +315,7 @@ std::string S3GlobalBucketIndexMetadata::to_json() {
 }
 
 int S3GlobalBucketIndexMetadata::from_json(std::string content) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   Json::Value root;
   Json::Reader reader;
   bool parsingSuccessful = reader.parse(content.c_str(), root);

--- a/server/s3_global_bucket_index_metadata.h
+++ b/server/s3_global_bucket_index_metadata.h
@@ -62,6 +62,7 @@ class S3GlobalBucketIndexMetadata {
   // region
   std::string location_constraint;
   std::string request_id;
+  std::string stripped_request_id;
 
   std::shared_ptr<S3RequestObject> request;
   std::shared_ptr<MotrAPI> s3_motr_api;

--- a/server/s3_head_bucket_action.cc
+++ b/server/s3_head_bucket_action.cc
@@ -26,9 +26,9 @@ S3HeadBucketAction::S3HeadBucketAction(
     std::shared_ptr<S3RequestObject> req,
     std::shared_ptr<S3BucketMetadataFactory> bucket_meta_factory)
     : S3BucketAction(std::move(req), std::move(bucket_meta_factory)) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
-  s3_log(S3_LOG_INFO, request_id, "S3 API: Head Bucket. Bucket[%s]\n",
+  s3_log(S3_LOG_INFO, stripped_request_id, "S3 API: Head Bucket. Bucket[%s]\n",
          request->get_bucket_name().c_str());
 
   setup_steps();
@@ -41,7 +41,7 @@ void S3HeadBucketAction::setup_steps() {
 }
 
 void S3HeadBucketAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::failed_to_launch) {
     s3_log(S3_LOG_ERROR, request_id,
            "Bucket metadata load operation failed due to pre launch failure\n");
@@ -57,7 +57,7 @@ void S3HeadBucketAction::fetch_bucket_info_failed() {
 }
 
 void S3HeadBucketAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
     S3Error error(get_s3_error_code(), request->get_request_id(),
@@ -75,5 +75,5 @@ void S3HeadBucketAction::send_response_to_s3_client() {
     request->send_response(S3HttpSuccess200);
   }
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_head_object_action.cc
+++ b/server/s3_head_object_action.cc
@@ -28,11 +28,12 @@ S3HeadObjectAction::S3HeadObjectAction(
     std::shared_ptr<S3ObjectMetadataFactory> object_meta_factory)
     : S3ObjectAction(std::move(req), std::move(bucket_meta_factory),
                      std::move(object_meta_factory)) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
-  s3_log(
-      S3_LOG_INFO, request_id, "S3 API: Head Object. Bucket[%s] Object[%s]\n",
-      request->get_bucket_name().c_str(), request->get_object_name().c_str());
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "S3 API: Head Object. Bucket[%s] Object[%s]\n",
+         request->get_bucket_name().c_str(),
+         request->get_object_name().c_str());
 
   setup_steps();
 }
@@ -44,7 +45,7 @@ void S3HeadObjectAction::setup_steps() {
 }
 
 void S3HeadObjectAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::missing) {
     set_s3_error("NoSuchBucket");
   } else if (bucket_metadata->get_state() ==
@@ -56,11 +57,11 @@ void S3HeadObjectAction::fetch_bucket_info_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3HeadObjectAction::fetch_object_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (object_metadata->get_state() == S3ObjectMetadataState::present) {
     struct m0_uint128 object_list_index_oid =
         bucket_metadata->get_object_list_index_oid();
@@ -86,11 +87,11 @@ void S3HeadObjectAction::fetch_object_info_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3HeadObjectAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -136,5 +137,5 @@ void S3HeadObjectAction::send_response_to_s3_client() {
     request->send_response(error.get_http_status_code(), response_xml);
   }
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_head_service_action.cc
+++ b/server/s3_head_service_action.cc
@@ -26,7 +26,7 @@
 
 S3HeadServiceAction::S3HeadServiceAction(std::shared_ptr<S3RequestObject> req)
     : S3Action(req, true, nullptr, true, true) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
   setup_steps();
 }
@@ -38,7 +38,7 @@ void S3HeadServiceAction::setup_steps() {
 }
 
 void S3HeadServiceAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
 
   // Disable Audit logs for Haproxy healthchecks
   const char* full_path_uri = request->c_get_full_path();
@@ -60,5 +60,5 @@ void S3HeadServiceAction::send_response_to_s3_client() {
   }
   S3_RESET_SHUTDOWN_SIGNAL;  // for shutdown testcases
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_log.h
+++ b/server/s3_log.h
@@ -63,23 +63,23 @@ inline const char* s3_log_get_req_id(const std::string& requestid) {
 //    only if S3 log level is set to DEBUG.
 // 2. Logging a FATAL message terminates the program (after the message is
 //    logged).so demote it to ERROR
-#define s3_log(loglevel, requestid, fmt, ...)                             \
-  do {                                                                    \
-    if (loglevel >= s3log_level) {                                        \
-      char* s3_log_msg__ = nullptr;                                       \
-      int s3_log_len__ =                                                  \
-          asprintf(&s3_log_msg__, "[%s] [ReqID: %s] " fmt "\n", __func__, \
-                   s3_log_get_req_id(requestid), ##__VA_ARGS__);          \
-      if (s3_log_len__ > 0) {                                             \
-        if (s3_log_msg__[s3_log_len__ - 2] == '\n')                       \
-          s3_log_msg__[s3_log_len__ - 1] = '\0';                          \
-        s3_log_msg_##loglevel(s3_log_msg__);                              \
-        free(s3_log_msg__);                                               \
-      }                                                                   \
-    }                                                                     \
-    if (loglevel >= S3_LOG_FATAL) {                                       \
-      s3_fatal_handler(1);                                                \
-    }                                                                     \
+#define s3_log(loglevel, requestid, fmt, ...)                    \
+  do {                                                           \
+    if (loglevel >= s3log_level) {                               \
+      char* s3_log_msg__ = nullptr;                              \
+      int s3_log_len__ =                                         \
+          asprintf(&s3_log_msg__, "[Req:%s] " fmt "\n",          \
+                   s3_log_get_req_id(requestid), ##__VA_ARGS__); \
+      if (s3_log_len__ > 0) {                                    \
+        if (s3_log_msg__[s3_log_len__ - 2] == '\n')              \
+          s3_log_msg__[s3_log_len__ - 1] = '\0';                 \
+        s3_log_msg_##loglevel(s3_log_msg__);                     \
+        free(s3_log_msg__);                                      \
+      }                                                          \
+    }                                                            \
+    if (loglevel >= S3_LOG_FATAL) {                              \
+      s3_fatal_handler(1);                                       \
+    }                                                            \
   } while (0)
 
 // Note:

--- a/server/s3_management_api_handler.cc
+++ b/server/s3_management_api_handler.cc
@@ -23,7 +23,7 @@
 #include "s3_account_delete_metadata_action.h"
 
 void S3ManagementAPIHandler::create_action() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "Action operation code = %d\n",
          operation_code);
   switch (operation_code) {
@@ -43,5 +43,5 @@ void S3ManagementAPIHandler::create_action() {
       // should never be here.
       return;
   };  // switch operation_code
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }

--- a/server/s3_mem_pool_manager.cc
+++ b/server/s3_mem_pool_manager.cc
@@ -67,8 +67,7 @@ int S3MempoolManager::initialize(std::vector<int> unit_sizes,
 
   for (auto unit_size : unit_sizes) {
     MemoryPoolHandle handle;
-    s3_log(S3_LOG_INFO, "", "Creating memory pool for unit_size = %d.\n",
-           unit_size);
+    s3_log(S3_LOG_INFO, "", "mem pool for size = %d\n", unit_size);
 
     int rc = mempool_create_with_shared_mem(
         unit_size, initial_buffer_count_per_pool * unit_size,
@@ -122,7 +121,8 @@ void S3MempoolManager::free_pools() {
 
 //  Return the buffer of give unit_size
 void *S3MempoolManager::get_buffer_for_unit_size(size_t unit_size) {
-  s3_log(S3_LOG_DEBUG, "", "Entering with unit_size[%zu]\n", unit_size);
+  s3_log(S3_LOG_DEBUG, "", "%s Entry with unit_size[%zu]\n", __func__,
+         unit_size);
   auto item = pool_of_mem_pool.find(unit_size);
   if (item != pool_of_mem_pool.end()) {
     // We have required memory pool.
@@ -153,7 +153,8 @@ void *S3MempoolManager::get_buffer_for_unit_size(size_t unit_size) {
 // Releases the give buffer back to pool
 int S3MempoolManager::release_buffer_for_unit_size(void *buf,
                                                    size_t unit_size) {
-  s3_log(S3_LOG_DEBUG, "", "Entering with unit_size[%zu]\n", unit_size);
+  s3_log(S3_LOG_DEBUG, "", "%s Entry with unit_size[%zu]\n", __func__,
+         unit_size);
   auto item = pool_of_mem_pool.find(unit_size);
   if (item != pool_of_mem_pool.end()) {
     s3_log(S3_LOG_DEBUG, "",
@@ -162,7 +163,8 @@ int S3MempoolManager::release_buffer_for_unit_size(void *buf,
     MemoryPoolHandle handle = item->second;
     return mempool_releasebuffer(handle, buf, unit_size);
   }
-  s3_log(S3_LOG_ERROR, "", "Exiting: Not found unit_size[%zu]\n", unit_size);
+  s3_log(S3_LOG_ERROR, "", "%s Exit: Not found unit_size[%zu]\n", __func__,
+         unit_size);
   // Should never be here
   return S3_MEMPOOL_ERROR;
 }

--- a/server/s3_motr_context.cc
+++ b/server/s3_motr_context.cc
@@ -105,7 +105,8 @@ static int s3_bufvec_alloc_aligned(struct m0_bufvec *bufvec, uint32_t num_segs,
 }
 
 struct s3_motr_obj_context *create_obj_context(size_t count) {
-  s3_log(S3_LOG_DEBUG, "", "Entering with object count = %zu\n", count);
+  s3_log(S3_LOG_DEBUG, "", "%s Entry with object count = %zu\n", __func__,
+         count);
 
   struct s3_motr_obj_context *ctx = (struct s3_motr_obj_context *)calloc(
       1, sizeof(struct s3_motr_obj_context));
@@ -113,23 +114,24 @@ struct s3_motr_obj_context *create_obj_context(size_t count) {
   ctx->objs = (struct m0_obj *)calloc(count, sizeof(struct m0_obj));
   ctx->obj_count = count;
   global_motr_obj.insert(ctx);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return ctx;
 }
 
 int free_obj_context(struct s3_motr_obj_context *ctx) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
 
   free(ctx->objs);
   free(ctx);
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return 0;
 }
 
 // To create a basic motr operation
 struct s3_motr_op_context *create_basic_op_ctx(size_t op_count) {
-  s3_log(S3_LOG_DEBUG, "", "Entering with op_count = %zu\n", op_count);
+  s3_log(S3_LOG_DEBUG, "", "%s Entry with op_count = %zu\n", __func__,
+         op_count);
 
   struct s3_motr_op_context *ctx =
       (struct s3_motr_op_context *)calloc(1, sizeof(struct s3_motr_op_context));
@@ -138,12 +140,12 @@ struct s3_motr_op_context *create_basic_op_ctx(size_t op_count) {
   ctx->cbs = (struct m0_op_ops *)calloc(op_count, sizeof(struct m0_op_ops));
   ctx->op_count = op_count;
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return ctx;
 }
 
 int free_basic_op_ctx(struct s3_motr_op_context *ctx) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   if (!shutdown_motr_teardown_called) {
     global_motr_object_ops_list.erase(ctx);
     for (size_t i = 0; i < ctx->op_count; i++) {
@@ -155,7 +157,7 @@ int free_basic_op_ctx(struct s3_motr_op_context *ctx) {
     free(ctx->cbs);
     free(ctx);
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return 0;
 }
 
@@ -164,8 +166,8 @@ int free_basic_op_ctx(struct s3_motr_op_context *ctx) {
 struct s3_motr_rw_op_context *create_basic_rw_op_ctx(size_t motr_buf_count,
                                                      size_t unit_size,
                                                      bool allocate_bufs) {
-  s3_log(S3_LOG_DEBUG, "", "Entering motr_buf_count = %zu, unit_size = %zu\n",
-         motr_buf_count, unit_size);
+  s3_log(S3_LOG_DEBUG, "", "%s Entry motr_buf_count = %zu, unit_size = %zu\n",
+         __func__, motr_buf_count, unit_size);
 
   struct s3_motr_rw_op_context *ctx = (struct s3_motr_rw_op_context *)calloc(
       1, sizeof(struct s3_motr_rw_op_context));
@@ -183,7 +185,8 @@ struct s3_motr_rw_op_context *create_basic_rw_op_ctx(size_t motr_buf_count,
     free(ctx->data);
     free(ctx->attr);
     free(ctx);
-    s3_log(S3_LOG_DEBUG, "", "Exiting with NULL - possible out-of-memory\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit with NULL - possible out-of-memory\n",
+           __func__);
     return NULL;
   }
 
@@ -194,7 +197,8 @@ struct s3_motr_rw_op_context *create_basic_rw_op_ctx(size_t motr_buf_count,
     free(ctx->attr);
     free(ctx->ext);
     free(ctx);
-    s3_log(S3_LOG_DEBUG, "", "Exiting with NULL - possible out-of-memory\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit with NULL - possible out-of-memory\n",
+           __func__);
     return NULL;
   }
 
@@ -206,15 +210,16 @@ struct s3_motr_rw_op_context *create_basic_rw_op_ctx(size_t motr_buf_count,
     free(ctx->attr);
     free(ctx->ext);
     free(ctx);
-    s3_log(S3_LOG_DEBUG, "", "Exiting with NULL - possible out-of-memory\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit with NULL - possible out-of-memory\n",
+           __func__);
     return NULL;
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return ctx;
 }
 
 int free_basic_rw_op_ctx(struct s3_motr_rw_op_context *ctx) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
 
   s3_bufvec_free_aligned(ctx->data, ctx->unit_size, ctx->allocated_bufs);
   m0_bufvec_free(ctx->attr);
@@ -223,35 +228,36 @@ int free_basic_rw_op_ctx(struct s3_motr_rw_op_context *ctx) {
   free(ctx->data);
   free(ctx->attr);
   free(ctx);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return 0;
 }
 
 /* Motr index API */
 struct s3_motr_idx_context *create_idx_context(size_t idx_count) {
-  s3_log(S3_LOG_DEBUG, "", "Entering with idx_count = %zu\n", idx_count);
+  s3_log(S3_LOG_DEBUG, "", "%s Entry with idx_count = %zu\n", __func__,
+         idx_count);
 
   struct s3_motr_idx_context *ctx = (struct s3_motr_idx_context *)calloc(
       1, sizeof(struct s3_motr_idx_context));
   ctx->idx = (struct m0_idx *)calloc(idx_count, sizeof(struct m0_idx));
   ctx->idx_count = idx_count;
   global_motr_idx.insert(ctx);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return ctx;
 }
 
 int free_idx_context(struct s3_motr_idx_context *ctx) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
 
   free(ctx->idx);
   free(ctx);
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return 0;
 }
 
 struct s3_motr_idx_op_context *create_basic_idx_op_ctx(int op_count) {
-  s3_log(S3_LOG_DEBUG, "", "Entering with op_count = %d\n", op_count);
+  s3_log(S3_LOG_DEBUG, "", "%s Entry with op_count = %d\n", __func__, op_count);
 
   struct s3_motr_idx_op_context *ctx = (struct s3_motr_idx_op_context *)calloc(
       1, sizeof(struct s3_motr_idx_op_context));
@@ -259,12 +265,12 @@ struct s3_motr_idx_op_context *create_basic_idx_op_ctx(int op_count) {
   ctx->cbs = (struct m0_op_ops *)calloc(op_count, sizeof(struct m0_op_ops));
   ctx->op_count = op_count;
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return ctx;
 }
 
 int free_basic_idx_op_ctx(struct s3_motr_idx_op_context *ctx) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   if (!shutdown_motr_teardown_called) {
     global_motr_idx_ops_list.erase(ctx);
 
@@ -284,7 +290,7 @@ int free_basic_idx_op_ctx(struct s3_motr_idx_op_context *ctx) {
     free(ctx);
   }
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return 0;
 }
 
@@ -330,7 +336,7 @@ void index_bufvec_free(struct m0_bufvec *bv) {
 }
 
 struct s3_motr_kvs_op_context *create_basic_kvs_op_ctx(int no_of_keys) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, "", "no of keys = %d\n", no_of_keys);
 
   struct s3_motr_kvs_op_context *ctx = (struct s3_motr_kvs_op_context *)calloc(
@@ -342,7 +348,7 @@ struct s3_motr_kvs_op_context *create_basic_kvs_op_ctx(int no_of_keys) {
   if (ctx->values == NULL) goto FAIL;
   ctx->rcs = (int *)calloc(no_of_keys, sizeof(int));
   if (ctx->rcs == NULL) goto FAIL;
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return ctx;
 
 FAIL:
@@ -362,12 +368,12 @@ FAIL:
 }
 
 int free_basic_kvs_op_ctx(struct s3_motr_kvs_op_context *ctx) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
 
   index_bufvec_free(ctx->keys);
   index_bufvec_free(ctx->values);
   free(ctx->rcs);
   free(ctx);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return 0;
 }

--- a/server/s3_motr_kvs_reader.h
+++ b/server/s3_motr_kvs_reader.h
@@ -51,7 +51,8 @@ class S3MotrKVSReaderContext : public S3AsyncOpContextBase {
       : S3AsyncOpContextBase(req, success_callback, failed_callback, 1,
                              motr_api) {
     request_id = request->get_request_id();
-    s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+    stripped_request_id = request->get_stripped_request_id();
+    s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
     // Create or write, we need op context
     motr_idx_op_context = create_basic_idx_op_ctx(1);
@@ -62,7 +63,7 @@ class S3MotrKVSReaderContext : public S3AsyncOpContextBase {
   }
 
   ~S3MotrKVSReaderContext() {
-    s3_log(S3_LOG_DEBUG, request_id, "Destructor\n");
+    s3_log(S3_LOG_DEBUG, request_id, "%s\n", __func__);
 
     if (has_motr_idx_op_context) {
       free_basic_idx_op_ctx(motr_idx_op_context);
@@ -106,6 +107,7 @@ class S3MotrKVSReader {
   std::shared_ptr<MotrAPI> s3_motr_api;
 
   std::string request_id;
+  std::string stripped_request_id;
 
   // Used to report to caller
   std::function<void()> handler_on_success;

--- a/server/s3_motr_kvs_writer.cc
+++ b/server/s3_motr_kvs_writer.cc
@@ -39,7 +39,8 @@ S3MotrKVSWriter::S3MotrKVSWriter(std::shared_ptr<RequestObject> req,
                                  std::shared_ptr<MotrAPI> motr_api)
     : request(req), state(S3MotrKVSWriterOpState::start), idx_ctx(nullptr) {
   request_id = request->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  stripped_request_id = request->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   if (motr_api) {
     s3_motr_api = motr_api;
   } else {
@@ -51,7 +52,8 @@ S3MotrKVSWriter::S3MotrKVSWriter(std::string req_id,
                                  std::shared_ptr<MotrAPI> motr_api)
     : state(S3MotrKVSWriterOpState::start), idx_ctx(nullptr) {
   request_id = std::move(req_id);
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  stripped_request_id = std::string(request_id.end() - 12, request_id.end());
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   if (motr_api) {
     s3_motr_api = std::move(motr_api);
   } else {
@@ -60,7 +62,7 @@ S3MotrKVSWriter::S3MotrKVSWriter(std::string req_id,
 }
 
 S3MotrKVSWriter::~S3MotrKVSWriter() {
-  s3_log(S3_LOG_DEBUG, request_id, "Destructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s\n", __func__);
   clean_up_contexts();
 }
 
@@ -85,8 +87,8 @@ void S3MotrKVSWriter::clean_up_contexts() {
 void S3MotrKVSWriter::create_index(std::string index_name,
                                    std::function<void(void)> on_success,
                                    std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_INFO, request_id, "Entering with index_name = %s\n",
-         index_name.c_str());
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry with index_name = %s\n",
+         __func__, index_name.c_str());
 
   struct m0_uint128 id = {0ULL, 0ULL};
   S3UriToMotrOID(s3_motr_api, index_name.c_str(), request_id, &id,
@@ -94,15 +96,15 @@ void S3MotrKVSWriter::create_index(std::string index_name,
 
   create_index_with_oid(id, on_success, on_failed);
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3MotrKVSWriter::create_index_with_oid(
     struct m0_uint128 idx_oid, std::function<void(void)> on_success,
     std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_INFO, request_id,
-         "Entering with idx_oid = %" SCNx64 " : %" SCNx64 "\n", idx_oid.u_hi,
-         idx_oid.u_lo);
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "%s Entry with idx_oid = %" SCNx64 " : %" SCNx64 "\n", __func__,
+         idx_oid.u_hi, idx_oid.u_lo);
   int rc = 0;
   this->handler_on_success = on_success;
   this->handler_on_failed = on_failed;
@@ -154,19 +156,19 @@ void S3MotrKVSWriter::create_index_with_oid(
   s3_motr_api->motr_op_launch(request->addb_request_id, idx_op_ctx->ops, 1,
                               MotrOpType::createidx);
   global_motr_idx_ops_list.insert(idx_op_ctx);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3MotrKVSWriter::create_index_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_stats_inc("create_index_op_success_count");
   state = S3MotrKVSWriterOpState::created;
   this->handler_on_success();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3MotrKVSWriter::create_index_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (state != S3MotrKVSWriterOpState::failed_to_launch) {
     if (writer_context->get_errno_for(0) == -EEXIST) {
       state = S3MotrKVSWriterOpState::exists;
@@ -177,7 +179,7 @@ void S3MotrKVSWriter::create_index_failed() {
     }
   }
   this->handler_on_failed();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 // Sync motr is currently done using motr_idx_op
@@ -185,8 +187,9 @@ void S3MotrKVSWriter::create_index_failed() {
 // void S3MotrKVSWriter::sync_index(std::function<void(void)> on_success,
 //                                    std::function<void(void)> on_failed,
 //                                    int index_count) {
-//   s3_log(S3_LOG_INFO, request_id, "Entering with index_count = %d\n",
-//          index_count);
+//   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry with index_count =
+// %d\n",
+//     __func__, index_count);
 //   int rc = 0;
 //   this->handler_on_success = on_success;
 //   this->handler_on_failed = on_failed;
@@ -230,11 +233,11 @@ void S3MotrKVSWriter::create_index_failed() {
 //   s3_motr_api->motr_op_launch(request->addb_request_id,
 //                                   &idx_op_ctx->sync_op, 1,
 //                                   MotrOpType::createidx);
-//   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+//   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 // }
 
 // void S3MotrKVSWriter::sync_index_successful() {
-//   s3_log(S3_LOG_INFO, request_id, "Entering\n");
+//   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 //   s3_stats_inc("sync_index_op_success_count");
 //   if (state == S3MotrKVSWriterOpState::deleting) {
 //     state = S3MotrKVSWriterOpState::deleted;
@@ -242,11 +245,11 @@ void S3MotrKVSWriter::create_index_failed() {
 //     state = S3MotrKVSWriterOpState::saved;
 //   }
 //   this->handler_on_success();
-//   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+//   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 // }
 
 // void S3MotrKVSWriter::sync_index_failed() {
-//   s3_log(S3_LOG_INFO, request_id, "Entering\n");
+//   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 //   if (state != S3MotrKVSWriterOpState::failed_to_launch) {
 //     if (sync_context->get_errno_for(0) == -ENOENT) {
 //       state = S3MotrKVSWriterOpState::missing;
@@ -258,15 +261,15 @@ void S3MotrKVSWriter::create_index_failed() {
 //     }
 //   }
 //   this->handler_on_failed();
-//   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+//   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 // }
 
 void S3MotrKVSWriter::delete_index(struct m0_uint128 idx_oid,
                                    std::function<void(void)> on_success,
                                    std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_INFO, request_id,
-         "Entering with idx_oid = %" SCNx64 " : %" SCNx64 "\n", idx_oid.u_hi,
-         idx_oid.u_lo);
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "%s Entry with idx_oid = %" SCNx64 " : %" SCNx64 "\n", __func__,
+         idx_oid.u_hi, idx_oid.u_lo);
   this->handler_on_success = on_success;
   this->handler_on_failed = on_failed;
 
@@ -327,18 +330,18 @@ void S3MotrKVSWriter::delete_index(struct m0_uint128 idx_oid,
   s3_motr_api->motr_op_launch(request->addb_request_id, idx_op_ctx->ops, 1,
                               MotrOpType::deleteidx);
   global_motr_idx_ops_list.insert(idx_op_ctx);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3MotrKVSWriter::delete_index_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   state = S3MotrKVSWriterOpState::deleted;
   this->handler_on_success();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3MotrKVSWriter::delete_index_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (state != S3MotrKVSWriterOpState::failed_to_launch) {
     if (writer_context->get_errno_for(0) == -ENOENT) {
       s3_log(S3_LOG_DEBUG, request_id, "Index doesn't exists\n");
@@ -349,13 +352,14 @@ void S3MotrKVSWriter::delete_index_failed() {
     }
   }
   this->handler_on_failed();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3MotrKVSWriter::delete_indexes(std::vector<struct m0_uint128> oids,
                                      std::function<void(void)> on_success,
                                      std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_INFO, request_id, "Entering with %zu indexes\n", oids.size());
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry with %zu indexes\n",
+         __func__, oids.size());
 
   {
     for (auto &oid : oids) {
@@ -429,32 +433,33 @@ void S3MotrKVSWriter::delete_indexes(std::vector<struct m0_uint128> oids,
   s3_motr_api->motr_op_launch(request->addb_request_id, idx_op_ctx->ops,
                               oids.size(), MotrOpType::deleteidx);
   global_motr_idx_ops_list.insert(idx_op_ctx);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3MotrKVSWriter::delete_indexes_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   state = S3MotrKVSWriterOpState::deleted;
   this->handler_on_success();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3MotrKVSWriter::delete_indexes_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_ERROR, request_id, "Deletion of Index failed\n");
   if (state != S3MotrKVSWriterOpState::failed_to_launch) {
     state = S3MotrKVSWriterOpState::failed;
   }
   this->handler_on_failed();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3MotrKVSWriter::put_keyval(
     struct m0_uint128 oid, const std::map<std::string, std::string> &kv_list,
     std::function<void(void)> on_success, std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_INFO, request_id, "Entering with oid = %" SCNx64 " : %" SCNx64
-                                  " and %zu key/value pairs\n",
-         oid.u_hi, oid.u_lo, kv_list.size());
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "%s Entry with oid = %" SCNx64 " : %" SCNx64
+         " and %zu key/value pairs\n",
+         __func__, oid.u_hi, oid.u_lo, kv_list.size());
   {
     for (auto &kv : kv_list) {
       s3_log(S3_LOG_DEBUG, request_id, "key = %s, value = %s\n",
@@ -570,15 +575,16 @@ int S3MotrKVSWriter::put_keyval_impl(
     }
   }
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return 0;
 }
 
 int S3MotrKVSWriter::put_keyval_sync(
     struct m0_uint128 oid, const std::map<std::string, std::string> &kv_list) {
-  s3_log(S3_LOG_INFO, request_id, "Entering with oid = %" SCNx64 " : %" SCNx64
-                                  " and %zu key/value pairs\n",
-         oid.u_hi, oid.u_lo, kv_list.size());
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "%s Entry with oid = %" SCNx64 " : %" SCNx64
+         " and %zu key/value pairs\n",
+         __func__, oid.u_hi, oid.u_lo, kv_list.size());
 
   /* For the moment sync kvs operation for fake kvs is not supported */
   assert(S3Option::get_instance()->is_sync_kvs_allowed());
@@ -610,9 +616,11 @@ void S3MotrKVSWriter::put_keyval(struct m0_uint128 oid, std::string key,
                                  std::string val,
                                  std::function<void(void)> on_success,
                                  std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_INFO, request_id, "Entering with oid = %" SCNx64 " : %" SCNx64
-                                  " key = %s and value = %s\n",
-         oid.u_hi, oid.u_lo, key.c_str(), val.c_str());
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "%s Entry with oid = %" SCNx64 " : %" SCNx64
+         " key = %s and value = %s\n",
+         __func__, oid.u_hi, oid.u_lo, key.c_str(), val.c_str());
+
   assert(!key.empty());
   // Add error when any key is empty
   if (key.empty()) {
@@ -679,35 +687,35 @@ void S3MotrKVSWriter::put_keyval(struct m0_uint128 oid, std::string key,
   s3_motr_api->motr_op_launch(request->addb_request_id, idx_op_ctx->ops, 1,
                               MotrOpType::putkv);
   global_motr_idx_ops_list.insert(idx_op_ctx);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3MotrKVSWriter::put_keyval_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_stats_inc("put_keyval_success_count");
   // todo: Add check, verify if (kvs_ctx->rcs == 0)
   // do this when cassandra + motr-kvs rcs implementation completed
   // in motr
   state = S3MotrKVSWriterOpState::created;
   this->handler_on_success();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3MotrKVSWriter::put_keyval_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_ERROR, request_id, "Writing of key value failed\n");
   if (state != S3MotrKVSWriterOpState::failed_to_launch) {
     state = S3MotrKVSWriterOpState::failed;
   }
   this->handler_on_failed();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 // Sync motr is currently done using motr_idx_op
 
 // void S3MotrKVSWriter::sync_keyval(std::function<void(void)> on_success,
 //                                     std::function<void(void)> on_failed) {
-//   s3_log(S3_LOG_INFO, request_id, "Entering\n");
+//   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 //   int rc = 0;
 //   this->handler_on_success = on_success;
 //   this->handler_on_failed = on_failed;
@@ -761,49 +769,49 @@ void S3MotrKVSWriter::put_keyval_failed() {
 // MotrOpType::putkv);
 //   }
 
-//   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+//   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 // }
 
 // void S3MotrKVSWriter::sync_keyval_successful() {
-//   s3_log(S3_LOG_INFO, request_id, "Entering\n");
+//   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 //   s3_stats_inc("sync_keyval_op_success_count");
 //   if (state == S3MotrKVSWriterOpState::deleting) {
 //     state = S3MotrKVSWriterOpState::deleted;
 //   } else {
 //     state = S3MotrKVSWriterOpState::saved;
 //   }
-//   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+//   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 // }
 
 // void S3MotrKVSWriter::sync_keyval_failed() {
-//   s3_log(S3_LOG_INFO, request_id, "Entering\n");
+//   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 //   if (state != S3MotrKVSWriterOpState::failed_to_launch) {
 //     state = S3MotrKVSWriterOpState::failed;
 //   }
 //   this->handler_on_failed();
-//   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+//   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 // }
 
 void S3MotrKVSWriter::delete_keyval(struct m0_uint128 oid, std::string key,
                                     std::function<void(void)> on_success,
                                     std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_INFO, request_id,
-         "Entering with oid %" SCNx64 " : %" SCNx64 " and key %s\n", oid.u_hi,
-         oid.u_lo, key.c_str());
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "%s Entry with oid %" SCNx64 " : %" SCNx64 " and key %s\n", __func__,
+         oid.u_hi, oid.u_lo, key.c_str());
   std::vector<std::string> keys;
   keys.push_back(key);
 
   delete_keyval(oid, keys, on_success, on_failed);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3MotrKVSWriter::delete_keyval(struct m0_uint128 oid,
                                     std::vector<std::string> keys,
                                     std::function<void(void)> on_success,
                                     std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_INFO, request_id,
-         "Entering with oid %" SCNx64 " : %" SCNx64 " and %zu keys\n", oid.u_hi,
-         oid.u_lo, keys.size());
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "%s Entry with oid %" SCNx64 " : %" SCNx64 " and %zu keys\n", __func__,
+         oid.u_hi, oid.u_lo, keys.size());
   int rc;
   for (auto key : keys) {
     s3_log(S3_LOG_DEBUG, request_id, "key = %s\n", key.c_str());
@@ -882,21 +890,21 @@ void S3MotrKVSWriter::delete_keyval(struct m0_uint128 oid,
   s3_motr_api->motr_op_launch(request->addb_request_id, idx_op_ctx->ops, 1,
                               MotrOpType::deletekv);
   global_motr_idx_ops_list.insert(idx_op_ctx);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3MotrKVSWriter::delete_keyval_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // todo: Add check, verify if (kvs_ctx->rcs == 0)
   // do this when cassandra + motr-kvs rcs implementation completed
   // in motr
   state = S3MotrKVSWriterOpState::deleted;
   this->handler_on_success();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3MotrKVSWriter::delete_keyval_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (state != S3MotrKVSWriterOpState::failed_to_launch) {
     if (writer_context->get_errno_for(0) == -ENOENT) {
       s3_log(S3_LOG_DEBUG, request_id, "The key doesn't exist\n");
@@ -907,14 +915,14 @@ void S3MotrKVSWriter::delete_keyval_failed() {
     }
   }
   this->handler_on_failed();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3MotrKVSWriter::set_up_key_value_store(
     struct s3_motr_kvs_op_context *kvs_ctx, const std::string &key,
     const std::string &val, size_t pos) {
   // TODO - clean up these buffers
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   kvs_ctx->keys->ov_vec.v_count[pos] = key.length();
   kvs_ctx->keys->ov_buf[pos] = (char *)malloc(key.length());
   memcpy(kvs_ctx->keys->ov_buf[pos], (void *)key.c_str(), key.length());
@@ -930,5 +938,5 @@ void S3MotrKVSWriter::set_up_key_value_store(
   s3_log(S3_LOG_DEBUG, request_id, "kvs_ctx->vals->ov_buf[%lu] = %s\n", pos,
          std::string((char *)kvs_ctx->values->ov_buf[pos],
                      kvs_ctx->values->ov_vec.v_count[pos]).c_str());
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_motr_kvs_writer.h
+++ b/server/s3_motr_kvs_writer.h
@@ -49,7 +49,7 @@ class S3SyncMotrKVSWriterContext {
   S3SyncMotrKVSWriterContext(std::string req_id, int ops_cnt)
       : request_id(std::move(req_id)), ops_count(ops_cnt) {
 
-    s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+    s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
     // Create or write, we need op context
     motr_idx_op_context = create_basic_idx_op_ctx(ops_count);
     has_motr_idx_op_context = true;
@@ -58,7 +58,7 @@ class S3SyncMotrKVSWriterContext {
   }
 
   ~S3SyncMotrKVSWriterContext() {
-    s3_log(S3_LOG_DEBUG, request_id, "Destructor\n");
+    s3_log(S3_LOG_DEBUG, request_id, "%s\n", __func__);
     if (has_motr_idx_op_context) {
       free_basic_idx_op_ctx(motr_idx_op_context);
     }
@@ -88,6 +88,7 @@ class S3AsyncMotrKVSWriterContext : public S3SyncMotrKVSWriterContext,
                                     public S3AsyncOpContextBase {
 
   std::string request_id = "";
+  std::string stripped_request_id = "";
 
  public:
   S3AsyncMotrKVSWriterContext(std::shared_ptr<RequestObject> req,
@@ -99,11 +100,12 @@ class S3AsyncMotrKVSWriterContext : public S3SyncMotrKVSWriterContext,
         S3AsyncOpContextBase(req, success_callback, failed_callback, ops_count,
                              motr_api) {
     request_id = req ? req->get_request_id() : "";
-    s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+    stripped_request_id = req ? req->get_stripped_request_id() : "";
+    s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   }
 
   ~S3AsyncMotrKVSWriterContext() {
-    s3_log(S3_LOG_DEBUG, request_id, "Destructor\n");
+    s3_log(S3_LOG_DEBUG, request_id, "%s\n", __func__);
   }
 };
 
@@ -132,6 +134,8 @@ class S3MotrKVSWriter {
   std::string kvs_value;
 
   std::string request_id;
+  std::string stripped_request_id;
+
   // Used to report to caller
   std::function<void()> handler_on_success;
   std::function<void()> handler_on_failed;

--- a/server/s3_motr_layout.cc
+++ b/server/s3_motr_layout.cc
@@ -48,7 +48,8 @@ S3MotrLayoutMap::S3MotrLayoutMap() {
 }
 
 bool S3MotrLayoutMap::load_layout_recommendations(std::string filename) {
-  s3_log(S3_LOG_DEBUG, "", "Entering with filename = %s\n", filename.c_str());
+  s3_log(S3_LOG_DEBUG, "", "%s Entry with filename = %s\n", __func__,
+         filename.c_str());
   try {
     YAML::Node root_node = YAML::LoadFile(filename);
     if (root_node.IsNull()) {
@@ -138,7 +139,8 @@ int S3MotrLayoutMap::get_best_layout_for_object_size() {
 
 // Returns the <layout id and unit size> recommended for give object size.
 int S3MotrLayoutMap::get_layout_for_object_size(size_t obj_size) {
-  s3_log(S3_LOG_DEBUG, "", "Entering with obj_size = %zu\n", obj_size);
+  s3_log(S3_LOG_DEBUG, "", "%s Entry with obj_size = %zu\n", __func__,
+         obj_size);
 
   if (obj_size == 0 || obj_size <= obj_layout_map.begin()->first) {
     // obj_size is zero OR less than the smallest UP_TO_OBJ_SIZE

--- a/server/s3_motr_reader.cc
+++ b/server/s3_motr_reader.cc
@@ -45,7 +45,8 @@ S3MotrReader::S3MotrReader(std::shared_ptr<RequestObject> req,
       is_object_opened(false),
       obj_ctx(nullptr) {
   request_id = request->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  stripped_request_id = request->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
   if (motr_api) {
     s3_motr_api = motr_api;
@@ -78,8 +79,8 @@ void S3MotrReader::clean_up_contexts() {
 bool S3MotrReader::read_object_data(size_t num_of_blocks,
                                     std::function<void(void)> on_success,
                                     std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_INFO, request_id,
-         "Entering with num_of_blocks = %zu from last_index = %zu\n",
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "%s Entry with num_of_blocks = %zu from last_index = %zu\n", __func__,
          num_of_blocks, last_index);
 
   bool rc = true;
@@ -103,7 +104,7 @@ bool S3MotrReader::read_object_data(size_t num_of_blocks,
       rc = false;
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return rc;
 }
 
@@ -127,13 +128,13 @@ bool S3MotrReader::check_object_exist(std::function<void(void)> on_success,
     }
   }
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return rc;
 }
 
 int S3MotrReader::open_object(std::function<void(void)> on_success,
                               std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   int rc = 0;
 
   is_object_opened = false;
@@ -176,7 +177,7 @@ int S3MotrReader::open_object(std::function<void(void)> on_success,
   ctx->ops[0]->op_datum = (void *)op_ctx;
   s3_motr_api->motr_op_setup(ctx->ops[0], &ctx->cbs[0], 0);
 
-  s3_log(S3_LOG_INFO, request_id,
+  s3_log(S3_LOG_INFO, stripped_request_id,
          "Motr API: openobj(oid: ("
          "%" SCNx64 " : %" SCNx64 "))\n",
          oid.u_hi, oid.u_lo);
@@ -184,13 +185,13 @@ int S3MotrReader::open_object(std::function<void(void)> on_success,
   s3_motr_api->motr_op_launch(request->addb_request_id, ctx->ops, 1,
                               MotrOpType::openobj);
   global_motr_object_ops_list.insert(ctx);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return rc;
 }
 
 void S3MotrReader::open_object_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
-  s3_log(S3_LOG_INFO, request_id,
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
+  s3_log(S3_LOG_INFO, stripped_request_id,
          "Motr API Successful: openobj(oid: ("
          "%" SCNx64 " : %" SCNx64 "))\n",
          oid.u_hi, oid.u_lo);
@@ -203,14 +204,14 @@ void S3MotrReader::open_object_successful() {
         this->handler_on_failed();
       }
     }
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   } else {
     this->handler_on_success();
   }
 }
 
 void S3MotrReader::open_object_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (state != S3MotrReaderOpState::failed_to_launch) {
     s3_log(S3_LOG_DEBUG, request_id, "errno = %d\n",
            open_context->get_errno_for(0));
@@ -225,14 +226,14 @@ void S3MotrReader::open_object_failed() {
   }
   this->handler_on_failed();
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 bool S3MotrReader::read_object() {
   int rc;
-  s3_log(S3_LOG_INFO, request_id,
-         "Entering with num_of_blocks_to_read = %zu from last_index = %zu\n",
-         num_of_blocks_to_read, last_index);
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "%s Entry with num_of_blocks_to_read = %zu from last_index = %zu\n",
+         __func__, num_of_blocks_to_read, last_index);
 
   assert(is_object_opened);
 
@@ -285,7 +286,7 @@ bool S3MotrReader::read_object() {
 
   reader_context->start_timer_for("read_object_data");
 
-  s3_log(S3_LOG_INFO, request_id,
+  s3_log(S3_LOG_INFO, stripped_request_id,
          "Motr API: readobj(operation: M0_OC_READ, oid: ("
          "%" SCNx64 " : %" SCNx64 "))\n",
          oid.u_hi, oid.u_lo);
@@ -293,23 +294,23 @@ bool S3MotrReader::read_object() {
   s3_motr_api->motr_op_launch(request->addb_request_id, ctx->ops, 1,
                               MotrOpType::readobj);
   global_motr_object_ops_list.insert(ctx);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return true;
 }
 
 void S3MotrReader::read_object_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
-  s3_log(S3_LOG_INFO, request_id,
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
+  s3_log(S3_LOG_INFO, stripped_request_id,
          "Motr API Successful: readobj(oid: ("
          "%" SCNx64 " : %" SCNx64 "))\n",
          oid.u_hi, oid.u_lo);
   state = S3MotrReaderOpState::success;
   this->handler_on_success();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3MotrReader::read_object_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "errno = %d\n",
          reader_context->get_errno_for(0));
   if (reader_context->get_errno_for(0) == -ENOENT) {
@@ -331,19 +332,19 @@ size_t S3MotrReader::get_first_block(char **data) {
 
 // Returns size of data in next block and -1 if there is no content or done
 size_t S3MotrReader::get_next_block(char **data) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id,
          "num_of_blocks_to_read = %zu from iteration_index = %zu\n",
          num_of_blocks_to_read, iteration_index);
   size_t data_read = 0;
   if (iteration_index == num_of_blocks_to_read) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return 0;
   }
 
   *data = (char *)motr_rw_op_context->data->ov_buf[iteration_index];
   data_read = motr_rw_op_context->data->ov_vec.v_count[iteration_index];
   iteration_index++;
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return data_read;
 }

--- a/server/s3_motr_reader.h
+++ b/server/s3_motr_reader.h
@@ -47,6 +47,7 @@ class S3MotrReaderContext : public S3AsyncOpContextBase {
 
   int layout_id;
   std::string request_id;
+  std::string stripped_request_id;
 
  public:
   S3MotrReaderContext(std::shared_ptr<RequestObject> req,
@@ -57,7 +58,9 @@ class S3MotrReaderContext : public S3AsyncOpContextBase {
       : S3AsyncOpContextBase(req, success_callback, failed_callback, 1,
                              motr_api) {
     request_id = request->get_request_id();
-    s3_log(S3_LOG_DEBUG, request_id, "Constructor: layout_id = %d\n", layoutid);
+    stripped_request_id = request->get_stripped_request_id();
+    s3_log(S3_LOG_DEBUG, request_id, "%s Ctor: layout_id = %d\n", __func__,
+           layoutid);
     assert(layoutid > 0);
 
     layout_id = layoutid;
@@ -71,7 +74,7 @@ class S3MotrReaderContext : public S3AsyncOpContextBase {
   }
 
   ~S3MotrReaderContext() {
-    s3_log(S3_LOG_DEBUG, request_id, "Destructor\n");
+    s3_log(S3_LOG_DEBUG, request_id, "%s\n", __func__);
 
     if (has_motr_op_context) {
       free_basic_op_ctx(motr_op_context);
@@ -140,6 +143,7 @@ class S3MotrReader {
   std::shared_ptr<MotrAPI> s3_motr_api;
 
   std::string request_id;
+  std::string stripped_request_id;
 
   // Used to report to caller
   std::function<void()> handler_on_success;

--- a/server/s3_motr_wrapper.cc
+++ b/server/s3_motr_wrapper.cc
@@ -38,7 +38,7 @@ void ConcreteMotrAPI::motr_fake_op_launch(struct m0_op **op, uint32_t nr) {
 
 void ConcreteMotrAPI::motr_fake_redis_op_launch(struct m0_op **op,
                                                 uint32_t nr) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   auto redis_ctx = S3FakeMotrRedisKvs::instance();
 
   for (uint32_t i = 0; i < nr; ++i) {
@@ -60,7 +60,7 @@ void ConcreteMotrAPI::motr_fake_redis_op_launch(struct m0_op **op,
       s3_motr_op_stable(cop);
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void ConcreteMotrAPI::motr_fi_op_launch(struct m0_op **op, uint32_t nr) {

--- a/server/s3_motr_writer.h
+++ b/server/s3_motr_writer.h
@@ -98,6 +98,7 @@ class S3MotrWiter {
   std::string content_md5;
   uint64_t last_index;
   std::string request_id;
+  std::string stripped_request_id;
   // md5 for the content written to motr.
   MD5hash md5crypt;
 

--- a/server/s3_object_action_base.cc
+++ b/server/s3_object_action_base.cc
@@ -33,7 +33,7 @@ S3ObjectAction::S3ObjectAction(
     : S3Action(std::move(req), check_shutdown, std::move(auth_factory),
                skip_auth) {
 
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   object_list_oid = {0ULL, 0ULL};
   objects_version_list_oid = {0ULL, 0ULL};
   if (bucket_meta_factory) {
@@ -51,11 +51,11 @@ S3ObjectAction::S3ObjectAction(
 }
 
 S3ObjectAction::~S3ObjectAction() {
-  s3_log(S3_LOG_DEBUG, request_id, "Destructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s\n", __func__);
 }
 
 void S3ObjectAction::fetch_bucket_info() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   bucket_metadata =
       bucket_metadata_factory->create_bucket_metadata_obj(request);
@@ -63,7 +63,7 @@ void S3ObjectAction::fetch_bucket_info() {
       std::bind(&S3ObjectAction::fetch_bucket_info_success, this),
       std::bind(&S3ObjectAction::fetch_bucket_info_failed, this));
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3ObjectAction::fetch_bucket_info_success() {
@@ -73,7 +73,7 @@ void S3ObjectAction::fetch_bucket_info_success() {
 }
 
 void S3ObjectAction::fetch_object_info() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   // Object create case no object metadata exist
   s3_log(S3_LOG_DEBUG, request_id, "Found bucket metadata\n");
   object_list_oid = bucket_metadata->get_object_list_index_oid();
@@ -102,7 +102,7 @@ void S3ObjectAction::fetch_object_info() {
         std::bind(&S3ObjectAction::fetch_object_info_success, this),
         std::bind(&S3ObjectAction::fetch_object_info_failed, this));
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3ObjectAction::fetch_object_info_success() {
@@ -113,11 +113,11 @@ void S3ObjectAction::fetch_object_info_success() {
 void S3ObjectAction::load_metadata() { fetch_bucket_info(); }
 
 void S3ObjectAction::set_authorization_meta() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   auth_client->set_acl_and_policy(object_metadata->get_encoded_object_acl(),
                                   bucket_metadata->get_policy_as_json());
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3ObjectAction::setup_fi_for_shutdown_tests() {

--- a/server/s3_object_api_handler.cc
+++ b/server/s3_object_api_handler.cc
@@ -39,7 +39,7 @@
 #include "s3_stats.h"
 
 void S3ObjectAPIHandler::create_action() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "Operation code = %d\n", operation_code);
 
   switch (operation_code) {
@@ -203,5 +203,5 @@ void S3ObjectAPIHandler::create_action() {
       // should never be here.
       return;
   };  // switch operation_code
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_object_list_response.cc
+++ b/server/s3_object_list_response.cc
@@ -37,7 +37,7 @@ S3ObjectListResponse::S3ObjectListResponse(std::string encoding_type)
       next_marker_uploadid(""),
       key_count(""),
       response_xml("") {
-  s3_log(S3_LOG_DEBUG, "", "Constructor\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Ctor\n", __func__);
   object_list.clear();
   part_list.clear();
 }

--- a/server/s3_object_list_v2_response.cc
+++ b/server/s3_object_list_v2_response.cc
@@ -30,7 +30,7 @@ S3ObjectListResponseV2::S3ObjectListResponseV2(const std::string& encoding_type)
       start_after(""),
       response_v2_xml(""),
       cont_token_specified(false) {
-  s3_log(S3_LOG_DEBUG, "", "Constructor\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Ctor\n", __func__);
   s3_log(S3_LOG_DEBUG, "", "Encoding type = %s", encoding_type.c_str());
 }
 

--- a/server/s3_object_metadata.cc
+++ b/server/s3_object_metadata.cc
@@ -114,8 +114,8 @@ S3ObjectMetadata::S3ObjectMetadata(
 
   request = std::move(req);
   request_id = request->get_request_id();
-
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  stripped_request_id = request->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
   if (bucketname.empty()) {
     bucket_name = request->get_bucket_name();
@@ -321,7 +321,7 @@ void S3ObjectMetadata::validate() {
 
 void S3ObjectMetadata::load(std::function<void(void)> on_success,
                             std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   // object_list_index_oid should be set before using this method
   assert(object_list_index_oid.u_hi || object_list_index_oid.u_lo);
 
@@ -336,7 +336,7 @@ void S3ObjectMetadata::load(std::function<void(void)> on_success,
       object_list_index_oid, object_name,
       std::bind(&S3ObjectMetadata::load_successful, this),
       std::bind(&S3ObjectMetadata::load_failed, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3ObjectMetadata::load_successful() {
@@ -399,7 +399,7 @@ void S3ObjectMetadata::save(std::function<void(void)> on_success,
 
 // Save to objects version list index
 void S3ObjectMetadata::save_version_metadata() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   // objects_version_list_index_oid should be set before using this method
   assert(objects_version_list_index_oid.u_hi ||
          objects_version_list_index_oid.u_lo);
@@ -411,7 +411,7 @@ void S3ObjectMetadata::save_version_metadata() {
       this->version_entry_to_json(),
       std::bind(&S3ObjectMetadata::save_version_metadata_successful, this),
       std::bind(&S3ObjectMetadata::save_version_metadata_failed, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3ObjectMetadata::save_version_metadata_successful() {
@@ -433,7 +433,7 @@ void S3ObjectMetadata::save_version_metadata_failed() {
 }
 
 void S3ObjectMetadata::save_metadata() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   // object_list_index_oid should be set before using this method
   assert(object_list_index_oid.u_hi || object_list_index_oid.u_lo);
 
@@ -443,17 +443,17 @@ void S3ObjectMetadata::save_metadata() {
       object_list_index_oid, object_name, this->to_json(),
       std::bind(&S3ObjectMetadata::save_metadata_successful, this),
       std::bind(&S3ObjectMetadata::save_metadata_failed, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 // Save to objects list index
 void S3ObjectMetadata::save_metadata(std::function<void(void)> on_success,
                                      std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   this->handler_on_success = on_success;
   this->handler_on_failed = on_failed;
   save_metadata();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3ObjectMetadata::save_metadata_successful() {
@@ -486,7 +486,7 @@ void S3ObjectMetadata::remove(std::function<void(void)> on_success,
 }
 
 void S3ObjectMetadata::remove_object_metadata() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   // object_list_index_oid should be set before using this method
   assert(object_list_index_oid.u_hi || object_list_index_oid.u_lo);
 
@@ -533,7 +533,7 @@ void S3ObjectMetadata::remove_version_metadata(
 }
 
 void S3ObjectMetadata::remove_version_metadata() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   // objects_version_list_index_oid should be set before using this method
   assert(objects_version_list_index_oid.u_hi ||
          objects_version_list_index_oid.u_lo);
@@ -750,7 +750,7 @@ void S3ObjectMetadata::delete_object_tags() { object_tags.clear(); }
 
 std::string S3ObjectMetadata::get_tags_as_xml() {
 
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   std::string user_defined_tags;
   std::string tags_as_xml_str;
 
@@ -768,7 +768,7 @@ std::string S3ObjectMetadata::get_tags_as_xml() {
       "</TagSet>"
       "</Tagging>";
   s3_log(S3_LOG_DEBUG, request_id, "Tags xml: %s\n", tags_as_xml_str.c_str());
-  s3_log(S3_LOG_INFO, request_id, "Exiting\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Exit", __func__);
   return tags_as_xml_str;
 }
 

--- a/server/s3_object_metadata.h
+++ b/server/s3_object_metadata.h
@@ -57,6 +57,7 @@ class S3ObjectMetadataCopyable {
   int layout_id = 0;
 
   std::string request_id;
+  std::string stripped_request_id;
   std::string encoded_acl;
 
   std::map<std::string, std::string> system_defined_attribute;

--- a/server/s3_part_metadata.cc
+++ b/server/s3_part_metadata.cc
@@ -67,7 +67,8 @@ S3PartMetadata::S3PartMetadata(
     std::shared_ptr<S3MotrKVSWriterFactory> kv_writer_factory)
     : request(req) {
   request_id = request->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  stripped_request_id = request->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   initialize(uploadid, part_num);
   part_index_name_oid = {0ULL, 0ULL};
 
@@ -91,7 +92,8 @@ S3PartMetadata::S3PartMetadata(
     std::shared_ptr<S3MotrKVSWriterFactory> kv_writer_factory)
     : request(req) {
   request_id = request->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  stripped_request_id = request->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   initialize(uploadid, part_num);
   part_index_name_oid = oid;
 
@@ -174,7 +176,7 @@ void S3PartMetadata::add_user_defined_attribute(std::string key,
 void S3PartMetadata::load(std::function<void(void)> on_success,
                           std::function<void(void)> on_failed,
                           int part_num = 1) {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   str_part_num = "";
   if (part_num > 0) {
     str_part_num = std::to_string(part_num);
@@ -188,7 +190,7 @@ void S3PartMetadata::load(std::function<void(void)> on_success,
   motr_kv_reader->get_keyval(part_index_name_oid, str_part_num,
                              std::bind(&S3PartMetadata::load_successful, this),
                              std::bind(&S3PartMetadata::load_failed, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PartMetadata::load_successful() {
@@ -224,27 +226,27 @@ void S3PartMetadata::load_failed() {
 
 void S3PartMetadata::create_index(std::function<void(void)> on_success,
                                   std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   this->handler_on_success = on_success;
   this->handler_on_failed = on_failed;
   put_metadata = false;
   create_part_index();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PartMetadata::save(std::function<void(void)> on_success,
                           std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
 
   this->handler_on_success = on_success;
   this->handler_on_failed = on_failed;
   put_metadata = true;
   save_metadata();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PartMetadata::create_part_index() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   // Mark missing as we initiate write, in case it fails to write.
   state = S3PartMetadataState::missing;
 
@@ -255,7 +257,7 @@ void S3PartMetadata::create_part_index() {
       index_name,
       std::bind(&S3PartMetadata::create_part_index_successful, this),
       std::bind(&S3PartMetadata::create_part_index_failed, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PartMetadata::create_part_index_successful() {
@@ -289,7 +291,7 @@ void S3PartMetadata::create_part_index_failed() {
 }
 
 void S3PartMetadata::save_metadata() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   // Set up system attributes
   system_defined_attribute["Upload-ID"] = upload_id;
   if (!motr_kv_writer) {
@@ -300,7 +302,7 @@ void S3PartMetadata::save_metadata() {
       part_index_name_oid, part_number, this->to_json(),
       std::bind(&S3PartMetadata::save_metadata_successful, this),
       std::bind(&S3PartMetadata::save_metadata_failed, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PartMetadata::save_metadata_successful() {
@@ -323,7 +325,7 @@ void S3PartMetadata::save_metadata_failed() {
 void S3PartMetadata::remove(std::function<void(void)> on_success,
                             std::function<void(void)> on_failed,
                             int remove_part = 0) {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   std::string part_removal = std::to_string(remove_part);
 
   this->handler_on_success = on_success;
@@ -340,7 +342,7 @@ void S3PartMetadata::remove(std::function<void(void)> on_success,
       part_index_name_oid, part_removal,
       std::bind(&S3PartMetadata::remove_successful, this),
       std::bind(&S3PartMetadata::remove_failed, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PartMetadata::remove_successful() {
@@ -361,7 +363,7 @@ void S3PartMetadata::remove_failed() {
 
 void S3PartMetadata::remove_index(std::function<void(void)> on_success,
                                   std::function<void(void)> on_failed) {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
 
   this->handler_on_success = on_success;
   this->handler_on_failed = on_failed;
@@ -373,7 +375,7 @@ void S3PartMetadata::remove_index(std::function<void(void)> on_success,
       part_index_name_oid,
       std::bind(&S3PartMetadata::remove_index_successful, this),
       std::bind(&S3PartMetadata::remove_index_failed, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PartMetadata::remove_index_successful() {
@@ -449,13 +451,13 @@ void S3PartMetadata::regenerate_new_indexname() {
 
 void S3PartMetadata::handle_collision() {
   if (collision_attempt_count < MAX_COLLISION_RETRY_COUNT) {
-    s3_log(S3_LOG_INFO, request_id,
+    s3_log(S3_LOG_INFO, stripped_request_id,
            "Object ID collision happened for index %s\n", index_name.c_str());
     // Handle Collision
     regenerate_new_indexname();
     collision_attempt_count++;
     if (collision_attempt_count > 5) {
-      s3_log(S3_LOG_INFO, request_id,
+      s3_log(S3_LOG_INFO, stripped_request_id,
              "Object ID collision happened %zu times for index %s\n",
              collision_attempt_count, index_name.c_str());
     }

--- a/server/s3_part_metadata.h
+++ b/server/s3_part_metadata.h
@@ -68,6 +68,7 @@ class S3PartMetadata {
   std::string str_part_num;
 
   std::string request_id;
+  std::string stripped_request_id;
 
   std::map<std::string, std::string> system_defined_attribute;
   std::map<std::string, std::string> user_defined_attribute;

--- a/server/s3_perf_metrics.cc
+++ b/server/s3_perf_metrics.cc
@@ -84,7 +84,7 @@ int s3_perf_metrics_init(evbase_t *evbase) {
   if (!g_option_instance->is_stats_enabled()) {
     return 0;
   }
-  s3_log(S3_LOG_DEBUG, "", "Entering");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry", __func__);
 
   AtExit call_fini([]() { s3_perf_metrics_fini(); });
 
@@ -121,7 +121,7 @@ void s3_perf_metrics_fini() {
   if (!g_option_instance->is_stats_enabled()) {
     return;
   }
-  s3_log(S3_LOG_DEBUG, "", "Entering");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry", __func__);
   if (gs_throughput_event) {
     gs_throughput_event->del_evtimer();
     gs_throughput_event.reset();
@@ -135,7 +135,8 @@ void s3_perf_count_incoming_bytes(int byte_count) {
   if (!g_option_instance->is_stats_enabled()) {
     return;
   }
-  s3_log(S3_LOG_DEBUG, "", "Entering with byte_count = %d", byte_count);
+  s3_log(S3_LOG_DEBUG, "", "%s Entry with byte_count = %d", __func__,
+         byte_count);
   if (gs_throughput_event) {
     gs_throughput_event->more_bytes_in(byte_count);
   }
@@ -145,7 +146,8 @@ void s3_perf_count_outcoming_bytes(int byte_count) {
   if (!g_option_instance->is_stats_enabled()) {
     return;
   }
-  s3_log(S3_LOG_DEBUG, "", "Entering with byte_count = %d", byte_count);
+  s3_log(S3_LOG_DEBUG, "", "%s Entry with byte_count = %d", __func__,
+         byte_count);
   if (gs_throughput_event) {
     gs_throughput_event->more_bytes_out(byte_count);
   }

--- a/server/s3_post_complete_action.cc
+++ b/server/s3_post_complete_action.cc
@@ -44,13 +44,13 @@ S3PostCompleteAction::S3PostCompleteAction(
     std::shared_ptr<S3MotrKVSWriterFactory> kv_writer_factory)
     : S3ObjectAction(std::move(req), std::move(bucket_meta_factory),
                      std::move(object_meta_factory), false) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
   upload_id = request->get_query_string_value("uploadId");
   bucket_name = request->get_bucket_name();
   object_name = request->get_object_name();
 
-  s3_log(S3_LOG_INFO, request_id,
+  s3_log(S3_LOG_INFO, stripped_request_id,
          "S3 API: Complete Multipart Upload. Bucket[%s] Object[%s]\
          for UploadId[%s]\n",
          bucket_name.c_str(), object_name.c_str(), upload_id.c_str());
@@ -116,13 +116,13 @@ void S3PostCompleteAction::setup_steps() {
 }
 
 void S3PostCompleteAction::fetch_bucket_info_success() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_post_complete_action_state = S3PostCompleteActionState::validationFailed;
   if (bucket_metadata->get_state() == S3BucketMetadataState::missing) {
     set_s3_error("NoSuchBucket");
@@ -138,13 +138,13 @@ void S3PostCompleteAction::fetch_bucket_info_failed() {
 }
 
 void S3PostCompleteAction::fetch_object_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::load_and_validate_request() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (request->get_data_length() > 0) {
     if (request->has_all_body_content()) {
       if (validate_request_body(request->get_full_body_content_as_string())) {
@@ -172,11 +172,11 @@ void S3PostCompleteAction::load_and_validate_request() {
     send_response_to_s3_client();
     return;
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::consume_incoming_content() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (request->is_s3_client_read_error()) {
     s3_post_complete_action_state = S3PostCompleteActionState::validationFailed;
     client_read_error();
@@ -195,11 +195,11 @@ void S3PostCompleteAction::consume_incoming_content() {
     // else just wait till entire body arrives. rare.
     request->resume();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::fetch_multipart_info() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   multipart_index_oid = bucket_metadata->get_multipart_index_oid();
   multipart_metadata =
@@ -212,7 +212,7 @@ void S3PostCompleteAction::fetch_multipart_info() {
       std::bind(&S3PostCompleteAction::fetch_multipart_info_success, this),
       std::bind(&S3PostCompleteAction::fetch_multipart_info_failed, this));
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::fetch_multipart_info_success() {
@@ -247,7 +247,7 @@ void S3PostCompleteAction::fetch_multipart_info_failed() {
 }
 
 void S3PostCompleteAction::get_next_parts_info() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "Fetching parts list from KV store\n");
   motr_kv_reader =
       s3_motr_kvs_reader_factory->create_motr_kvs_reader(request, s3_motr_api);
@@ -258,7 +258,8 @@ void S3PostCompleteAction::get_next_parts_info() {
 }
 
 void S3PostCompleteAction::get_next_parts_info_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering with size %d while requested %d\n",
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "%s Entry with size %d while requested %d\n", __func__,
          (int)motr_kv_reader->get_key_values().size(), (int)count_we_requested);
   if (motr_kv_reader->get_key_values().size() > 0) {
     // Do validation of parts
@@ -350,7 +351,7 @@ bool S3PostCompleteAction::is_abort_multipart() {
 }
 
 bool S3PostCompleteAction::validate_parts() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   size_t part_one_size_in_multipart_metadata =
       multipart_metadata->get_part_one_size();
   if (part_metadata == NULL) {
@@ -466,12 +467,12 @@ bool S3PostCompleteAction::validate_parts() {
       part_kv = parts.erase(part_kv);
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return true;
 }
 
 void S3PostCompleteAction::add_object_oid_to_probable_dead_oid_list() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   new_object_metadata = object_metadata_factory->create_object_metadata_obj(
       request, bucket_metadata->get_object_list_index_oid());
@@ -567,19 +568,19 @@ void S3PostCompleteAction::add_object_oid_to_probable_dead_oid_list() {
       next();
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::add_object_oid_to_probable_dead_oid_list_success() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_post_complete_action_state =
       S3PostCompleteActionState::probableEntryRecordSaved;
   next();
-  s3_log(S3_LOG_INFO, "", "Exiting\n");
+  s3_log(S3_LOG_INFO, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::add_object_oid_to_probable_dead_oid_list_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_post_complete_action_state =
       S3PostCompleteActionState::probableEntryRecordFailed;
   if (motr_kv_writer->get_state() == S3MotrKVSWriterOpState::failed_to_launch) {
@@ -588,11 +589,11 @@ void S3PostCompleteAction::add_object_oid_to_probable_dead_oid_list_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::save_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (is_abort_multipart()) {
     next();
   } else {
@@ -614,69 +615,69 @@ void S3PostCompleteAction::save_metadata() {
         std::bind(&S3PostCompleteAction::save_object_metadata_succesful, this),
         std::bind(&S3PostCompleteAction::save_object_metadata_failed, this));
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::save_object_metadata_succesful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   obj_metadata_updated = true;
   s3_post_complete_action_state = S3PostCompleteActionState::metadataSaved;
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::save_object_metadata_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_post_complete_action_state = S3PostCompleteActionState::metadataSaveFailed;
   if (new_object_metadata->get_state() ==
       S3ObjectMetadataState::failed_to_launch) {
     set_s3_error("ServiceUnavailable");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::delete_multipart_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   multipart_metadata->remove(
       std::bind(&S3PostCompleteAction::delete_multipart_metadata_success, this),
       std::bind(&S3PostCompleteAction::delete_multipart_metadata_failed, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::delete_multipart_metadata_success() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (is_abort_multipart()) {
     s3_post_complete_action_state =
         S3PostCompleteActionState::abortedSinceValidationFailed;
   }
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 // TODO - mark this for cleanup by backgrounddelete on failure??
 void S3PostCompleteAction::delete_multipart_metadata_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // S3 backgrounddelete should delete KV from multi part index
   s3_log(S3_LOG_ERROR, request_id,
          "Deletion of %s key failed from multipart index\n",
          object_name.c_str());
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 // TODO - mark this for cleanup by backgrounddelete on failure??
 void S3PostCompleteAction::delete_part_list_index() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   part_metadata->remove_index(
       std::bind(&S3PostCompleteAction::next, this),
       std::bind(&S3PostCompleteAction::delete_part_list_index_failed, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::delete_part_list_index_failed() {
   m0_uint128 part_index_oid;
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   part_index_oid = part_metadata->get_part_index_oid();
   // S3 backgrounddelete should cleanup/remove part index
   s3_log(S3_LOG_ERROR, request_id,
@@ -684,11 +685,11 @@ void S3PostCompleteAction::delete_part_list_index_failed() {
          "%" SCNx64 " : %" SCNx64 "\n",
          part_index_oid.u_hi, part_index_oid.u_lo);
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 bool S3PostCompleteAction::validate_request_body(std::string& xml_str) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   xmlNode* child_node;
   xmlChar* xml_part_number;
@@ -773,7 +774,7 @@ bool S3PostCompleteAction::validate_request_body(std::string& xml_str) {
 }
 
 void S3PostCompleteAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (is_error_state() && !get_s3_error_code().empty()) {
     S3Error error(get_s3_error_code(), request->get_request_id(),
@@ -822,11 +823,11 @@ void S3PostCompleteAction::send_response_to_s3_client() {
   }
   request->resume(false);
   startcleanup();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::startcleanup() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // Clear task list and setup cleanup task list
   clear_tasks();
   cleanup_started = true;
@@ -874,11 +875,11 @@ void S3PostCompleteAction::startcleanup() {
   }
   // Start running the cleanup task list
   start();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::mark_old_oid_for_deletion() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   assert(!old_oid_str.empty());
   assert(!new_oid_str.empty());
 
@@ -896,7 +897,7 @@ void S3PostCompleteAction::mark_old_oid_for_deletion() {
                              old_oid_rec_key, old_probable_del_rec->to_json(),
                              std::bind(&S3PostCompleteAction::next, this),
                              std::bind(&S3PostCompleteAction::next, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::delete_old_object() {
@@ -910,7 +911,7 @@ void S3PostCompleteAction::delete_old_object() {
   // If old object exists and deletion of old is disabled, then return
   if ((old_object_oid.u_hi || old_object_oid.u_lo) &&
       S3Option::get_instance()->is_s3server_obj_delayed_del_enabled()) {
-    s3_log(S3_LOG_INFO, request_id,
+    s3_log(S3_LOG_INFO, stripped_request_id,
            "Skipping deletion of old object. The old object will be deleted by "
            "BD.\n");
     // Call next task in the pipeline
@@ -922,11 +923,11 @@ void S3PostCompleteAction::delete_old_object() {
       std::bind(&S3PostCompleteAction::remove_old_object_version_metadata,
                 this),
       std::bind(&S3PostCompleteAction::next, this), old_layout_id);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::remove_old_object_version_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   object_metadata = object_metadata_factory->create_object_metadata_obj(
       request, bucket_metadata->get_object_list_index_oid());
@@ -941,11 +942,11 @@ void S3PostCompleteAction::remove_old_object_version_metadata() {
   object_metadata->remove_version_metadata(
       std::bind(&S3PostCompleteAction::remove_old_oid_probable_record, this),
       std::bind(&S3PostCompleteAction::next, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::remove_old_oid_probable_record() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   assert(!old_oid_str.empty());
   assert(!new_oid_str.empty());
 
@@ -960,11 +961,11 @@ void S3PostCompleteAction::remove_old_oid_probable_record() {
                                 old_oid_rec_key,
                                 std::bind(&S3PostCompleteAction::next, this),
                                 std::bind(&S3PostCompleteAction::next, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::mark_new_oid_for_deletion() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   assert(!new_oid_str.empty());
   assert(is_abort_multipart());
 
@@ -979,11 +980,11 @@ void S3PostCompleteAction::mark_new_oid_for_deletion() {
                              new_oid_str, new_probable_del_rec->to_json(),
                              std::bind(&S3PostCompleteAction::next, this),
                              std::bind(&S3PostCompleteAction::next, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::delete_new_object() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   assert(new_object_oid.u_hi || new_object_oid.u_lo);
   assert(is_abort_multipart());
 
@@ -996,11 +997,11 @@ void S3PostCompleteAction::delete_new_object() {
   motr_writer->delete_object(
       std::bind(&S3PostCompleteAction::remove_new_oid_probable_record, this),
       std::bind(&S3PostCompleteAction::next, this), layout_id);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::remove_new_oid_probable_record() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   assert(!new_oid_str.empty());
 
   if (!motr_kv_writer) {
@@ -1011,13 +1012,13 @@ void S3PostCompleteAction::remove_new_oid_probable_record() {
                                 new_oid_str,
                                 std::bind(&S3PostCompleteAction::next, this),
                                 std::bind(&S3PostCompleteAction::next, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::set_authorization_meta() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   auth_client->set_acl_and_policy(bucket_metadata->get_encoded_bucket_acl(),
                                   bucket_metadata->get_policy_as_json());
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_post_multipartobject_action.cc
+++ b/server/s3_post_multipartobject_action.cc
@@ -45,9 +45,9 @@ S3PostMultipartObjectAction::S3PostMultipartObjectAction(
     std::shared_ptr<S3MotrKVSWriterFactory> kv_writer_factory)
     : S3ObjectAction(std::move(req), std::move(bucket_meta_factory),
                      std::move(object_meta_factory)) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
-  s3_log(S3_LOG_INFO, request_id,
+  s3_log(S3_LOG_INFO, stripped_request_id,
          "S3 API: Initiate Multipart Upload. Bucket[%s]\
          Object[%s]\n",
          request->get_bucket_name().c_str(),
@@ -129,7 +129,7 @@ void S3PostMultipartObjectAction::setup_steps() {
 }
 void S3PostMultipartObjectAction::fetch_object_info_failed() { next(); }
 void S3PostMultipartObjectAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (bucket_metadata->get_state() == S3BucketMetadataState::missing) {
     s3_log(S3_LOG_DEBUG, request_id, "Bucket not found\n");
@@ -144,12 +144,12 @@ void S3PostMultipartObjectAction::fetch_bucket_info_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 void S3PostMultipartObjectAction::fetch_object_info_success() { next(); }
 
 void S3PostMultipartObjectAction::validate_x_amz_tagging_if_present() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   std::string new_object_tags = request->get_header_value("x-amz-tagging");
   s3_log(S3_LOG_DEBUG, request_id, "Received tags= %s\n",
          new_object_tags.c_str());
@@ -163,7 +163,7 @@ void S3PostMultipartObjectAction::validate_x_amz_tagging_if_present() {
 
 void S3PostMultipartObjectAction::parse_x_amz_tagging_header(
     std::string content) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   struct evkeyvalq key_value;
   memset(&key_value, 0, sizeof(key_value));
   if (0 == evhttp_parse_query_str(content.c_str(), &key_value)) {
@@ -182,11 +182,11 @@ void S3PostMultipartObjectAction::parse_x_amz_tagging_header(
     set_s3_error("InvalidTagError");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostMultipartObjectAction::validate_tags() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   std::string xml;
   std::shared_ptr<S3PutTagBody> put_object_tag_body =
       put_object_tag_body_factory->create_put_resource_tags_body(xml,
@@ -198,11 +198,11 @@ void S3PostMultipartObjectAction::validate_tags() {
     set_s3_error("InvalidTagError");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostMultipartObjectAction::check_upload_is_inprogress() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::present) {
     S3Uuid uuid;
     upload_id = uuid.get_string_uuid();
@@ -234,11 +234,11 @@ void S3PostMultipartObjectAction::check_upload_is_inprogress() {
     assert(false);
     s3_log(S3_LOG_ERROR, request_id, "Bug: Report issue to Support team.\n");
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostMultipartObjectAction::check_multipart_object_info_status() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (object_multipart_metadata->get_state() !=
       S3ObjectMetadataState::present) {
     if (object_multipart_metadata->get_state() ==
@@ -248,7 +248,7 @@ void S3PostMultipartObjectAction::check_multipart_object_info_status() {
           "Object metadata load operation failed due to pre launch failure\n");
       set_s3_error("ServiceUnavailable");
       send_response_to_s3_client();
-      s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+      s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
       return;
     }
     // Multipart upload not in progress for this object_name
@@ -281,11 +281,11 @@ void S3PostMultipartObjectAction::check_multipart_object_info_status() {
     set_s3_error("InvalidObjectState");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostMultipartObjectAction::check_object_state() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   S3ObjectMetadataState object_state = object_metadata->get_state();
   if (object_state == S3ObjectMetadataState::present) {
     s3_log(S3_LOG_DEBUG, request_id, "S3ObjectMetadataState::present\n");
@@ -311,11 +311,11 @@ void S3PostMultipartObjectAction::check_object_state() {
     set_s3_error("InternalError");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostMultipartObjectAction::create_object() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   create_object_timer.start();
   if (tried_count == 0) {
     motr_writer = motr_writer_factory->create_motr_writer(request, oid);
@@ -331,11 +331,11 @@ void S3PostMultipartObjectAction::create_object() {
   // for shutdown testcases, check FI and set shutdown signal
   S3_CHECK_FI_AND_SET_SHUTDOWN_SIGNAL(
       "post_multipartobject_action_create_object_shutdown_fail");
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostMultipartObjectAction::create_object_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   create_object_timer.stop();
   const size_t time_in_millisecond =
       create_object_timer.elapsed_time_in_millisec();
@@ -346,11 +346,11 @@ void S3PostMultipartObjectAction::create_object_successful() {
   add_task_rollback(
       std::bind(&S3PostMultipartObjectAction::rollback_create, this));
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostMultipartObjectAction::create_object_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   create_object_timer.stop();
   LOG_PERF("create_object_failed_ms", request_id.c_str(),
@@ -359,7 +359,7 @@ void S3PostMultipartObjectAction::create_object_failed() {
                   create_object_timer.elapsed_time_in_millisec());
 
   if (check_shutdown_and_rollback()) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
 
@@ -375,23 +375,24 @@ void S3PostMultipartObjectAction::create_object_failed() {
     set_s3_error("InternalError");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostMultipartObjectAction::collision_occured() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (check_shutdown_and_rollback()) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   if (tried_count < MAX_COLLISION_RETRY_COUNT) {
-    s3_log(S3_LOG_INFO, request_id, "Object ID collision happened for uri %s\n",
+    s3_log(S3_LOG_INFO, stripped_request_id,
+           "Object ID collision happened for uri %s\n",
            request->get_object_uri().c_str());
     // Handle Collision
     create_new_oid(oid);
     tried_count++;
     if (tried_count > 5) {
-      s3_log(S3_LOG_INFO, request_id,
+      s3_log(S3_LOG_INFO, stripped_request_id,
              "Object ID collision happened %d times for uri %s\n", tried_count,
              request->get_object_uri().c_str());
     }
@@ -425,7 +426,7 @@ void S3PostMultipartObjectAction::create_new_oid(
 }
 
 void S3PostMultipartObjectAction::create_part_meta_index() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   part_metadata =
       part_metadata_factory->create_part_metadata_obj(request, upload_id, 0);
@@ -434,42 +435,42 @@ void S3PostMultipartObjectAction::create_part_meta_index() {
                 this),
       std::bind(&S3PostMultipartObjectAction::create_part_meta_index_failed,
                 this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostMultipartObjectAction::create_part_meta_index_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   object_multipart_metadata->set_part_index_oid(
       part_metadata->get_part_index_oid());
   add_task_rollback(std::bind(
       &S3PostMultipartObjectAction::rollback_create_part_meta_index, this));
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostMultipartObjectAction::create_part_meta_index_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (part_metadata->get_state() == S3PartMetadataState::failed_to_launch) {
     s3_log(S3_LOG_WARN, request_id, "Multipart index creation failed\n");
     set_s3_error("ServiceUnavailable");
   }
   // Clean up will be done after response.
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostMultipartObjectAction::rollback_create() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   motr_writer->set_oid(oid);
   motr_writer->delete_object(
       std::bind(&S3PostMultipartObjectAction::rollback_next, this),
       std::bind(&S3PostMultipartObjectAction::rollback_create_failed, this),
       layout_id);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostMultipartObjectAction::rollback_create_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (motr_writer->get_state() != S3MotrWiterOpState::missing) {
     s3_log(S3_LOG_ERROR, request_id,
            "Deletion of object failed, this oid will be stale in Motr: "
@@ -479,21 +480,21 @@ void S3PostMultipartObjectAction::rollback_create_failed() {
            S3_IEM_DELETE_OBJ_FAIL_JSON);
   }
   rollback_next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostMultipartObjectAction::rollback_create_part_meta_index() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   part_metadata->remove_index(
       std::bind(&S3PostMultipartObjectAction::rollback_next, this),
       std::bind(
           &S3PostMultipartObjectAction::rollback_create_part_meta_index_failed,
           this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostMultipartObjectAction::rollback_create_part_meta_index_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   m0_uint128 part_index_oid = part_metadata->get_part_index_oid();
   s3_log(S3_LOG_ERROR, request_id,
          "Deletion of index failed, this oid will be stale in Motr"
@@ -502,11 +503,11 @@ void S3PostMultipartObjectAction::rollback_create_part_meta_index_failed() {
   s3_iem(LOG_ERR, S3_IEM_DELETE_IDX_FAIL, S3_IEM_DELETE_IDX_FAIL_STR,
          S3_IEM_DELETE_IDX_FAIL_JSON);
   rollback_next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostMultipartObjectAction::save_upload_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   object_multipart_metadata->set_layout_id(layout_id);
 
@@ -534,11 +535,11 @@ void S3PostMultipartObjectAction::save_upload_metadata() {
   // for shutdown testcases, check FI and set shutdown signal
   S3_CHECK_FI_AND_SET_SHUTDOWN_SIGNAL(
       "post_multipartobject_action_save_upload_metadata_shutdown_fail");
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostMultipartObjectAction::save_upload_metadata_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (object_multipart_metadata->get_state() ==
       S3ObjectMetadataState::failed_to_launch) {
     s3_log(S3_LOG_WARN, request_id, "save upload index metadata failed\n");
@@ -548,11 +549,11 @@ void S3PostMultipartObjectAction::save_upload_metadata_failed() {
   }
   // Clean up will be done after response.
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostMultipartObjectAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (S3Option::get_instance()->is_getoid_enabled()) {
 
@@ -599,12 +600,12 @@ void S3PostMultipartObjectAction::send_response_to_s3_client() {
 
   S3_RESET_SHUTDOWN_SIGNAL;  // for shutdown testcases
   startcleanup();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostMultipartObjectAction::startcleanup() {
   // Clean up utilizes rollback task list
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (object_multipart_metadata &&
       object_multipart_metadata->get_state() == S3ObjectMetadataState::saved) {
     assert(!is_error_state() && get_s3_error_code().empty());
@@ -616,9 +617,9 @@ void S3PostMultipartObjectAction::startcleanup() {
 }
 
 void S3PostMultipartObjectAction::set_authorization_meta() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   auth_client->set_acl_and_policy(bucket_metadata->get_encoded_bucket_acl(),
                                   bucket_metadata->get_policy_as_json());
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_post_to_main_loop.cc
+++ b/server/s3_post_to_main_loop.cc
@@ -23,7 +23,7 @@
 
 void S3PostToMainLoop::operator()(user_event_on_main_loop callback,
                                   const std::string &request_id) {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   struct event *ev_user = NULL;
   struct user_event_context *user_context =
       (struct user_event_context *)context;
@@ -40,5 +40,5 @@ void S3PostToMainLoop::operator()(user_event_on_main_loop callback,
   user_context->user_event =
       (void *)ev_user;  // remember so we can free this event.
   event_active(ev_user, EV_READ | EV_WRITE | EV_TIMEOUT, 1);
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }

--- a/server/s3_post_to_main_loop.h
+++ b/server/s3_post_to_main_loop.h
@@ -43,7 +43,7 @@ class S3PostToMainLoop {
 
  public:
   S3PostToMainLoop(void *ctx) : context(ctx) {
-    s3_log(S3_LOG_DEBUG, "", "Constructor\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Ctor\n", __func__);
   }
 
   void operator()(user_event_on_main_loop callback,

--- a/server/s3_put_bucket_action.cc
+++ b/server/s3_put_bucket_action.cc
@@ -29,9 +29,9 @@ S3PutBucketAction::S3PutBucketAction(
     std::shared_ptr<S3BucketMetadataFactory> bucket_meta_factory,
     std::shared_ptr<S3PutBucketBodyFactory> bucket_body_factory)
     : S3Action(std::move(req)) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
-  s3_log(S3_LOG_INFO, request_id, "S3 API: Put Bucket. Bucket[%s]\n",
+  s3_log(S3_LOG_INFO, stripped_request_id, "S3 API: Put Bucket. Bucket[%s]\n",
          request->get_bucket_name().c_str());
 
   if (bucket_meta_factory) {
@@ -58,7 +58,7 @@ void S3PutBucketAction::setup_steps() {
 }
 
 void S3PutBucketAction::validate_request() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (!is_authorizationheader_present) {
     set_s3_error("AccessDenied");
@@ -78,7 +78,7 @@ void S3PutBucketAction::validate_request() {
     // for shutdown testcases, check FI and set shutdown signal
     S3_CHECK_FI_AND_SET_SHUTDOWN_SIGNAL(
         "put_bucket_action_validate_request_shutdown_fail");
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   }
 }
 
@@ -95,7 +95,7 @@ void S3PutBucketAction::consume_incoming_content() {
 }
 
 void S3PutBucketAction::validate_request_body(std::string content) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // S3PutBucketBody bucket(content);
   put_bucket_body = put_bucketbody_factory->create_put_bucket_body(content);
   if (put_bucket_body->isOK()) {
@@ -106,11 +106,11 @@ void S3PutBucketAction::validate_request_body(std::string content) {
     set_s3_error("MalformedXML");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutBucketAction::validate_bucket_name() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   // get bucket name
   std::string bucket_name = request->get_bucket_name();
@@ -213,21 +213,21 @@ void S3PutBucketAction::validate_bucket_name() {
   } else {
     next();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutBucketAction::read_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // Trigger metadata read async operation with callback
   bucket_metadata =
       bucket_metadata_factory->create_bucket_metadata_obj(request);
   bucket_metadata->load(std::bind(&S3PutBucketAction::next, this),
                         std::bind(&S3PutBucketAction::next, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutBucketAction::create_bucket() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   // Trigger metadata write async operation with callback
   // XXX Check if last step was successful.
@@ -262,11 +262,11 @@ void S3PutBucketAction::create_bucket() {
     set_s3_error("InternalError");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutBucketAction::create_bucket_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::failed_to_launch) {
     s3_log(S3_LOG_ERROR, request_id,
            "Save bucket metadata operation failed due to prelaunch failure\n");
@@ -276,11 +276,11 @@ void S3PutBucketAction::create_bucket_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutBucketAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -302,5 +302,5 @@ void S3PutBucketAction::send_response_to_s3_client() {
   }
   S3_RESET_SHUTDOWN_SIGNAL;  // for shutdown testcases
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_put_bucket_body.cc
+++ b/server/s3_put_bucket_body.cc
@@ -26,7 +26,7 @@
 
 S3PutBucketBody::S3PutBucketBody(std::string &xml)
     : xml_content(xml), is_valid(false) {
-  s3_log(S3_LOG_DEBUG, "", "Constructor\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Ctor\n", __func__);
   parse_and_validate();
 }
 

--- a/server/s3_put_bucket_tagging_action.cc
+++ b/server/s3_put_bucket_tagging_action.cc
@@ -27,9 +27,10 @@ S3PutBucketTaggingAction::S3PutBucketTaggingAction(
     std::shared_ptr<S3BucketMetadataFactory> bucket_meta_factory,
     std::shared_ptr<S3PutTagsBodyFactory> bucket_body_factory)
     : S3BucketAction(std::move(req), std::move(bucket_meta_factory)) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
-  s3_log(S3_LOG_INFO, request_id, "S3 API: Put Bucket Tagging. Bucket[%s]\n",
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "S3 API: Put Bucket Tagging. Bucket[%s]\n",
          request->get_bucket_name().c_str());
 
   if (bucket_body_factory) {
@@ -50,7 +51,7 @@ void S3PutBucketTaggingAction::setup_steps() {
 }
 
 void S3PutBucketTaggingAction::validate_request() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (request->has_all_body_content()) {
     new_bucket_tags = request->get_full_body_content_as_string();
@@ -62,11 +63,11 @@ void S3PutBucketTaggingAction::validate_request() {
         request->get_data_length() /* we ask for all */
         );
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutBucketTaggingAction::consume_incoming_content() {
-  s3_log(S3_LOG_INFO, request_id, "Consume data\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "Consume data\n");
   if (request->is_s3_client_read_error()) {
     client_read_error();
   } else if (request->has_all_body_content()) {
@@ -79,7 +80,7 @@ void S3PutBucketTaggingAction::consume_incoming_content() {
 }
 
 void S3PutBucketTaggingAction::validate_request_body(std::string content) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   put_bucket_tag_body =
       put_bucket_tag_body_factory->create_put_resource_tags_body(content,
                                                                  request_id);
@@ -90,11 +91,11 @@ void S3PutBucketTaggingAction::validate_request_body(std::string content) {
     set_s3_error("MalformedXML");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutBucketTaggingAction::validate_request_xml_tags() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
 
   if (put_bucket_tag_body->validate_bucket_xml_tags(bucket_tags_map)) {
     next();
@@ -102,11 +103,11 @@ void S3PutBucketTaggingAction::validate_request_xml_tags() {
     set_s3_error("InvalidTagError");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutBucketTaggingAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::missing) {
     set_s3_error("NoSuchBucket");
   } else if (bucket_metadata->get_state() ==
@@ -118,11 +119,11 @@ void S3PutBucketTaggingAction::fetch_bucket_info_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutBucketTaggingAction::save_tags_to_bucket_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::present) {
     s3_log(S3_LOG_DEBUG, request_id, "Setting bucket tags =%s\n",
            new_bucket_tags.c_str());
@@ -135,11 +136,11 @@ void S3PutBucketTaggingAction::save_tags_to_bucket_metadata() {
             &S3PutBucketTaggingAction::save_tags_to_bucket_metadata_failed,
             this));
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutBucketTaggingAction::save_tags_to_bucket_metadata_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::failed_to_launch) {
     s3_log(S3_LOG_ERROR, request_id,
            "Save Bucket metadata operation failed due to prelaunch failure\n");
@@ -149,11 +150,11 @@ void S3PutBucketTaggingAction::save_tags_to_bucket_metadata_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutBucketTaggingAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -174,5 +175,5 @@ void S3PutBucketTaggingAction::send_response_to_s3_client() {
 
   S3_RESET_SHUTDOWN_SIGNAL;  // for shutdown testcases
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_put_chunk_upload_object_action.cc
+++ b/server/s3_put_chunk_upload_object_action.cc
@@ -52,9 +52,9 @@ S3PutChunkUploadObjectAction::S3PutChunkUploadObjectAction(
       motr_write_completed(false),
       auth_in_progress(false),
       auth_completed(false) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
-  s3_log(S3_LOG_INFO, request_id,
+  s3_log(S3_LOG_INFO, stripped_request_id,
          "S3 API: Put Object (Chunk mode). Bucket[%s]\
          Object[%s]\n",
          request->get_bucket_name().c_str(),
@@ -122,11 +122,11 @@ void S3PutChunkUploadObjectAction::setup_steps() {
 }
 
 void S3PutChunkUploadObjectAction::chunk_auth_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   auth_in_progress = false;
   auth_completed = true;
   if (check_shutdown_and_rollback(true)) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   if (motr_write_completed) {
@@ -144,7 +144,7 @@ void S3PutChunkUploadObjectAction::chunk_auth_successful() {
 }
 
 void S3PutChunkUploadObjectAction::chunk_auth_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_put_chunk_action_state =
       S3PutChunkUploadObjectActionState::dataSignatureCheckFailed;
   auth_in_progress = false;
@@ -152,7 +152,7 @@ void S3PutChunkUploadObjectAction::chunk_auth_failed() {
   auth_completed = true;
   set_s3_error("SignatureDoesNotMatch");
   if (check_shutdown_and_rollback(true)) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   if (motr_write_in_progress) {
@@ -162,11 +162,11 @@ void S3PutChunkUploadObjectAction::chunk_auth_failed() {
     // Clean up will be done after response.
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_put_chunk_action_state =
       S3PutChunkUploadObjectActionState::validationFailed;
   if (bucket_metadata->get_state() == S3BucketMetadataState::missing) {
@@ -180,11 +180,11 @@ void S3PutChunkUploadObjectAction::fetch_bucket_info_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::validate_x_amz_tagging_if_present() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   std::string new_object_tags = request->get_header_value("x-amz-tagging");
   s3_log(S3_LOG_DEBUG, request_id, "Received tags= %s\n",
          new_object_tags.c_str());
@@ -200,7 +200,7 @@ void S3PutChunkUploadObjectAction::validate_x_amz_tagging_if_present() {
 
 void S3PutChunkUploadObjectAction::parse_x_amz_tagging_header(
     std::string content) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   struct evkeyvalq key_value;
   memset(&key_value, 0, sizeof(key_value));
   if (0 == evhttp_parse_query_str(content.c_str(), &key_value)) {
@@ -221,11 +221,11 @@ void S3PutChunkUploadObjectAction::parse_x_amz_tagging_header(
     set_s3_error("InvalidTagError");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::validate_tags() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   std::string xml;
   std::shared_ptr<S3PutTagBody> put_object_tag_body =
       put_object_tag_body_factory->create_put_resource_tags_body(xml,
@@ -239,11 +239,11 @@ void S3PutChunkUploadObjectAction::validate_tags() {
     set_s3_error("InvalidTagError");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::fetch_object_info_failed() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   struct m0_uint128 object_list_oid =
       bucket_metadata->get_object_list_index_oid();
   if ((object_list_oid.u_hi == 0ULL && object_list_oid.u_lo == 0ULL) ||
@@ -264,11 +264,11 @@ void S3PutChunkUploadObjectAction::fetch_object_info_failed() {
   } else {
     next();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::fetch_object_info_success() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (object_metadata->get_state() == S3ObjectMetadataState::present) {
     s3_log(S3_LOG_DEBUG, request_id, "S3ObjectMetadataState::present\n");
     old_object_oid = object_metadata->get_oid();
@@ -294,11 +294,11 @@ void S3PutChunkUploadObjectAction::fetch_object_info_success() {
     set_s3_error("InternalError");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::validate_put_chunk_request() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if ((request->get_object_name()).length() > MAX_OBJECT_KEY_LENGTH) {
     s3_put_chunk_action_state =
@@ -314,7 +314,7 @@ void S3PutChunkUploadObjectAction::validate_put_chunk_request() {
   } else {
     next();
   }
-  s3_log(S3_LOG_DEBUG, nullptr, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, nullptr, "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::_set_layout_id(int layout_id) {
@@ -326,7 +326,7 @@ void S3PutChunkUploadObjectAction::_set_layout_id(int layout_id) {
 }
 
 void S3PutChunkUploadObjectAction::create_object() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   create_object_timer.start();
   if (tried_count == 0) {
     motr_writer =
@@ -341,11 +341,11 @@ void S3PutChunkUploadObjectAction::create_object() {
       std::bind(&S3PutChunkUploadObjectAction::create_object_successful, this),
       std::bind(&S3PutChunkUploadObjectAction::create_object_failed, this),
       layout_id);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::create_object_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_put_chunk_action_state =
       S3PutChunkUploadObjectActionState::newObjOidCreated;
 
@@ -363,13 +363,13 @@ void S3PutChunkUploadObjectAction::create_object_successful() {
   new_object_metadata->set_layout_id(layout_id);
 
   add_object_oid_to_probable_dead_oid_list();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::create_object_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (check_shutdown_and_rollback()) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   if (motr_writer->get_state() == S3MotrWiterOpState::exists) {
@@ -399,23 +399,24 @@ void S3PutChunkUploadObjectAction::create_object_failed() {
     set_s3_error("InternalError");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::collision_detected() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (check_shutdown_and_rollback()) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   if (tried_count < MAX_COLLISION_RETRY_COUNT) {
-    s3_log(S3_LOG_INFO, request_id, "Object ID collision happened for uri %s\n",
+    s3_log(S3_LOG_INFO, stripped_request_id,
+           "Object ID collision happened for uri %s\n",
            request->get_object_uri().c_str());
     // Handle Collision
     create_new_oid(new_object_oid);
     tried_count++;
     if (tried_count > 5) {
-      s3_log(S3_LOG_INFO, request_id,
+      s3_log(S3_LOG_INFO, stripped_request_id,
              "Object ID collision happened %d times for uri %s\n", tried_count,
              request->get_object_uri().c_str());
     }
@@ -453,7 +454,7 @@ void S3PutChunkUploadObjectAction::create_new_oid(
 }
 
 void S3PutChunkUploadObjectAction::initiate_data_streaming() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   create_object_timer.stop();
   LOG_PERF("create_object_successful_ms", request_id.c_str(),
@@ -484,11 +485,11 @@ void S3PutChunkUploadObjectAction::initiate_data_streaming() {
           motr_write_payload_size);
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::consume_incoming_content() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // for shutdown testcases, check FI and set shutdown signal
   S3_CHECK_FI_AND_SET_SHUTDOWN_SIGNAL(
       "put_chunk_upload_object_action_consume_incoming_content_shutdown_fail");
@@ -505,7 +506,7 @@ void S3PutChunkUploadObjectAction::consume_incoming_content() {
             motr_write_payload_size) {
       write_object(request->get_buffered_input());
       if (!motr_write_in_progress && write_failed) {
-        s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+        s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
         return;
       }
     }
@@ -518,11 +519,11 @@ void S3PutChunkUploadObjectAction::consume_incoming_content() {
            request->get_buffered_input()->get_content_length());
     request->pause();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::send_chunk_details_if_any() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // Also send any ready chunk data for auth
   while (request->is_chunk_detail_ready()) {
     S3ChunkDetail detail = request->pop_chunk_detail();
@@ -544,7 +545,7 @@ void S3PutChunkUploadObjectAction::send_chunk_details_if_any() {
 
 void S3PutChunkUploadObjectAction::write_object(
     std::shared_ptr<S3AsyncBufferOptContainer> buffer) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   // Also send any ready chunk data for auth
   send_chunk_details_if_any();
@@ -560,18 +561,18 @@ void S3PutChunkUploadObjectAction::write_object(
       buffer->get_buffers(content_length), buffer->size_of_each_evbuf);
   motr_write_in_progress = true;
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::write_object_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "Write to motr successful\n");
   motr_write_in_progress = false;
 
   request->get_buffered_input()->flush_used_buffers();
 
   if (check_shutdown_and_rollback()) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   if (request->is_s3_client_read_error()) {
@@ -585,7 +586,7 @@ void S3PutChunkUploadObjectAction::write_object_successful() {
            S3PutChunkUploadObjectActionState::dataSignatureCheckFailed);
     // Clean up will be done after response.
     send_response_to_s3_client();
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
 
@@ -614,7 +615,7 @@ void S3PutChunkUploadObjectAction::write_object_successful() {
 }
 
 void S3PutChunkUploadObjectAction::write_object_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   motr_write_in_progress = false;
   write_failed = true;
@@ -638,7 +639,7 @@ void S3PutChunkUploadObjectAction::write_object_failed() {
   }
 
   if (check_shutdown_and_rollback()) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   motr_write_completed = true;
@@ -647,11 +648,11 @@ void S3PutChunkUploadObjectAction::write_object_failed() {
     send_response_to_s3_client();
   }
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::save_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   // to rest Date and Last-Modfied time object metadata
   new_object_metadata->reset_date_time_to_current();
@@ -676,17 +677,17 @@ void S3PutChunkUploadObjectAction::save_metadata() {
                 this),
       std::bind(&S3PutChunkUploadObjectAction::save_object_metadata_failed,
                 this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::save_object_metadata_success() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_put_chunk_action_state = S3PutChunkUploadObjectActionState::metadataSaved;
   next();
 }
 
 void S3PutChunkUploadObjectAction::save_object_metadata_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_put_chunk_action_state =
       S3PutChunkUploadObjectActionState::metadataSaveFailed;
   if (new_object_metadata->get_state() ==
@@ -696,11 +697,11 @@ void S3PutChunkUploadObjectAction::save_object_metadata_failed() {
   }
   // Clean up will be done after response.
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::add_object_oid_to_probable_dead_oid_list() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   std::map<std::string, std::string> probable_oid_list;
   assert(!new_oid_str.empty());
 
@@ -755,12 +756,12 @@ void S3PutChunkUploadObjectAction::add_object_oid_to_probable_dead_oid_list() {
       std::bind(&S3PutChunkUploadObjectAction::
                      add_object_oid_to_probable_dead_oid_list_failed,
                 this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::
     add_object_oid_to_probable_dead_oid_list_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_put_chunk_action_state =
       S3PutChunkUploadObjectActionState::probableEntryRecordFailed;
   if (motr_kv_writer->get_state() == S3MotrKVSWriterOpState::failed_to_launch) {
@@ -770,15 +771,15 @@ void S3PutChunkUploadObjectAction::
   }
   // Clean up will be done after response.
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if ((auth_in_progress) &&
       (get_auth_client()->get_state() == S3AuthClientOpState::started)) {
     get_auth_client()->abort_chunk_auth_op();
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
 
@@ -825,11 +826,11 @@ void S3PutChunkUploadObjectAction::send_response_to_s3_client() {
   request->resume(false);
 
   startcleanup();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::startcleanup() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // TODO: Perf - all below tasks can be done in parallel
   // Any of the following steps fail, backgrounddelete will be able to perform
   // cleanups.
@@ -897,7 +898,7 @@ void S3PutChunkUploadObjectAction::startcleanup() {
 }
 
 void S3PutChunkUploadObjectAction::mark_new_oid_for_deletion() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   assert(!new_oid_str.empty());
 
   // update new oid, key = newoid, force_del = true
@@ -912,11 +913,11 @@ void S3PutChunkUploadObjectAction::mark_new_oid_for_deletion() {
       new_probable_del_rec->to_json(),
       std::bind(&S3PutChunkUploadObjectAction::next, this),
       std::bind(&S3PutChunkUploadObjectAction::next, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::mark_old_oid_for_deletion() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   assert(!old_oid_str.empty());
   assert(!new_oid_str.empty());
 
@@ -937,11 +938,11 @@ void S3PutChunkUploadObjectAction::mark_old_oid_for_deletion() {
       old_probable_del_rec->to_json(),
       std::bind(&S3PutChunkUploadObjectAction::next, this),
       std::bind(&S3PutChunkUploadObjectAction::next, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::remove_old_oid_probable_record() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   assert(!old_oid_str.empty());
   assert(!new_oid_str.empty());
 
@@ -956,11 +957,11 @@ void S3PutChunkUploadObjectAction::remove_old_oid_probable_record() {
       global_probable_dead_object_list_index_oid, old_oid_rec_key,
       std::bind(&S3PutChunkUploadObjectAction::next, this),
       std::bind(&S3PutChunkUploadObjectAction::next, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::remove_new_oid_probable_record() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   assert(!new_oid_str.empty());
 
   if (!motr_kv_writer) {
@@ -971,11 +972,11 @@ void S3PutChunkUploadObjectAction::remove_new_oid_probable_record() {
       global_probable_dead_object_list_index_oid, new_oid_str,
       std::bind(&S3PutChunkUploadObjectAction::next, this),
       std::bind(&S3PutChunkUploadObjectAction::next, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::delete_old_object() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // If PUT is success, we delete old object if present
   assert(old_object_oid.u_hi != 0ULL || old_object_oid.u_lo != 0ULL);
 
@@ -996,21 +997,21 @@ void S3PutChunkUploadObjectAction::delete_old_object() {
           &S3PutChunkUploadObjectAction::remove_old_object_version_metadata,
           this),
       std::bind(&S3PutChunkUploadObjectAction::next, this), old_layout_id);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::remove_old_object_version_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   object_metadata->remove_version_metadata(
       std::bind(&S3PutChunkUploadObjectAction::remove_old_oid_probable_record,
                 this),
       std::bind(&S3PutChunkUploadObjectAction::next, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::delete_new_object() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // If PUT failed, then clean new object.
   assert(s3_put_chunk_action_state !=
          S3PutChunkUploadObjectActionState::completed);
@@ -1021,13 +1022,13 @@ void S3PutChunkUploadObjectAction::delete_new_object() {
       std::bind(&S3PutChunkUploadObjectAction::remove_new_oid_probable_record,
                 this),
       std::bind(&S3PutChunkUploadObjectAction::next, this), layout_id);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutChunkUploadObjectAction::set_authorization_meta() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   auth_client->set_acl_and_policy(bucket_metadata->get_encoded_bucket_acl(),
                                   bucket_metadata->get_policy_as_json());
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_put_fi_action.cc
+++ b/server/s3_put_fi_action.cc
@@ -30,7 +30,7 @@
 
 S3PutFiAction::S3PutFiAction(std::shared_ptr<S3RequestObject> req)
     : S3Action(req, false) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
   clear_tasks();
   setup_steps();
@@ -133,7 +133,7 @@ void S3PutFiAction::set_fault_injection() {
 }
 
 void S3PutFiAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (!is_error_state() && get_s3_error_code().empty()) {
     request->send_response(S3HttpSuccess200);
@@ -151,5 +151,5 @@ void S3PutFiAction::send_response_to_s3_client() {
   request->resume();
 
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_put_multiobject_action.cc
+++ b/server/s3_put_multiobject_action.cc
@@ -40,11 +40,11 @@ S3PutMultiObjectAction::S3PutMultiObjectAction(
       motr_write_completed(false),
       auth_in_progress(false),
       auth_completed(false) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   part_number = get_part_number();
   upload_id = request->get_query_string_value("uploadId");
 
-  s3_log(S3_LOG_INFO, request_id,
+  s3_log(S3_LOG_INFO, stripped_request_id,
          "S3 API: Upload Part. Bucket[%s] Object[%s]\
          Part[%d] for UploadId[%s]\n",
          request->get_bucket_name().c_str(), request->get_object_name().c_str(),
@@ -109,16 +109,16 @@ void S3PutMultiObjectAction::setup_steps() {
 }
 
 void S3PutMultiObjectAction::validate_multipart_request() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (!request->is_chunked() && !request->is_header_present("Content-Length")) {
     // For non-chunked upload, the Header 'Content-Length' is missing
-    s3_log(S3_LOG_INFO, request_id, "Missing Content-Length header");
+    s3_log(S3_LOG_INFO, stripped_request_id, "Missing Content-Length header");
     set_s3_error("MissingContentLength");
     send_response_to_s3_client();
   } else {
     next();
   }
-  s3_log(S3_LOG_INFO, request_id, "Exiting\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Exit", __func__);
 }
 
 void S3PutMultiObjectAction::check_part_details() {
@@ -140,11 +140,11 @@ void S3PutMultiObjectAction::check_part_details() {
 }
 
 void S3PutMultiObjectAction::chunk_auth_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   auth_in_progress = false;
   auth_completed = true;
   if (check_shutdown_and_rollback(true)) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   if (motr_write_completed) {
@@ -160,12 +160,12 @@ void S3PutMultiObjectAction::chunk_auth_successful() {
 }
 
 void S3PutMultiObjectAction::chunk_auth_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   auth_failed = true;
   auth_completed = true;
   set_s3_error("SignatureDoesNotMatch");
   if (check_shutdown_and_rollback(true)) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   if (motr_write_in_progress) {
@@ -176,19 +176,19 @@ void S3PutMultiObjectAction::chunk_auth_failed() {
 }
 
 void S3PutMultiObjectAction::fetch_bucket_info_success() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::present) {
     next();
   } else {
     set_s3_error("NoSuchBucket");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 void S3PutMultiObjectAction::fetch_object_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 void S3PutMultiObjectAction::fetch_bucket_info_failed() {
   s3_log(S3_LOG_ERROR, request_id, "Bucket does not exists\n");
@@ -206,7 +206,7 @@ void S3PutMultiObjectAction::fetch_bucket_info_failed() {
 }
 
 void S3PutMultiObjectAction::fetch_multipart_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   object_multipart_metadata =
       object_mp_metadata_factory->create_object_mp_metadata_obj(
           request, bucket_metadata->get_multipart_index_oid(), upload_id);
@@ -214,7 +214,7 @@ void S3PutMultiObjectAction::fetch_multipart_metadata() {
   object_multipart_metadata->load(
       std::bind(&S3PutMultiObjectAction::next, this),
       std::bind(&S3PutMultiObjectAction::fetch_multipart_failed, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutMultiObjectAction::fetch_multipart_failed() {
@@ -231,7 +231,7 @@ void S3PutMultiObjectAction::fetch_multipart_failed() {
 }
 
 void S3PutMultiObjectAction::save_multipart_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // This function to be called for part 1 upload
   // so that other parts can see the size of part 1
   // to proceed.Also this is only in case of
@@ -255,7 +255,7 @@ void S3PutMultiObjectAction::save_multipart_metadata() {
              part_one_size_in_multipart_metadata, current_part_one_size);
       set_s3_error("InvalidObjectState");
       send_response_to_s3_client();
-      s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+      s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
       return;
     }
   }
@@ -265,11 +265,11 @@ void S3PutMultiObjectAction::save_multipart_metadata() {
   object_multipart_metadata->save(
       std::bind(&S3PutMultiObjectAction::next, this),
       std::bind(&S3PutMultiObjectAction::save_multipart_metadata_failed, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutMultiObjectAction::save_multipart_metadata_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_ERROR, request_id,
          "Failed to update multipart metadata with part one size\n");
   if (object_multipart_metadata->get_state() ==
@@ -281,17 +281,17 @@ void S3PutMultiObjectAction::save_multipart_metadata_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutMultiObjectAction::fetch_firstpart_info() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   part_metadata = part_metadata_factory->create_part_metadata_obj(
       request, object_multipart_metadata->get_part_index_oid(), upload_id, 1);
   part_metadata->load(
       std::bind(&S3PutMultiObjectAction::next, this),
       std::bind(&S3PutMultiObjectAction::fetch_firstpart_info_failed, this), 1);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutMultiObjectAction::fetch_firstpart_info_failed() {
@@ -319,7 +319,7 @@ void S3PutMultiObjectAction::_set_layout_id(int layout_id) {
 }
 
 void S3PutMultiObjectAction::compute_part_offset() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   size_t offset = 0;
   if (part_number != 1) {
     size_t part_one_size = 0;
@@ -374,18 +374,18 @@ void S3PutMultiObjectAction::compute_part_offset() {
              "Rejecting request as part size is not aligned w.r.t unit_size\n");
       // part size is not multiple of unit size, block request
       set_s3_error("InvalidPartSize");
-      s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+      s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
       send_response_to_s3_client();
       return;
     }
   }
   next();
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutMultiObjectAction::initiate_data_streaming() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   total_data_to_stream = request->get_data_length();
   // request->resume();
@@ -410,11 +410,11 @@ void S3PutMultiObjectAction::initiate_data_streaming() {
           motr_write_payload_size);
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutMultiObjectAction::consume_incoming_content() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // for shutdown testcases, check FI and set shutdown signal
   S3_CHECK_FI_AND_SET_SHUTDOWN_SIGNAL(
       "put_multiobject_action_consume_incoming_content_shutdown_fail");
@@ -434,7 +434,7 @@ void S3PutMultiObjectAction::consume_incoming_content() {
             motr_write_payload_size) {
       write_object(request->get_buffered_input());
       if (!motr_write_in_progress && motr_write_completed) {
-        s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+        s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
         return;
       }
     }
@@ -447,11 +447,11 @@ void S3PutMultiObjectAction::consume_incoming_content() {
            request->get_buffered_input()->get_content_length());
     request->pause();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutMultiObjectAction::send_chunk_details_if_any() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   while (request->is_chunk_detail_ready()) {
     S3ChunkDetail detail = request->pop_chunk_detail();
     s3_log(S3_LOG_DEBUG, request_id, "Using chunk details for auth:\n");
@@ -473,7 +473,7 @@ void S3PutMultiObjectAction::send_chunk_details_if_any() {
 void S3PutMultiObjectAction::write_object(
     std::shared_ptr<S3AsyncBufferOptContainer> buffer) {
 
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (request->is_chunked()) {
     // Also send any ready chunk data for auth
@@ -491,17 +491,17 @@ void S3PutMultiObjectAction::write_object(
 
   motr_write_in_progress = true;
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutMultiObjectAction::write_object_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   motr_write_in_progress = false;
 
   request->get_buffered_input()->flush_used_buffers();
 
   if (check_shutdown_and_rollback()) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   if (request->is_s3_client_read_error()) {
@@ -573,7 +573,7 @@ void S3PutMultiObjectAction::write_object_failed() {
 }
 
 void S3PutMultiObjectAction::save_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   part_metadata = part_metadata_factory->create_part_metadata_obj(
       request, object_multipart_metadata->get_part_index_oid(), upload_id,
       part_number);
@@ -597,11 +597,11 @@ void S3PutMultiObjectAction::save_metadata() {
   part_metadata->save(
       std::bind(&S3PutMultiObjectAction::next, this),
       std::bind(&S3PutMultiObjectAction::save_metadata_failed, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutMultiObjectAction::save_metadata_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (part_metadata->get_state() == S3PartMetadataState::failed_to_launch) {
     s3_log(S3_LOG_ERROR, request_id,
            "Save of Part metadata failed due to pre launch failure\n");
@@ -611,16 +611,16 @@ void S3PutMultiObjectAction::save_metadata_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutMultiObjectAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if ((auth_in_progress) &&
       (get_auth_client()->get_state() == S3AuthClientOpState::started)) {
     get_auth_client()->abort_chunk_auth_op();
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
 
@@ -668,13 +668,13 @@ void S3PutMultiObjectAction::send_response_to_s3_client() {
   request->resume(false);
 
   done();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 void S3PutMultiObjectAction::set_authorization_meta() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   auth_client->set_acl_and_policy(bucket_metadata->get_encoded_bucket_acl(),
                                   bucket_metadata->get_policy_as_json());
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 

--- a/server/s3_put_object_action.cc
+++ b/server/s3_put_object_action.cc
@@ -46,9 +46,10 @@ S3PutObjectAction::S3PutObjectAction(
                      std::move(object_meta_factory)),
       total_data_to_stream(0),
       write_in_progress(false) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
-  s3_log(S3_LOG_INFO, request_id, "S3 API: Put Object. Bucket[%s] Object[%s]\n",
+  s3_log(S3_LOG_INFO, stripped_request_id,
+         "S3 API: Put Object. Bucket[%s] Object[%s]\n",
          request->get_bucket_name().c_str(),
          request->get_object_name().c_str());
 
@@ -107,7 +108,7 @@ void S3PutObjectAction::setup_steps() {
 }
 
 void S3PutObjectAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   s3_put_action_state = S3PutObjectActionState::validationFailed;
   if (bucket_metadata->get_state() == S3BucketMetadataState::missing) {
@@ -123,11 +124,11 @@ void S3PutObjectAction::fetch_bucket_info_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::validate_x_amz_tagging_if_present() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   std::string new_object_tags = request->get_header_value("x-amz-tagging");
   s3_log(S3_LOG_DEBUG, request_id, "Received tags= %s\n",
          new_object_tags.c_str());
@@ -141,7 +142,7 @@ void S3PutObjectAction::validate_x_amz_tagging_if_present() {
 }
 
 void S3PutObjectAction::validate_put_request() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if ((request->get_object_name()).length() > MAX_OBJECT_KEY_LENGTH) {
     s3_put_action_state = S3PutObjectActionState::validationFailed;
@@ -164,7 +165,7 @@ void S3PutObjectAction::validate_put_request() {
 }
 
 void S3PutObjectAction::parse_x_amz_tagging_header(std::string content) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   struct evkeyvalq key_value;
   memset(&key_value, 0, sizeof(key_value));
   if (0 == evhttp_parse_query_str(content.c_str(), &key_value)) {
@@ -184,11 +185,11 @@ void S3PutObjectAction::parse_x_amz_tagging_header(std::string content) {
     set_s3_error("InvalidTagError");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::validate_tags() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   std::string xml;
   std::shared_ptr<S3PutTagBody> put_object_tag_body =
       put_object_tag_body_factory->create_put_resource_tags_body(xml,
@@ -201,7 +202,7 @@ void S3PutObjectAction::validate_tags() {
     set_s3_error("InvalidTagError");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::fetch_object_info_failed() {
@@ -228,7 +229,7 @@ void S3PutObjectAction::fetch_object_info_failed() {
 }
 
 void S3PutObjectAction::fetch_object_info_success() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (object_metadata->get_state() == S3ObjectMetadataState::present) {
     s3_log(S3_LOG_DEBUG, request_id, "S3ObjectMetadataState::present\n");
     old_object_oid = object_metadata->get_oid();
@@ -252,7 +253,7 @@ void S3PutObjectAction::fetch_object_info_success() {
     set_s3_error("InternalError");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::_set_layout_id(int layout_id) {
@@ -264,7 +265,7 @@ void S3PutObjectAction::_set_layout_id(int layout_id) {
 }
 
 void S3PutObjectAction::create_object() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_timer.start();
   if (tried_count == 0) {
     motr_writer =
@@ -282,11 +283,11 @@ void S3PutObjectAction::create_object() {
   // for shutdown testcases, check FI and set shutdown signal
   S3_CHECK_FI_AND_SET_SHUTDOWN_SIGNAL(
       "put_object_action_create_object_shutdown_fail");
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::create_object_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_put_action_state = S3PutObjectActionState::newObjOidCreated;
 
   // New Object or overwrite, create new metadata and release old.
@@ -303,13 +304,13 @@ void S3PutObjectAction::create_object_successful() {
   new_object_metadata->set_layout_id(layout_id);
 
   add_object_oid_to_probable_dead_oid_list();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::create_object_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (check_shutdown_and_rollback()) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   if (motr_writer->get_state() == S3MotrWiterOpState::exists) {
@@ -332,7 +333,7 @@ void S3PutObjectAction::create_object_failed() {
     }
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 /*
@@ -360,17 +361,18 @@ void S3PutObjectAction::create_object_failed() {
 
 void S3PutObjectAction::collision_detected() {
   if (check_shutdown_and_rollback()) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   if (tried_count < MAX_COLLISION_RETRY_COUNT) {
-    s3_log(S3_LOG_INFO, request_id, "Object ID collision happened for uri %s\n",
+    s3_log(S3_LOG_INFO, stripped_request_id,
+           "Object ID collision happened for uri %s\n",
            request->get_object_uri().c_str());
     // Handle Collision
     create_new_oid(new_object_oid);
     tried_count++;
     if (tried_count > 5) {
-      s3_log(S3_LOG_INFO, request_id,
+      s3_log(S3_LOG_INFO, stripped_request_id,
              "Object ID collision happened %d times for uri %s\n", tried_count,
              request->get_object_uri().c_str());
     }
@@ -406,7 +408,7 @@ void S3PutObjectAction::create_new_oid(struct m0_uint128 current_oid) {
 }
 
 void S3PutObjectAction::initiate_data_streaming() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_timer.stop();
   const auto mss = s3_timer.elapsed_time_in_millisec();
   LOG_PERF("create_object_successful_ms", request_id.c_str(), mss);
@@ -430,11 +432,11 @@ void S3PutObjectAction::initiate_data_streaming() {
           motr_write_payload_size);
     }
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::consume_incoming_content() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   // for shutdown testcases, check FI and set shutdown signal
   S3_CHECK_FI_AND_SET_SHUTDOWN_SIGNAL(
       "put_object_action_consume_incoming_content_shutdown_fail");
@@ -465,15 +467,15 @@ void S3PutObjectAction::consume_incoming_content() {
            request->get_buffered_input()->get_content_length());
     request->pause();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::write_object(
     std::shared_ptr<S3AsyncBufferOptContainer> buffer) {
 
   size_t content_length = buffer->get_content_length();
-  s3_log(S3_LOG_DEBUG, request_id, "Entering with buffer length = %zu\n",
-         content_length);
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry with buffer length = %zu\n",
+         __func__, content_length);
 
   if (content_length > motr_write_payload_size) {
     content_length = motr_write_payload_size;
@@ -484,11 +486,11 @@ void S3PutObjectAction::write_object(
       buffer->get_buffers(content_length), buffer->size_of_each_evbuf);
 
   write_in_progress = true;
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::write_object_successful() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "Write to motr successful\n");
 
   request->get_buffered_input()->flush_used_buffers();
@@ -496,7 +498,7 @@ void S3PutObjectAction::write_object_successful() {
   write_in_progress = false;
 
   if (check_shutdown_and_rollback()) {
-    s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
     return;
   }
   if (request->is_s3_client_read_error()) {
@@ -537,7 +539,7 @@ void S3PutObjectAction::write_object_successful() {
     s3_put_action_state = S3PutObjectActionState::writeFailed;
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::write_object_failed() {
@@ -563,7 +565,7 @@ void S3PutObjectAction::write_object_failed() {
 }
 
 void S3PutObjectAction::save_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   std::string s_md5_got = request->get_header_value("content-md5");
   if (!s_md5_got.empty()) {
@@ -605,17 +607,17 @@ void S3PutObjectAction::save_metadata() {
   new_object_metadata->save(
       std::bind(&S3PutObjectAction::save_object_metadata_success, this),
       std::bind(&S3PutObjectAction::save_object_metadata_failed, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::save_object_metadata_success() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_put_action_state = S3PutObjectActionState::metadataSaved;
   next();
 }
 
 void S3PutObjectAction::save_object_metadata_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_put_action_state = S3PutObjectActionState::metadataSaveFailed;
   if (new_object_metadata->get_state() ==
       S3ObjectMetadataState::failed_to_launch) {
@@ -626,11 +628,11 @@ void S3PutObjectAction::save_object_metadata_failed() {
   }
   // Clean up will be done after response.
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::add_object_oid_to_probable_dead_oid_list() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   std::map<std::string, std::string> probable_oid_list;
   assert(!new_oid_str.empty());
 
@@ -685,11 +687,11 @@ void S3PutObjectAction::add_object_oid_to_probable_dead_oid_list() {
       std::bind(
           &S3PutObjectAction::add_object_oid_to_probable_dead_oid_list_failed,
           this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::add_object_oid_to_probable_dead_oid_list_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_put_action_state = S3PutObjectActionState::probableEntryRecordFailed;
   if (motr_kv_writer->get_state() == S3MotrKVSWriterOpState::failed_to_launch) {
     set_s3_error("ServiceUnavailable");
@@ -698,11 +700,11 @@ void S3PutObjectAction::add_object_oid_to_probable_dead_oid_list_failed() {
   }
   // Clean up will be done after response.
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (S3Option::get_instance()->is_getoid_enabled()) {
 
@@ -754,11 +756,11 @@ void S3PutObjectAction::send_response_to_s3_client() {
   S3_RESET_SHUTDOWN_SIGNAL;  // for shutdown testcases
   request->resume(false);
   startcleanup();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::startcleanup() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // TODO: Perf - all/some of below tasks can be done in parallel
   // Any of the following steps fail, backgrounddelete will be able to perform
   // cleanups.
@@ -817,7 +819,7 @@ void S3PutObjectAction::startcleanup() {
 }
 
 void S3PutObjectAction::mark_new_oid_for_deletion() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   assert(!new_oid_str.empty());
 
   // update new oid, key = newoid, force_del = true
@@ -831,11 +833,11 @@ void S3PutObjectAction::mark_new_oid_for_deletion() {
                              new_oid_str, new_probable_del_rec->to_json(),
                              std::bind(&S3PutObjectAction::next, this),
                              std::bind(&S3PutObjectAction::next, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::mark_old_oid_for_deletion() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   assert(!old_oid_str.empty());
   assert(!new_oid_str.empty());
 
@@ -856,11 +858,11 @@ void S3PutObjectAction::mark_old_oid_for_deletion() {
                              old_oid_rec_key, old_probable_del_rec->to_json(),
                              std::bind(&S3PutObjectAction::next, this),
                              std::bind(&S3PutObjectAction::next, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::remove_old_oid_probable_record() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   assert(!old_oid_str.empty());
   assert(!new_oid_str.empty());
 
@@ -875,11 +877,11 @@ void S3PutObjectAction::remove_old_oid_probable_record() {
                                 old_oid_rec_key,
                                 std::bind(&S3PutObjectAction::next, this),
                                 std::bind(&S3PutObjectAction::next, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::remove_new_oid_probable_record() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   assert(!new_oid_str.empty());
 
   if (!motr_kv_writer) {
@@ -890,11 +892,11 @@ void S3PutObjectAction::remove_new_oid_probable_record() {
                                 new_oid_str,
                                 std::bind(&S3PutObjectAction::next, this),
                                 std::bind(&S3PutObjectAction::next, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::delete_old_object() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // If PUT is success, we delete old object if present
   assert(old_object_oid.u_hi != 0ULL || old_object_oid.u_lo != 0ULL);
 
@@ -912,20 +914,20 @@ void S3PutObjectAction::delete_old_object() {
   motr_writer->delete_object(
       std::bind(&S3PutObjectAction::remove_old_object_version_metadata, this),
       std::bind(&S3PutObjectAction::next, this), old_layout_id);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::remove_old_object_version_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   object_metadata->remove_version_metadata(
       std::bind(&S3PutObjectAction::remove_old_oid_probable_record, this),
       std::bind(&S3PutObjectAction::next, this));
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::delete_new_object() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // If PUT failed, then clean new object.
   assert(s3_put_action_state != S3PutObjectActionState::completed);
   assert(new_object_oid.u_hi != 0ULL || new_object_oid.u_lo != 0ULL);
@@ -934,13 +936,13 @@ void S3PutObjectAction::delete_new_object() {
   motr_writer->delete_object(
       std::bind(&S3PutObjectAction::remove_new_oid_probable_record, this),
       std::bind(&S3PutObjectAction::next, this), layout_id);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectAction::set_authorization_meta() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   auth_client->set_acl_and_policy(bucket_metadata->get_encoded_bucket_acl(),
                                   bucket_metadata->get_policy_as_json());
   next();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_put_object_tagging_action.cc
+++ b/server/s3_put_object_tagging_action.cc
@@ -29,9 +29,9 @@ S3PutObjectTaggingAction::S3PutObjectTaggingAction(
     std::shared_ptr<S3PutTagsBodyFactory> object_body_factory)
     : S3ObjectAction(std::move(req), std::move(bucket_meta_factory),
                      std::move(object_meta_factory)) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
-  s3_log(S3_LOG_INFO, request_id,
+  s3_log(S3_LOG_INFO, stripped_request_id,
          "S3 API: PutObjectTaggingAction. Bucket[%s] Object[%s]\n",
          request->get_bucket_name().c_str(),
          request->get_object_name().c_str());
@@ -53,7 +53,7 @@ void S3PutObjectTaggingAction::setup_steps() {
 }
 
 void S3PutObjectTaggingAction::validate_request() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (request->has_all_body_content()) {
     new_object_tags = request->get_full_body_content_as_string();
@@ -66,7 +66,7 @@ void S3PutObjectTaggingAction::validate_request() {
         );
   }
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectTaggingAction::consume_incoming_content() {
@@ -83,7 +83,7 @@ void S3PutObjectTaggingAction::consume_incoming_content() {
 }
 
 void S3PutObjectTaggingAction::validate_request_body(std::string content) {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   put_object_tag_body =
       put_object_tag_body_factory->create_put_resource_tags_body(content,
                                                                  request_id);
@@ -94,11 +94,11 @@ void S3PutObjectTaggingAction::validate_request_body(std::string content) {
     set_s3_error("MalformedXML");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectTaggingAction::validate_request_xml_tags() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
 
   if (put_object_tag_body->validate_object_xml_tags(object_tags_map)) {
     next();
@@ -106,11 +106,11 @@ void S3PutObjectTaggingAction::validate_request_xml_tags() {
     set_s3_error("InvalidTagError");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectTaggingAction::fetch_bucket_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (bucket_metadata->get_state() == S3BucketMetadataState::missing) {
     set_s3_error("NoSuchBucket");
   } else if (bucket_metadata->get_state() ==
@@ -123,11 +123,11 @@ void S3PutObjectTaggingAction::fetch_bucket_info_failed() {
   }
 
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectTaggingAction::fetch_object_info_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if ((object_list_oid.u_lo == 0ULL && object_list_oid.u_hi == 0ULL) ||
       (object_metadata->get_state() == S3ObjectMetadataState::missing)) {
     set_s3_error("NoSuchKey");
@@ -140,11 +140,11 @@ void S3PutObjectTaggingAction::fetch_object_info_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectTaggingAction::save_tags_to_object_metadata() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // bypass shutdown signal check for next task
   check_shutdown_signal_for_next_task(false);
   object_metadata->set_tags(object_tags_map);
@@ -155,7 +155,7 @@ void S3PutObjectTaggingAction::save_tags_to_object_metadata() {
 }
 
 void S3PutObjectTaggingAction::save_tags_to_object_metadata_failed() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (object_metadata->get_state() == S3ObjectMetadataState::failed_to_launch) {
     s3_log(S3_LOG_ERROR, request_id,
            "Object metadata load operation failed due to pre launch failure\n");
@@ -164,11 +164,11 @@ void S3PutObjectTaggingAction::save_tags_to_object_metadata_failed() {
     set_s3_error("InternalError");
   }
   send_response_to_s3_client();
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PutObjectTaggingAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_INFO, request_id, "Entering\n");
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (reject_if_shutting_down() ||
       (is_error_state() && !get_s3_error_code().empty())) {
@@ -187,6 +187,6 @@ void S3PutObjectTaggingAction::send_response_to_s3_client() {
   }
 
   S3_RESET_SHUTDOWN_SIGNAL;  // for shutdown testcases
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   done();
 }

--- a/server/s3_put_tag_body.cc
+++ b/server/s3_put_tag_body.cc
@@ -30,7 +30,7 @@
 S3PutTagBody::S3PutTagBody(std::string &xml, std::string &request)
     : xml_content(xml), request_id(request), is_valid(false) {
 
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   if (!xml.empty()) {
     parse_and_validate();
   }

--- a/server/s3_request_object.cc
+++ b/server/s3_request_object.cc
@@ -38,7 +38,7 @@ S3RequestObject::S3RequestObject(
     EventInterface* event_obj_ptr)
     : RequestObject(req, evhtp_obj_ptr, async_buf_factory, event_obj_ptr),
       s3_api_type(S3ApiType::unsupported) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
   bucket_name = object_name = "";
   object_size = 0;
@@ -53,7 +53,7 @@ S3RequestObject::S3RequestObject(
 }
 
 S3RequestObject::~S3RequestObject() {
-  s3_log(S3_LOG_DEBUG, request_id, "Destructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s\n", __func__);
   populate_and_log_audit_info();
 }
 
@@ -72,7 +72,8 @@ void S3RequestObject::set_bucket_name(const std::string& name) {
 
 void S3RequestObject::set_action_str(const std::string& action) {
   if (action != "HeadService") {
-    s3_log(S3_LOG_INFO, request_id, "S3Action =  %s\n", action.c_str());
+    s3_log(S3_LOG_INFO, stripped_request_id, "S3Action =  %s\n",
+           action.c_str());
   }
   s3_action = action;
 }
@@ -109,7 +110,7 @@ void S3RequestObject::set_default_acl(const std::string& acl) {
 const std::string& S3RequestObject::get_default_acl() { return default_acl; }
 
 void S3RequestObject::populate_and_log_audit_info() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry", __func__);
   if (S3Option::get_instance()->get_audit_logger_policy() == "disabled") {
     s3_log(S3_LOG_DEBUG, request_id,
            "Audit logger disabled by policy settings\n");
@@ -175,5 +176,5 @@ void S3RequestObject::populate_and_log_audit_info() {
     s3_log(S3_LOG_FATAL, request_id, "Audit Logger Error. STOP Server");
   }
   }
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }

--- a/server/s3_router.cc
+++ b/server/s3_router.cc
@@ -60,18 +60,19 @@ bool Router::is_subdomain_match(std::string& endpoint) {
 
 S3Router::S3Router(S3APIHandlerFactory* api_creator, S3UriFactory* uri_creator)
     : api_handler_factory(api_creator), uri_factory(uri_creator) {
-  s3_log(S3_LOG_DEBUG, "", "Constructor\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Ctor\n", __func__);
 }
 
 S3Router::~S3Router() {
-  s3_log(S3_LOG_DEBUG, "", "Destructor\n");
+  s3_log(S3_LOG_DEBUG, "", "%s\n", __func__);
   delete api_handler_factory;
   delete uri_factory;
 }
 
 void S3Router::dispatch(std::shared_ptr<RequestObject> request) {
   std::string request_id = request->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  std::string stripped_request_id = request->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   std::shared_ptr<S3RequestObject> s3request =
       std::dynamic_pointer_cast<S3RequestObject>(request);
   std::shared_ptr<S3APIHandler> handler;
@@ -124,18 +125,19 @@ void S3Router::dispatch(std::shared_ptr<RequestObject> request) {
 MotrRouter::MotrRouter(MotrAPIHandlerFactory* api_creator,
                        MotrUriFactory* uri_creator)
     : api_handler_factory(api_creator), uri_factory(uri_creator) {
-  s3_log(S3_LOG_DEBUG, "", "Constructor\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Ctor\n", __func__);
 }
 
 MotrRouter::~MotrRouter() {
-  s3_log(S3_LOG_DEBUG, "", "Destructor\n");
+  s3_log(S3_LOG_DEBUG, "", "%s\n", __func__);
   delete api_handler_factory;
   delete uri_factory;
 }
 
 void MotrRouter::dispatch(std::shared_ptr<RequestObject> request) {
   std::string request_id = request->get_request_id();
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  std::string stripped_request_id = request->get_stripped_request_id();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   std::shared_ptr<MotrRequestObject> motr_request =
       std::dynamic_pointer_cast<MotrRequestObject>(request);
   std::shared_ptr<MotrAPIHandler> handler;
@@ -143,7 +145,7 @@ void MotrRouter::dispatch(std::shared_ptr<RequestObject> request) {
   std::string host_name = motr_request->get_host_name();
 
   s3_log(S3_LOG_DEBUG, request_id, "host_name = %s\n", host_name.c_str());
-  s3_log(S3_LOG_INFO, request_id, "uri = %s\n",
+  s3_log(S3_LOG_INFO, stripped_request_id, "uri = %s\n",
          motr_request->c_get_full_path());
 
   std::unique_ptr<MotrURI> uri;

--- a/server/s3_service_api_handler.cc
+++ b/server/s3_service_api_handler.cc
@@ -24,7 +24,7 @@
 #include "s3_stats.h"
 
 void S3ServiceAPIHandler::create_action() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_DEBUG, request_id, "Action operation code = %d\n",
          operation_code);
 
@@ -53,5 +53,5 @@ void S3ServiceAPIHandler::create_action() {
       return;
   };  // switch operation_code
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_service_list_response.cc
+++ b/server/s3_service_list_response.cc
@@ -22,7 +22,7 @@
 #include "s3_common_utilities.h"
 
 S3ServiceListResponse::S3ServiceListResponse() {
-  s3_log(S3_LOG_DEBUG, "", "Constructor\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Ctor\n", __func__);
   bucket_list.clear();
 }
 

--- a/server/s3_stats.cc
+++ b/server/s3_stats.cc
@@ -89,7 +89,7 @@ int S3Stats::count_unique(const std::string& key, const std::string& value,
 }
 
 int S3Stats::load_allowlist() {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   std::string allowlist_filename =
       g_option_instance->get_stats_allowlist_filename();
   s3_log(S3_LOG_DEBUG, "", "Loading allowlist file: %s\n",
@@ -128,12 +128,12 @@ int S3Stats::load_allowlist() {
     s3_log(S3_LOG_ERROR, "", "YAML::Exception caught: %s\n", e.what());
     return -1;
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return 0;
 }
 
 int S3Stats::init() {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   if (load_allowlist() == -1) {
     s3_log(S3_LOG_ERROR, "", "load_allowlist failed parsing the file: %s\n",
            g_option_instance->get_stats_allowlist_filename().c_str());
@@ -164,17 +164,17 @@ int S3Stats::init() {
     errno = EINVAL;
     return -1;
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return 0;
 }
 
 void S3Stats::finish() {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   if (sock != -1) {
     socket_obj->close(sock);
     sock = -1;
   }
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 int S3Stats::send(const std::string& msg, int retry) {

--- a/server/s3_stats.h
+++ b/server/s3_stats.h
@@ -60,7 +60,7 @@ class S3Stats {
   S3Stats(const std::string& host_addr, const unsigned short port_num,
           SocketInterface* socket_obj_ptr = NULL)
       : host(host_addr), port(port_num), sock(-1) {
-    s3_log(S3_LOG_DEBUG, "", "Constructor\n");
+    s3_log(S3_LOG_DEBUG, "", "%s Ctor\n", __func__);
     metrics_allowlist.clear();
     if (socket_obj_ptr) {
       socket_obj.reset(socket_obj_ptr);

--- a/server/s3_uri.cc
+++ b/server/s3_uri.cc
@@ -31,6 +31,7 @@ S3URI::S3URI(std::shared_ptr<S3RequestObject> req)
       bucket_name(""),
       object_name("") {
   request_id = request->get_request_id();
+  stripped_request_id = request->get_stripped_request_id();
   setup_operation_code();
 }
 
@@ -66,7 +67,7 @@ void S3URI::setup_operation_code() {
 
 S3PathStyleURI::S3PathStyleURI(std::shared_ptr<S3RequestObject> req)
     : S3URI(req) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   std::string full_uri(request->c_get_full_path());
   // Regex is better, but lets live with raw parsing. regex = >gcc 4.9.0
   if (full_uri.compare("/") == 0) {
@@ -107,7 +108,7 @@ S3PathStyleURI::S3PathStyleURI(std::shared_ptr<S3RequestObject> req)
 S3VirtualHostStyleURI::S3VirtualHostStyleURI(
     std::shared_ptr<S3RequestObject> req)
     : S3URI(req) {
-  s3_log(S3_LOG_DEBUG, request_id, "Constructor\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   host_header = request->get_host_name();
 
   setup_bucket_name();
@@ -124,7 +125,7 @@ S3VirtualHostStyleURI::S3VirtualHostStyleURI(
 }
 
 void S3VirtualHostStyleURI::setup_bucket_name() {
-  s3_log(S3_LOG_DEBUG, request_id, "Entering\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   if (host_header.find(S3Option::get_instance()->get_default_endpoint()) !=
       std::string::npos) {
     bucket_name = host_header.substr(
@@ -139,5 +140,5 @@ void S3VirtualHostStyleURI::setup_bucket_name() {
           host_header.substr(0, (host_header.length() - (*it).length() - 1));
     }
   }
-  s3_log(S3_LOG_DEBUG, request_id, "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }

--- a/server/s3_uri.h
+++ b/server/s3_uri.h
@@ -41,6 +41,7 @@ class S3URI {
   std::string bucket_name;
   std::string object_name;
   std::string request_id;
+  std::string stripped_request_id;
 
  private:
   void setup_operation_code();

--- a/server/s3_uri_factory.cc
+++ b/server/s3_uri_factory.cc
@@ -23,7 +23,7 @@
 
 S3URI* S3UriFactory::create_uri_object(
     S3UriType uri_type, std::shared_ptr<S3RequestObject> request) {
-  s3_log(S3_LOG_DEBUG, request->get_request_id(), "Entering\n");
+  s3_log(S3_LOG_DEBUG, request->get_request_id(), "%s Entry\n", __func__);
 
   switch (uri_type) {
     case S3UriType::path_style:
@@ -37,6 +37,6 @@ S3URI* S3UriFactory::create_uri_object(
     default:
       break;
   };
-  s3_log(S3_LOG_DEBUG, request->get_request_id(), "Exiting\n");
+  s3_log(S3_LOG_DEBUG, request->get_request_id(), "%s Exit", __func__);
   return NULL;
 }

--- a/server/s3_uri_to_motr_oid.cc
+++ b/server/s3_uri_to_motr_oid.cc
@@ -32,7 +32,7 @@
 int S3UriToMotrOID(std::shared_ptr<MotrAPI> s3_motr_api, const char *name,
                    const std::string &request_id, m0_uint128 *ufid,
                    S3MotrEntityType type) {
-  s3_log(S3_LOG_DEBUG, "", "Entering\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
   int rc;
   S3Timer timer;
   struct m0_uint128 tmp_uint128;
@@ -125,6 +125,6 @@ int S3UriToMotrOID(std::shared_ptr<MotrAPI> s3_motr_api, const char *name,
            timer.elapsed_time_in_nanosec());
   s3_stats_timing("uri_to_motr_oid", timer.elapsed_time_in_millisec());
 
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return 0;
 }

--- a/server/s3server.cc
+++ b/server/s3server.cc
@@ -101,7 +101,7 @@ std::set<struct s3_motr_idx_context *> global_motr_idx;
 std::set<struct s3_motr_obj_context *> global_motr_obj;
 
 void s3_motr_init_timeout_cb(evutil_socket_t fd, short event, void *arg) {
-  s3_log(S3_LOG_ERROR, "", "Entering\n");
+  s3_log(S3_LOG_ERROR, "", "%s Entry\n", __func__);
   s3_iem(LOG_ALERT, S3_IEM_MOTR_CONN_FAIL, S3_IEM_MOTR_CONN_FAIL_STR,
          S3_IEM_MOTR_CONN_FAIL_JSON);
   event_base_loopbreak(global_evbase_handle);
@@ -138,10 +138,10 @@ static void on_client_request_error(evhtp_request_t *p_evhtp_req,
 // libevent run in the event loop after the signal occurs
 //
 static void s3_signal_cb(evutil_socket_t sig, short events, void *user_data) {
-  s3_log(S3_LOG_INFO, "", "Entering\n");
+  s3_log(S3_LOG_INFO, "", "%s Entry\n", __func__);
   s3_log(S3_LOG_INFO, "", "About to trigger shutdown\n");
   s3_kickoff_graceful_shutdown(1);
-  s3_log(S3_LOG_DEBUG, "", "Exiting\n");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return;
 }
 
@@ -184,8 +184,7 @@ static evhtp_res on_client_request_fini(evhtp_request_t *p_evhtp_req,
 
 extern "C" evhtp_res dispatch_s3_api_request(evhtp_request_t *req,
                                              evhtp_headers_t *hdrs, void *arg) {
-  s3_log(S3_LOG_INFO, "", "Received Request with uri [%s].\n",
-         req->uri->path->full);
+  s3_log(S3_LOG_INFO, "", "Req uri [%s]\n", req->uri->path->full);
 
   if (req->uri->query_raw) {
     s3_log(S3_LOG_DEBUG, "", "Received Request with query params [%s].\n",
@@ -314,8 +313,7 @@ extern "C" evhtp_res dispatch_s3_api_request(evhtp_request_t *req,
 extern "C" evhtp_res dispatch_motr_api_request(evhtp_request_t *req,
                                                evhtp_headers_t *hdrs,
                                                void *arg) {
-  s3_log(S3_LOG_INFO, "", "Received Request with uri [%s].\n",
-         req->uri->path->full);
+  s3_log(S3_LOG_INFO, "", "Request uri [%s]\n", req->uri->path->full);
 
   if (req->uri->query_raw) {
     s3_log(S3_LOG_DEBUG, "", "Received Request with query params [%s].\n",

--- a/ut/s3_request_object_test.cc
+++ b/ut/s3_request_object_test.cc
@@ -503,3 +503,14 @@ TEST_F(S3RequestObjectTest, FreeReadTimerNull) {
   EXPECT_CALL(*mock_event_obj_ptr, free_event(_)).Times(0);
   request_with_mock_http_event->free_client_read_timer();
 }
+
+TEST_F(S3RequestObjectTest, ValidateStrippedRequestId) {
+  std::string request_id = request->get_request_id();
+  std::string stripped_request_id = request->get_stripped_request_id();
+
+  std::string strip_request_id =
+      std::string(request_id.end() - 12, request_id.end());
+
+  EXPECT_TRUE(strip_request_id.compare(stripped_request_id) == 0);
+  EXPECT_TRUE(stripped_request_id.length() == 12);
+}


### PR DESCRIPTION
**S3 Server changes :**

> Changed Entering to Entry.
> Changed Exiting to Exit.
> Function names will be present in only Entry, Exit, Constructor
> and Destructor Log messages.
> Req ID changed to Req.
> Added Stripped Request id which will be used in place of
> request id.
> Received Request with uri shortened to Req uri.
> Memory pool for unit_size shortened to mempool for size.
> Additional print added to display request id the first time
> along with its stripped counterpart.

**Auth Server changes :**

> "Requested action is -" changed to "Action -".
> "ACL authorization request is validated successfully" changed to "ACL
> authorization success".
> "Sending HTTP Response code" changed to "HTTP Response".
> Added Stripped Request id.
> Removed thread and request id print.

Signed-off-by: Deepak Mahale <deepak.mahale@seagate.com>