### PR TITLE
EOS-15999:[MiniProvisioner] : s3confstore followup of EOS-15862 and implement set() and setkey() APIs

### DIFF
--- a/s3cortxutils/s3confstore/s3confstore/cortx_s3_confstore.py
+++ b/s3cortxutils/s3confstore/s3confstore/cortx_s3_confstore.py
@@ -23,6 +23,8 @@ from urllib.parse import urlparse
 import os.path
 import json
 import sys
+import inspect
+from cortx.utils.kv_store import kv_store_collection
 
 class S3CortxConfStore:
   default_index = "default_cortx_s3_confstore_index"
@@ -39,6 +41,13 @@ class S3CortxConfStore:
     """Get the key's config from constore"""
     result_get = self.conf_store.get(index, key, default_val=None)
     return result_get
+
+  def set_config(self, index: str, key: str, setval: str, save: bool):
+    """Set the key's value in constore"""
+    self.conf_store.set(index, key, setval)
+    if save == True:
+      """Update the index backend"""
+      self.conf_store.save(index)
 
   def get_data_config(self, index: str):
     """Obtains entire config for the given index from constore"""
@@ -69,36 +78,79 @@ class S3CortxConfStore:
       os.remove("/tmp/cortx_s3_confstoreuttest.json")
       exit(-1)
 
+    self.set_config(index, 'cluster.cluster_id', '1234', False)
+    result_data = self.get_config(index, 'cluster.cluster_id')
+    if result_data != '1234':
+      print("set_config() failed!")
+      os.remove("/tmp/cortx_s3_confstoreuttest.json")
+      exit(-1)
+
     os.remove("/tmp/cortx_s3_confstoreuttest.json")
     print("cortx_s3_confstore unit test passed!")
 
   def run(self):
     parser = argparse.ArgumentParser(description='Cortx-Utils ConfStore')
-    parser.add_argument("--load", help='Load the backing storage in this index')
+    parser.add_argument("--load", help='Load the backing storage in this index, pass --path to config')
     parser.add_argument("--get", help='Obtain config for this given index using a key, pass --key')
     parser.add_argument("--get_data", help='Obtains entire config for this given index')
-    parser.add_argument("--key", help='Provide a key to be used in --get')
+    parser.add_argument("--set", help='Sets config value for this given index using a key, pass --key and --setval')
+    parser.add_argument("--persistent", help='Optional, pass <Yes> if needed, to be used with --set, this updates the backend along with --set')
+    parser.add_argument("--key", help='Provide a key to be used in --get and --set')
     parser.add_argument("--getkey", help='Fetch value of the given key from default index, pass --path to config')
-    parser.add_argument("--path", help='example: JSON:///etc/cortx/myconf.json')
-    parser.add_argument("--uttest", help='An unit test for the load, get and get_data APIs')
-
-    args = parser.parse_args()
+    parser.add_argument("--setkey", help='Sets config value for the given key from default index, pass --path to config and --setval')
+    parser.add_argument("--setval", help='String value to be set using --set or --setkey')
+    parser.add_argument("--path", help='Path to config file, supported formats are: json, toml, yaml, ini, pillar (salt). Usage: <format>://<file_path>, e.g. JSON:///etc/cortx/myconf.json')
+    parser.add_argument("--uttest", help='An unit test for the load, get, get_data and set APIs')
 
     if len(sys.argv) < 2:
       print("Incorrect args, use -h to review usage")
       exit(-1)
 
+    args = parser.parse_args()
+
     if args.path:
+      if args.load == None and args.getkey == None and args.setkey == None:
+        print("--path is needed by only --load, --getkey and --setkey")
+        exit(-1)
       if os.path.isfile(urlparse(args.path).path) != True:
         print("config file: {} does not exist".format(args.path))
         exit(-1)
       else:
