### PR TITLE
EOS-16307: Init.sh script should upgrade cortx-py-utils rpm to latest version

### DIFF
--- a/ansible/common_build_env.yml
+++ b/ansible/common_build_env.yml
@@ -21,12 +21,6 @@
 
 # Prerequisites: Necessary yum repos setup, possibly jenkins_yum_repos.yml
 
-- name: install CORTX Python Utilities
-  yum:
-    name: cortx-py-utils
-    enablerepo: releases_cortx_py_utils
-    state: present
-
 - name: Install yum-utils if not present
   yum:
     name: yum-utils

--- a/scripts/env/dev/init.sh
+++ b/scripts/env/dev/init.sh
@@ -50,6 +50,16 @@ check_supported_kernel() {
   fi
 }
 
+install_cortx_py_utils() {
+  #rpm -q cortx-py-utils && yum remove cortx-py-utils -y && yum install cortx-py-utils -y
+  if rpm -q cortx-py-utils ; then
+    yum upgrade cortx-py-utils -y
+  else
+    yum install cortx-py-utils -y
+  fi
+  exit 1;
+}
+
 usage() {
   echo "Usage: $0
   optional arguments:
@@ -92,6 +102,8 @@ fi
 
 if [[ $# -eq 0 ]] ; then
   source ${S3_SRC_DIR}/scripts/env/common/setup-yum-repos.sh
+  # install or upgrade cortx-py-utils
+  install_cortx_py_utils
 else
   while getopts "ahs" x; do
       case "${x}" in
@@ -103,6 +115,8 @@ else
               ;;
           s)
              source ${S3_SRC_DIR}/scripts/env/common/setup-yum-repos.sh
+             # install or upgrade cortx-py-utils
+             install_cortx_py_utils
              ansible_automation=1;
              ;;
           *)

--- a/scripts/env/dev/init.sh
+++ b/scripts/env/dev/init.sh
@@ -57,7 +57,6 @@ install_cortx_py_utils() {
   else
     yum install cortx-py-utils -y
   fi
-  exit 1;
 }
 
 usage() {

--- a/scripts/env/release/init.sh
+++ b/scripts/env/release/init.sh
@@ -25,6 +25,16 @@ BASEDIR=$(dirname "$SCRIPT_PATH")
 S3_SRC_DIR="$BASEDIR/../../../"
 CURRENT_DIR=`pwd`
 
+install_cortx_py_utils() {
+  #rpm -q cortx-py-utils && yum remove cortx-py-utils -y && yum install cortx-py-utils -y
+  if rpm -q cortx-py-utils ; then
+    yum upgrade cortx-py-utils -y
+  else
+    yum install cortx-py-utils -y
+  fi
+  exit 1;
+}
+
 usage() {
   echo "Usage: $0
   optional arguments:
@@ -34,6 +44,8 @@ usage() {
 
 if [[ $# -eq 0 ]] ; then
   source ${S3_SRC_DIR}/scripts/env/common/setup-yum-repos.sh
+  # install or upgrade cortx-py-utils
+  install_cortx_py_utils
 else
   while getopts "ah" x; do
       case "${x}" in

--- a/scripts/env/release/init.sh
+++ b/scripts/env/release/init.sh
@@ -32,7 +32,6 @@ install_cortx_py_utils() {
   else
     yum install cortx-py-utils -y
   fi
-  exit 1;
 }
 
 usage() {

--- a/scripts/env/rpmbuild/init.sh
+++ b/scripts/env/rpmbuild/init.sh
@@ -33,7 +33,6 @@ install_cortx_py_utils() {
   else
     yum install cortx-py-utils -y
   fi
-  exit 1;
 }
 
 usage() {

--- a/scripts/env/rpmbuild/init.sh
+++ b/scripts/env/rpmbuild/init.sh
@@ -26,6 +26,16 @@ BASEDIR=$(dirname "$SCRIPT_PATH")
 S3_SRC_DIR="$BASEDIR/../../../"
 CURRENT_DIR=`pwd`
 
+install_cortx_py_utils() {
+  #rpm -q cortx-py-utils && yum remove cortx-py-utils -y && yum install cortx-py-utils -y
+  if rpm -q cortx-py-utils ; then
+    yum upgrade cortx-py-utils -y
+  else
+    yum install cortx-py-utils -y
+  fi
+  exit 1;
+}
+
 usage() {
   echo "Usage: $0
   optional arguments:
@@ -35,6 +45,8 @@ usage() {
 
 if [[ $# -eq 0 ]] ; then
   source ${S3_SRC_DIR}/scripts/env/common/setup-yum-repos.sh
+  # install or upgrade cortx-py-utils
+  install_cortx_py_utils
 else
   while getopts "ah" x; do
       case "${x}" in


### PR DESCRIPTION
- moved the installation of cortx-py-utils from the ansible files to init.sh as there is no way we can differentiate the installation for opensource and for dev vm.
- handled the upgrade scenario for cortx-py-utils

jenkins job passed:
- http://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/S3server-7.8.2003/390/consoleFull