### PR TITLE
EOS-15439:S3: Disable motr version check from s3 rpm spec file

### DIFF
--- a/rpms/s3/s3rpm.spec
+++ b/rpms/s3/s3rpm.spec
@@ -92,7 +92,9 @@ BuildRequires: python-keyring python-futures
 # TODO for rhel 8
 
 %if %{with cortx_motr}
-Requires: cortx-motr = %{h_cortxmotr_version}
+# Uncomment below line to enable motr version  check during s3server rpm installation
+#Requires: cortx-motr = %{h_cortxmotr_version}
+Requires: cortx-motr
 %endif
 Requires: libxml2
 Requires: libyaml


### PR DESCRIPTION
Disabling strict check between s3 and motr rpm 
Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>