-        try:
-          with open(urlparse(args.path).path) as f:
-            json.load(f)
-        except ValueError as e:
-          print("config file: {} must use valid JSON format: {}".format(urlparse(args.path).path, e))
+        store_type = urlparse(args.path).scheme
+        is_valid_type = False
+        valid_types = ''
+        storage = inspect.getmembers(kv_store_collection, inspect.isclass)
+        for name, cls in storage:
+          if hasattr(cls, 'name') and name != "KvStore":
+            valid_types += cls.name + ' '
+            if store_type == cls.name:
+              is_valid_type = True
+              break
+
+        if is_valid_type == False:
+          print("Invalid storage type {} in config file: {}, accepted types are {}".format(store_type, args.path, valid_types))
           exit(-1)
+
+        if store_type == 'json':
+          try:
+            with open(urlparse(args.path).path) as f:
+              json.load(f)
+          except ValueError as e:
+            print("config file: {} must use valid JSON format: {}".format(urlparse(args.path).path, e))
+            exit(-1)
+        """TODO: Implement rest of the type's content validators here"""
+
+    if args.key and args.get == None and args.set == None:
+      print("--key is needed by only --get and --set")
+      exit(-1)
+
+    if args.setval and args.set == None and args.setkey == None:
+      print("--setval is needed by only --set and --setkey")
+      exit(-1)
+
+    if args.persistent == "Yes" and args.set == None:
+      print("--persistent option to be used only with --set")
+      exit(-1)
 
     if args.get:
       if args.key == None:
@@ -113,14 +165,28 @@ class S3CortxConfStore:
       if result_get_data:
         print("{}".format(result_get_data))
 
-    if args.load or args.getkey:
+    if args.set:
+      if args.key == None:
+        print("Please provide the key to be set in confstore using --key")
+        exit(-1)
+      if args.setval == None:
+        print("Please provide the value to be set in string format using --setval")
+        exit(-1)
+      if args.persistent and args.persistent != "Yes":
+        print("Please provide Yes as the valid value for --persistent")
+        exit(-1)
+      self.set_config(args.set, args.key, args.setval, args.persistent == "Yes")
+
+    if args.load or args.getkey or args.setkey:
       if args.path == None:
         print("Please provide the path to be load into confstore")
         exit(-1)
       urlpath = args.path
+
       if args.load:
         self.load_config(args.load, urlpath)
         print("load conf: {} into index: {}".format(urlpath, args.load))
+
       elif args.getkey:
         self.load_config(self.default_index, urlpath)
         result_get = self.get_config(self.default_index, args.getkey)
@@ -128,6 +194,14 @@ class S3CortxConfStore:
           print("{}".format(result_get))
         else:
           exit(-2)
+
+      elif args.setkey:
+        if args.setval == None:
+          print("Please provide the value to be set in string format using --setval")
+          exit(-1)
+        self.load_config(self.default_index, urlpath)
+        self.set_config(self.default_index, args.setkey, args.setval, True)
+
     elif args.uttest:
       self.uttest(args.uttest)
     pass

--- a/s3cortxutils/s3confstore/s3confstore/cortx_s3_confstore.py
+++ b/s3cortxutils/s3confstore/s3confstore/cortx_s3_confstore.py
@@ -17,7 +17,6 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 import argparse
-# from cortx.utils.conf_store import Conf
 from cortx.utils.conf_store import ConfStore
 from urllib.parse import urlparse
 import os.path
@@ -42,7 +41,7 @@ class S3CortxConfStore:
     result_get = self.conf_store.get(index, key, default_val=None)
     return result_get
 
-  def set_config(self, index: str, key: str, setval: str, save: bool):
+  def set_config(self, index: str, key: str, setval: str, save: bool = False):
     """Set the key's value in constore"""
     self.conf_store.set(index, key, setval)
     if save == True:
@@ -110,7 +109,7 @@ class S3CortxConfStore:
 
     if args.path:
       if args.load == None and args.getkey == None and args.setkey == None:
-        print("--path is needed by only --load, --getkey and --setkey")
+        print("--path option is required only for --load, --getkey and --setkey options")
         exit(-1)
       if os.path.isfile(urlparse(args.path).path) != True:
         print("config file: {} does not exist".format(args.path))

