### PR TITLE
EOS-14519:Handle deletions in dev environment for delayed delete

### DIFF
--- a/dev-starts3.sh
+++ b/dev-starts3.sh
@@ -200,3 +200,20 @@ do
            --s3port $s3port --fault_injection true $fake_params --loading_indicators --getoid true
   ((++counter))
 done
+
+#restart s3background services
+is_producer_running=1
+$USE_SUDO systemctl is-active s3backgroundproducer 2>&1 > /dev/null || is_producer_running=0
+if [[ $is_producer_running -eq 1 ]]; then
+  $USE_SUDO systemctl stop s3backgroundproducer || echo "Cannot stop s3backgroundproducer services"
+fi
+
+is_consumer_running=1
+$USE_SUDO systemctl is-active s3backgroundconsumer 2>&1 > /dev/null || is_consumer_running=0
+if [[ $is_consumer_running -eq 1 ]]; then
+  $USE_SUDO systemctl stop s3backgroundconsumer || echo "Cannot stop s3backgroundconsumer services"
+fi
+
+$USE_SUDO systemctl start s3backgroundproducer
+$USE_SUDO systemctl start s3backgroundconsumer
+

--- a/dev-stops3.sh
+++ b/dev-stops3.sh
@@ -41,6 +41,19 @@ import yaml;
 print yaml.load(open("'$s3_config_file'"))["S3_SERVER_CONFIG"]["S3_SERVER_BIND_PORT"];
 ' | tr -d '\r\n'`
 
+# Stop any s3backgroundserver instances 
+is_producer_running=1
+$USE_SUDO systemctl is-active s3backgroundproducer 2>&1 > /dev/null || is_producer_running=0
+if [[ $is_producer_running -eq 1 ]]; then
+  $USE_SUDO systemctl stop s3backgroundproducer || echo "Cannot stop s3backgroundproducer services"
+fi
+
+is_consumer_running=1
+$USE_SUDO systemctl is-active s3backgroundconsumer 2>&1 > /dev/null || is_consumer_running=0
+if [[ $is_consumer_running -eq 1 ]]; then
+  $USE_SUDO systemctl stop s3backgroundconsumer || echo "Cannot stop s3backgroundconsumer services"
+fi
+
 instance=0
 while [[ $instance -lt $MAX_S3_INSTANCES_NUM ]]
 do

--- a/jenkins-build.sh
+++ b/jenkins-build.sh
@@ -261,18 +261,6 @@ if [ $cleanup_only -eq 1 ]; then
     set -e
 fi
 
-is_producer_running=1
-$USE_SUDO systemctl is-active s3backgroundproducer 2>&1 > /dev/null || is_producer_running=0
-if [[ $is_producer_running -eq 1 ]]; then
-  $USE_SUDO systemctl stop s3backgroundproducer || echo "Cannot stop s3backgroundproducer services"
-fi
-
-is_consumer_running=1
-$USE_SUDO systemctl is-active s3backgroundconsumer 2>&1 > /dev/null || is_consumer_running=0
-if [[ $is_consumer_running -eq 1 ]]; then
-  $USE_SUDO systemctl stop s3backgroundconsumer || echo "Cannot stop s3backgroundconsumer services"
-fi
-
 is_authsrv_running=1
 $USE_SUDO systemctl is-active s3authserver 2>&1 > /dev/null || is_authsrv_running=0
 if [[ $is_authsrv_running -eq 1 ]]; then
@@ -436,10 +424,6 @@ if [ "$statuss3" != "0" ]; then
   exit 1
 fi
 
-# Start the bgconsumer and producer service
-$USE_SUDO systemctl start s3backgroundconsumer
-$USE_SUDO systemctl start s3backgroundproducer
-
 # Add certificate to keystore
 if [ $use_http_client -eq 0 ]
 then
@@ -479,9 +463,6 @@ fi
 
 # Disable fault injection in AuthServer
 $USE_SUDO sed -i 's/enableFaultInjection=.*$/enableFaultInjection=false/g' /opt/seagate/cortx/auth/resources/authserver.properties