--- a/s3cortxutils/s3confstore/setup.py
+++ b/s3cortxutils/s3confstore/setup.py
@@ -21,7 +21,6 @@ from setuptools import setup
 files = ["VERSION"]
 
 # Load the version
-s3confstore_version = "1.0.0"
 current_script_path = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(current_script_path, 'VERSION')) as version_file:
     s3confstore_version = version_file.read().strip()


### PR DESCRIPTION
#  EOS-15999:[MiniProvisioner] : s3confstore followup of EOS-15862 and implement set() and setkey() APIs

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch does not have any conflicts_
- [] **Code review:** _All discussions have been resolved_
- [] **Sanity Testing:** _jenkins job running at http://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/S3server-7.8.2003/315/ _
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Unit test performed on VM for this change_

## UT
cat /etc/myconf.yaml
bridge: {manufacturer: homebridge.io, model: homebridge, name: Homebridge, pin: 031-45-154,
  port: '51831', username: 'CC:22:3D:E3:CE:30'}

/usr/local/bin/s3confstore --getkey "bridge.port" --path "YAML:///etc/myconf.yaml"
51831

/usr/local/bin/s3confstore --setkey "bridge.port" --path "YAML:///etc/myconf.yaml" --setval 51840

/usr/local/bin/s3confstore --getkey "bridge.port" --path "YAML:///etc/myconf.yaml"
51840

cat /etc/myconf.yaml
bridge: {manufacturer: homebridge.io, model: homebridge, name: Homebridge, pin: 031-45-154,
  port: '51840', username: 'CC:22:3D:E3:CE:30'}


cat /etc/myconf.json
{
  "bridge": {
    "name": "Homebridge",
    "username": "CC:22:3D:E3:CE:30",
    "manufacturer": "homebridge.io",
    "model": "homebridge",
    "port": "51831",
    "pin": "031-45-154"
  }
}

/usr/local/bin/s3confstore --getkey "bridge.port" --path "JSON:///etc/myconf.json"
51831

/usr/local/bin/s3confstore --setkey "bridge.port" --path "JSON:///etc/myconf.json" --setval 51840

cat /etc/myconf.json
{
  "bridge": {
    "name": "Homebridge",
    "username": "CC:22:3D:E3:CE:30",
    "manufacturer": "homebridge.io",
    "model": "homebridge",
    "port": "51840",
    "pin": "031-45-154"
  }
}

/usr/local/bin/s3confstore --setkey "bridge.port" --path "NOTEPAD:///etc/myconf.json" --setval 51840
Invalid storage type notepad in config file: NOTEPAD:///etc/myconf.json, accepted types are dict ini json jsonmessage salt text toml yaml

/usr/local/bin/s3confstore --getkey "bridge.username" --path "JSON:///etc/myconfbad.json"
config file: /etc/myconfbad.json must use valid JSON format: Expecting ',' delimiter: line 9 column 1 (char 162)

/usr/local/bin/s3confstore --uttest "index"
cortx_s3_confstore unit test passed!

/usr/local/bin/s3confstore --path "JSON:///etc/myconfbad.json"
--path is needed by only --load, --getkey and --setkey


## Commit Message
commit 0f49a36c38e29c2b815cf4afedf7bf36219989c0
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Thu Dec 24 02:51:29 2020 -0700

        EOS-15999:[MiniProvisioner] : s3confstore followup of EOS-15862 and implement set() and setkey() APIs
        Files updated:
                modified:   s3cortxutils/s3confstore/s3confstore/cortx_s3_confstore.py
                modified:   s3cortxutils/s3confstore/setup.py
        Change description:
                1. Address remaining review comments from EOS-15862's PR
                        a. Support for config file's storage type validator // TODO: content validation for non-json types
                        b. Remove version from s3cortxutils/s3confstore/setup.py
                2. Add --set and --setkey APIs
        Unit test:
                --setkey tested along with updated --uttest
                --JSON and YAML config file types are tested

    Signed-off-by: pratyush-seagate <pratyush.k.khan@seagate.com>