-
-$USE_SUDO systemctl stop s3backgroundconsumer || echo "Cannot stop s3background consumer services"
-$USE_SUDO systemctl stop s3backgroundproducer || echo "Cannot stop s3background producer services"
 
 $USE_SUDO systemctl stop s3authserver || echo "Cannot stop s3authserver services"
 $USE_SUDO ./dev-stops3.sh $callgraph_cmd || echo "Cannot stop s3 services"

--- a/jenkins-build.sh
+++ b/jenkins-build.sh
@@ -443,6 +443,10 @@ then
     exit 1
 fi
 
+# Stop S3 background services before tests are run
+systemctl stop s3backgroundproducer
+systemctl stop s3backgroundconsumer
+
 basic_test_cmd_par=""
 if [ $basic_test_only -eq 1 ]
 then

--- a/jenkins-build.sh
+++ b/jenkins-build.sh
@@ -424,6 +424,7 @@ if [ "$statuss3" != "0" ]; then
   exit 1
 fi
 
+
 # Add certificate to keystore
 if [ $use_http_client -eq 0 ]
 then

--- a/s3backgrounddelete/s3backgrounddelete/object_recovery_scheduler.py
+++ b/s3backgrounddelete/s3backgrounddelete/object_recovery_scheduler.py
@@ -72,6 +72,9 @@ class ObjectRecoveryScheduler(object):
                 self.config.get_rabbitmq_mode(),
                 self.config.get_rabbitmq_durable(),
                 self.logger)
+            # Cleanup all entries and enqueue only 1000 entries
+            mq_client.purge_queue(self.config.get_rabbitmq_queue_name())
+
             result, index_response = CORTXS3IndexApi(
                 self.config, logger=self.logger).list(
                     self.config.get_probable_delete_index_id(), self.config.get_max_keys(), marker)
@@ -117,8 +120,6 @@ class ObjectRecoveryScheduler(object):
                             self.logger.info(
                                 "Object recovery queue send data successfully :" +
                                 str(record))
-                    if (is_truncated == "true"):
-                        self.add_kv_to_queue(probable_delete_json["NextMarker"])
                 else:
                     self.logger.info(
                         "Index listing result empty. Ignoring adding entry to object recovery queue")

--- a/s3backgrounddelete/s3backgrounddelete/object_recovery_scheduler.py
+++ b/s3backgrounddelete/s3backgrounddelete/object_recovery_scheduler.py
@@ -58,6 +58,17 @@ class ObjectRecoveryScheduler(object):
         timeDeltaInMns = math.floor(timeDelta.total_seconds()/60)
         return (timeDeltaInMns >= OlderInMins)
 
+    @staticmethod
+    def stripMarker(record):
+        bisected_record = {}
+        for (key, value) in record.items():
+            if key == "Key":
+                bisected_record[key] = value[1:]
+            else:
+                bisected_record[key] = value
+
+        return bisected_record
+
     def add_kv_to_queue(self, marker = None):
         """Add object key value to object recovery queue."""
         self.logger.info("Adding kv list to queue")
@@ -105,6 +116,8 @@ class ObjectRecoveryScheduler(object):
                                               " is NOT older than " + str(leak_processing_delay) +
                                               "mins. Skipping entry")
                             continue
+
+                        record = ObjectRecoveryScheduler.stripMarker(record)
 
                         self.logger.info(
                             "Object recovery queue sending data :" +


### PR DESCRIPTION
## Problem Statement
_[EOS-14519](https://jts.seagate.com/browse/EOS-14519):_
_Handle deletions in dev environment using backgroundelete for delayed delete_

## Problem Description
Handle deletions in dev environment using backgroundelete
whenever S3 IO is performed using jenkins build job or
any manually executed S3 IO (outside of the jenkins session) by manually running all services (e.g, s3server, s3auth, haroxy, ldap, motr) there should be no object leak in the dev environment

## Solution Overview
_1) Ensure that rabbit mq is installed and is up and running_
_2) Stop/Start s3background producer and consumer services_
_3) In case of cleanup mode or after tests are run, leave s3backgroundproducer and s3backgroundconsumer in a disabled state_


## Unit Test Cases
_1)./jenkins with STs should start and finish cleanly (no objects and index entries in motr, no background service running)_

_2)background services should also start by default on dev-vm when we do start-s3 and dev-stop-s3_

_3)multiple times start-s3 and dev-stop-s3_
