### PR TITLE
EOS-16257: Build s3confstore and run UTs with jenkins build job

### DIFF
--- a/rebuildall.sh
+++ b/rebuildall.sh
@@ -46,6 +46,7 @@ usage() {
   echo '          --no-motrkvscli-build    : Do not build motrkvscli tool, Default (false)'
   echo '          --no-s3background-build    : Do not build s3background process, Default (false)'
   echo '          --no-s3recoverytool-build    : Do not build s3recoverytool process, Default (false)'
+  echo '          --no-s3confstoretool-build    : Do not build s3confstoretool process, Default (false)'
   echo '          --no-s3addbplugin-build    : Do not build s3 addb plugin library, Default (false)'
   echo '          --no-auth-build            : Do not build Auth Server, Default (false)'
   echo '          --no-jclient-build         : Do not build jclient, Default (false)'
@@ -138,7 +139,7 @@ get_motr_pkg_config_rpm() {
 # read the options
 OPTS=`getopt -o h --long no-motr-rpm,use-build-cache,no-check-code,no-clean-build,\
 no-s3ut-build,no-s3mempoolut-build,no-s3mempoolmgrut-build,no-s3server-build,\
-no-motrkvscli-build,no-s3background-build,no-s3recoverytool-build,\
+no-motrkvscli-build,no-s3background-build,no-s3recoverytool-build,no-s3confstoretool-build,\
 no-s3addbplugin-build,no-auth-build,no-jclient-build,no-jcloudclient-build,\
 no-s3iamcli-build,no-java-tests,no-install,just-gen-build-file,valgrind_memcheck,\
 help -n 'rebuildall.sh' -- "$@"`
@@ -156,6 +157,7 @@ no_s3server_build=0
 no_motrkvscli_build=0
 no_s3background_build=0
 no_s3recoverytool_build=0
+no_s3confstoretool_build=0
 no_s3addbplugin_build=0
 no_auth_build=0
 no_jclient_build=0
@@ -180,6 +182,7 @@ while true; do
     --no-motrkvscli-build) no_motrkvscli_build=1; shift ;;
     --no-s3background-build) no_s3background_build=1; shift ;;
     --no-s3recoverytool-build) no_s3recoverytool_build=1; shift ;;
+    --no-s3confstoretool-build) no_s3confstoretool_build=1; shift ;;
     --no-s3addbplugin-build) no_s3addbplugin_build=1; shift ;;
     --no-auth-build) no_auth_build=1; shift ;;
     --no-jclient-build) no_jclient_build=1; shift ;;
@@ -517,6 +520,17 @@ then
   if [ $no_s3recoverytool_build -eq 0 ]
   then
     cd s3recovery
+    if [ $no_clean_build -eq 0 ]
+    then
+      python36 setup.py install --force
+    else
+      python36 setup.py install
+    fi
+    cd -      
+  fi
+  if [ $no_s3confstoretool_build -eq 0 ]
+  then
+    cd s3cortxutils/s3confstore
     if [ $no_clean_build -eq 0 ]
     then
       python36 setup.py install --force

--- a/runalltest.sh
+++ b/runalltest.sh
@@ -121,7 +121,7 @@ then
   UT_MEMPOOLMGR_BIN=./bazel-bin/s3mempoolmgrut
   UT_S3BACKGROUNDDELETE=./s3backgrounddelete/scripts/run_all_ut.sh
   UT_S3RECOVERYTOOL=./s3recovery/scripts/run_all_ut.sh
-  UT_S3CONFTOOL=./s3cortxutils/s3confstore/scripts/run_all_ut.sh
+  UT_S3CONFSTORE=./s3cortxutils/s3confstore/scripts/run_all_ut.sh
 
   printf "\nCheck s3ut..."
   type  $UT_BIN >/dev/null
@@ -159,11 +159,11 @@ then
 
   $UT_S3RECOVERYTOOL 2>&1
 
-  printf "\nCheck s3conftoolut..."
-  type $UT_S3CONFTOOL >/dev/null
+  printf "\nCheck s3confstoreut..."
+  type $UT_S3CONFSTORE >/dev/null
   printf "OK \n"
 
-  $UT_S3CONFTOOL 2>&1
+  $UT_S3CONFSTORE 2>&1
 fi
 
 if [ $no_st_run -eq 0 ]

--- a/runalltest.sh
+++ b/runalltest.sh
@@ -121,6 +121,7 @@ then
   UT_MEMPOOLMGR_BIN=./bazel-bin/s3mempoolmgrut
   UT_S3BACKGROUNDDELETE=./s3backgrounddelete/scripts/run_all_ut.sh
   UT_S3RECOVERYTOOL=./s3recovery/scripts/run_all_ut.sh
+  UT_S3CONFTOOL=./s3cortxutils/s3confstore/scripts/run_all_ut.sh
 
   printf "\nCheck s3ut..."
   type  $UT_BIN >/dev/null
@@ -157,6 +158,12 @@ then
   printf "OK \n"
 
   $UT_S3RECOVERYTOOL 2>&1
+
+  printf "\nCheck s3conftoolut..."
+  type $UT_S3CONFTOOL >/dev/null
+  printf "OK \n"
+
+  $UT_S3CONFTOOL 2>&1
 fi
 
 if [ $no_st_run -eq 0 ]

--- a/s3cortxutils/s3confstore/s3confstore/cortx_s3_confstore.py
+++ b/s3cortxutils/s3confstore/s3confstore/cortx_s3_confstore.py
@@ -50,34 +50,6 @@ class S3CortxConfStore:
       """Update the index backend"""
       Conf.save(index)
 
-  def uttest(self, index: str):
-    """This will be removed to ut directory later"""
-    test_config = {
-      'cluster': {
-        "cluster_id": 'abcd-efgh-ijkl-mnop',
-        "cluster_hosts": 'myhost-1,myhost2,myhost-3',
-      }
-    }
-    with open(r'/tmp/cortx_s3_confstoreuttest.json', 'w+') as file:
-      json.dump(test_config, file, indent=2)
-    self.load_config(index, 'json:///tmp/cortx_s3_confstoreuttest.json')
-
-    result_data = self.get_config(index, 'cluster')
-    if 'cluster_id' not in result_data:
-      print("get_config() failed!")
-      os.remove("/tmp/cortx_s3_confstoreuttest.json")
-      exit(-1)
-
-    self.set_config(index, 'cluster>cluster_id', '1234', False)
-    result_data = self.get_config(index, 'cluster>cluster_id')
-    if result_data != '1234':
-      print("set_config() failed!")
-      os.remove("/tmp/cortx_s3_confstoreuttest.json")
-      exit(-1)
-
-    os.remove("/tmp/cortx_s3_confstoreuttest.json")
-    print("cortx_s3_confstore unit test passed!")
-
   def run(self):
     parser = argparse.ArgumentParser(description='Cortx-Utils ConfStore')
     parser.add_argument("--load", help='Load the backing storage in this index, pass --path to config')
@@ -89,7 +61,6 @@ class S3CortxConfStore:
     parser.add_argument("--setkey", help='Sets config value for the given key from default index, pass --path to config and --setval')
     parser.add_argument("--setval", help='String value to be set using --set or --setkey')
     parser.add_argument("--path", help='Path to config file, supported formats are: json, toml, yaml, ini, pillar (salt). Usage: <format>://<file_path>, e.g. JSON:///etc/cortx/myconf.json')
-    parser.add_argument("--uttest", help='An unit test for the load, get, get_data and set APIs')
 
     if len(sys.argv) < 2:
       print("Incorrect args, use -h to review usage")
@@ -188,8 +159,5 @@ class S3CortxConfStore:
           exit(-1)
         self.load_config(self.default_index, urlpath)
         self.set_config(self.default_index, args.setkey, args.setval, True)
-
-    elif args.uttest:
-      self.uttest(args.uttest)
     pass
 

--- a/s3cortxutils/s3confstore/scripts/run_all_ut.sh
+++ b/s3cortxutils/s3confstore/scripts/run_all_ut.sh
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+#Script to run UT's of s3recovery tool
+set -e
+
+abort()
+{
+    echo >&2 '
+***************
+*** FAILED ***
+***************
+'
+    echo "Error encountered. Exiting unit test runs prematurely..." >&2
+    trap : 0
+    exit 1
+}
+trap 'abort' 0
+
+printf "\nRunning s3confstore tool UT's...\n"
+
+SCRIPT_PATH=$(readlink -f "$0")
+SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
+
+#Update python path to source modules and run unit tests.
+PYTHONPATH=${PYTHONPATH}:${SCRIPT_DIR}/.. python36 -m pytest $SCRIPT_DIR/../ut/*.py -v
+
+echo "s3confstore tool UT's runs successfully"
+
+trap : 0
+

--- a/s3cortxutils/s3confstore/scripts/run_all_ut.sh
+++ b/s3cortxutils/s3confstore/scripts/run_all_ut.sh
@@ -17,7 +17,7 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-#Script to run UT's of s3recovery tool
+#Script to run UT's of s3confstore
 set -e
 
 abort()
@@ -33,7 +33,7 @@ abort()
 }
 trap 'abort' 0
 
-printf "\nRunning s3confstore tool UT's...\n"
+printf "\nRunning s3confstore UT's...\n"
 
 SCRIPT_PATH=$(readlink -f "$0")
 SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
@@ -41,7 +41,7 @@ SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
 #Update python path to source modules and run unit tests.
 PYTHONPATH=${PYTHONPATH}:${SCRIPT_DIR}/.. python36 -m pytest $SCRIPT_DIR/../ut/*.py -v
 
-echo "s3confstore tool UT's runs successfully"
+echo "s3confstore UT's runs successfully"
 
 trap : 0
 

--- a/s3cortxutils/s3confstore/scripts/run_all_ut.sh
+++ b/s3cortxutils/s3confstore/scripts/run_all_ut.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 #
 # Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
 #
@@ -39,7 +40,7 @@ SCRIPT_PATH=$(readlink -f "$0")
 SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
 
 #Update python path to source modules and run unit tests.
-PYTHONPATH=${PYTHONPATH}:${SCRIPT_DIR}/.. python36 -m pytest $SCRIPT_DIR/../ut/*.py -v
+PYTHONPATH="${PYTHONPATH}:${SCRIPT_DIR}"/.. python36 -m pytest "$SCRIPT_DIR"/../ut/*.py -v
 
 echo "s3confstore UT's runs successfully"
 

--- a/s3cortxutils/s3confstore/ut/s3confstore_unit_tests.py
+++ b/s3cortxutils/s3confstore/ut/s3confstore_unit_tests.py
@@ -19,8 +19,61 @@
 
 #!/usr/bin/python3.6
 
+import mock
+import unittest
+import json
+import os.path
 from s3confstore.cortx_s3_confstore import S3CortxConfStore
+from cortx.utils.conf_store import Conf
 
-def test_uttest():
-  s3confstore = S3CortxConfStore()
-  s3confstore.uttest("ut_index")
+class S3ConfStoreAPIsUT(unittest.TestCase):
+  """UT to test current APIs"""
+
+  def test_json_conf(self):
+    index = "dummy_idx_1"
+    s3confstore = S3CortxConfStore()
+    test_config = {
+      'cluster': {
+        "cluster_id": 'abcd-efgh-ijkl-mnop',
+        "cluster_hosts": 'myhost-1,myhost2,myhost-3',
+      }
+    }
+    with open(r'/tmp/cortx_s3_confstoreuttest.json', 'w+') as file:
+      json.dump(test_config, file, indent=2)
+    s3confstore.load_config(index, 'json:///tmp/cortx_s3_confstoreuttest.json')
+    result_data = s3confstore.get_config(index, 'cluster')
+    if 'cluster_id' not in result_data:
+      os.remove("/tmp/cortx_s3_confstoreuttest.json")
+      self.assertFalse(True)
+    s3confstore.set_config(index, 'cluster>cluster_id', '1234', False)
+    result_data = s3confstore.get_config(index, 'cluster>cluster_id')
+    if result_data != '1234':
+      os.remove("/tmp/cortx_s3_confstoreuttest.json")
+      self.assertFalse(True)
+    os.remove("/tmp/cortx_s3_confstoreuttest.json")
+
+  def test_yaml_conf(self):
+    index = "dummy_idx_2"
+    s3confstore = S3CortxConfStore()
+    test_config = "bridge: {manufacturer: homebridge.io, model: homebridge, name: Homebridge, pin: 031-45-154, port: '51840', username: 'CC:22:3D:E3:CE:30'}"
+    with open(r'/tmp/cortx_s3_confstoreuttest.yaml', 'w+') as file:
+      file.write(test_config)
+    s3confstore.load_config(index, 'yaml:///tmp/cortx_s3_confstoreuttest.yaml')
+    result_data = s3confstore.get_config(index, 'bridge')
+    if 'port' not in result_data:
+      os.remove("/tmp/cortx_s3_confstoreuttest.yaml")
+      self.assertFalse(True)
+    s3confstore.set_config(index, 'bridge>port', '1234', False)
+    result_data = s3confstore.get_config(index, 'bridge>port')
+    if result_data != '1234':
+      os.remove("/tmp/cortx_s3_confstoreuttest.yaml")
+      self.assertFalse(True)
+    os.remove("/tmp/cortx_s3_confstoreuttest.yaml")
+
+  @mock.patch.object(Conf, 'get')
+  def test_mock_get(self, mock_get_return):
+    index = "dummy_idx_3"
+    s3confstore = S3CortxConfStore()
+    mock_get_return.return_value = "dummy_return: dummy_123"
+    result_data = s3confstore.get_config(index, 'bridge')
+    self.assertTrue('dummy_123' in result_data)

--- a/s3cortxutils/s3confstore/ut/s3confstore_unit_tests.py
+++ b/s3cortxutils/s3confstore/ut/s3confstore_unit_tests.py
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+#!/usr/bin/python3.6
+
+from s3confstore.cortx_s3_confstore import S3CortxConfStore
+
+def test_uttest():
+  s3confstore = S3CortxConfStore()
+  s3confstore.uttest("ut_index")

--- a/s3cortxutils/s3confstore/ut/s3confstore_unit_tests.py
+++ b/s3cortxutils/s3confstore/ut/s3confstore_unit_tests.py
@@ -25,9 +25,11 @@ import json
 import os.path
 from s3confstore.cortx_s3_confstore import S3CortxConfStore
 from cortx.utils.conf_store import Conf
+import tempfile
 
 class S3ConfStoreAPIsUT(unittest.TestCase):
-  """UT to test current APIs"""
+  """
+  UT to test current APIs"""
 
   def test_json_conf(self):
     index = "dummy_idx_1"
@@ -38,42 +40,105 @@ class S3ConfStoreAPIsUT(unittest.TestCase):
         "cluster_hosts": 'myhost-1,myhost2,myhost-3',
       }
     }
-    with open(r'/tmp/cortx_s3_confstoreuttest.json', 'w+') as file:
+    tmpdir = tempfile.mkdtemp()
+    filename = 'cortx_s3_confstoreuttest.json'
+    saved_umask = os.umask(0o077)
+    path = os.path.join(tmpdir, filename)
+    with open(path, 'w+') as file:
       json.dump(test_config, file, indent=2)
-    s3confstore.load_config(index, 'json:///tmp/cortx_s3_confstoreuttest.json')
+    conf_url='json://' + path
+    s3confstore.load_config(index, conf_url)
     result_data = s3confstore.get_config(index, 'cluster')
     if 'cluster_id' not in result_data:
-      os.remove("/tmp/cortx_s3_confstoreuttest.json")
+      os.remove(path)
+      os.umask(saved_umask)
+      os.rmdir(tmpdir)
       self.assertFalse(True)
     s3confstore.set_config(index, 'cluster>cluster_id', '1234', False)
     result_data = s3confstore.get_config(index, 'cluster>cluster_id')
     if result_data != '1234':
-      os.remove("/tmp/cortx_s3_confstoreuttest.json")
+      os.remove(path)
+      os.umask(saved_umask)
+      os.rmdir(tmpdir)
       self.assertFalse(True)
-    os.remove("/tmp/cortx_s3_confstoreuttest.json")
+    os.remove(path)
+    os.umask(saved_umask)
+    os.rmdir(tmpdir)
 
   def test_yaml_conf(self):
     index = "dummy_idx_2"
     s3confstore = S3CortxConfStore()
     test_config = "bridge: {manufacturer: homebridge.io, model: homebridge, name: Homebridge, pin: 031-45-154, port: '51840', username: 'CC:22:3D:E3:CE:30'}"
-    with open(r'/tmp/cortx_s3_confstoreuttest.yaml', 'w+') as file:
+    tmpdir = tempfile.mkdtemp()
+    filename = 'cortx_s3_confstoreuttest.yaml'
+    saved_umask = os.umask(0o077)
+    path = os.path.join(tmpdir, filename)
+    with open(path, 'w+') as file:
       file.write(test_config)
-    s3confstore.load_config(index, 'yaml:///tmp/cortx_s3_confstoreuttest.yaml')
+    conf_url='yaml://' + path
+    s3confstore.load_config(index, conf_url)
     result_data = s3confstore.get_config(index, 'bridge')
     if 'port' not in result_data:
-      os.remove("/tmp/cortx_s3_confstoreuttest.yaml")
+      os.remove(path)
+      os.umask(saved_umask)
+      os.rmdir(tmpdir)
       self.assertFalse(True)
     s3confstore.set_config(index, 'bridge>port', '1234', False)
     result_data = s3confstore.get_config(index, 'bridge>port')
     if result_data != '1234':
-      os.remove("/tmp/cortx_s3_confstoreuttest.yaml")
+      os.remove(path)
+      os.umask(saved_umask)
+      os.rmdir(tmpdir)
       self.assertFalse(True)
-    os.remove("/tmp/cortx_s3_confstoreuttest.yaml")
+    os.remove(path)
+    os.umask(saved_umask)
+    os.rmdir(tmpdir)
+
+  @mock.patch.object(Conf, 'load')
+  @mock.patch.object(Conf, 'get')
+  def test_mock_load(self, mock_load_return, mock_get_return):
+    index = "dummy_idx_3"
+    s3confstore = S3CortxConfStore()
+    mock_load_return.return_value=None
+    mock_get_return.return_value = None
+    s3confstore.load_config(None, "dummy")
+    result_data = s3confstore.get_config(index, 'bridge')
+    self.assertTrue(result_data == mock_get_return.return_value)
 
   @mock.patch.object(Conf, 'get')
   def test_mock_get(self, mock_get_return):
-    index = "dummy_idx_3"
+    index = "dummy_idx_4"
     s3confstore = S3CortxConfStore()
     mock_get_return.return_value = "dummy_return: dummy_123"
     result_data = s3confstore.get_config(index, 'bridge')
     self.assertTrue('dummy_123' in result_data)
+
+  @mock.patch.object(Conf, 'load')
+  @mock.patch.object(Conf, 'get')
+  @mock.patch.object(Conf, 'set')
+  def test_mock_set(self, mock_load_return, mock_get_return, mock_set_return):
+    index = "dummy_idx_5"
+    s3confstore = S3CortxConfStore()
+    mock_load_return.return_value=None
+    mock_get_return.return_value = None
+    mock_set_return.return_value = None
+    s3confstore.load_config(None, "dummy")
+    s3confstore.set_config(index, "dummykey", "bridge:NA", False)
+    result_data = s3confstore.get_config(index, 'bridge')
+    self.assertTrue(result_data == mock_get_return.return_value)
+
+  @mock.patch.object(Conf, 'load')
+  @mock.patch.object(Conf, 'get')
+  @mock.patch.object(Conf, 'set')
+  @mock.patch.object(Conf, 'save')
+  def test_mock_save(self, mock_load_return, mock_get_return, mock_set_return, mock_save_return):
+    index = "dummy_idx_6"
+    s3confstore = S3CortxConfStore()
+    mock_load_return.return_value=None
+    mock_get_return.return_value = None
+    mock_set_return.return_value = None
+    mock_save_return.return_value = None
+    s3confstore.load_config(None, "dummy")
+    s3confstore.set_config(index, "dummykey", "bridge:NA", True)
+    result_data = s3confstore.get_config(index, 'bridge')
+    self.assertTrue(result_data == mock_get_return.return_value)

--- a/scripts/env/dev/init.sh
+++ b/scripts/env/dev/init.sh
@@ -50,6 +50,11 @@ check_supported_kernel() {
   fi
 }
 
+install_toml() {
+  echo "Installing toml"
+  pip3 install toml
+}
+
 usage() {
   echo "Usage: $0
   optional arguments:
@@ -92,6 +97,8 @@ fi
 
 if [[ $# -eq 0 ]] ; then
   source ${S3_SRC_DIR}/scripts/env/common/setup-yum-repos.sh
+  # install pip3 package toml if not present, needed by cortx-py-utils for s3confstore UT
+  install_toml
 else
   while getopts "ahs" x; do
       case "${x}" in
@@ -103,6 +110,8 @@ else
               ;;
           s)
              source ${S3_SRC_DIR}/scripts/env/common/setup-yum-repos.sh
+             # install pip3 package toml if not present, needed by cortx-py-utils for s3confstore UT
+             install_toml
              ansible_automation=1;
              ;;
           *)

--- a/scripts/env/release/init.sh
+++ b/scripts/env/release/init.sh
@@ -25,6 +25,11 @@ BASEDIR=$(dirname "$SCRIPT_PATH")
 S3_SRC_DIR="$BASEDIR/../../../"
 CURRENT_DIR=`pwd`
 
+install_toml() {
+  echo "Installing toml"
+  pip3 install toml
+}
+
 usage() {
   echo "Usage: $0
   optional arguments:
@@ -34,6 +39,8 @@ usage() {
 
 if [[ $# -eq 0 ]] ; then
   source ${S3_SRC_DIR}/scripts/env/common/setup-yum-repos.sh
+  # install pip3 package toml if not present, needed by cortx-py-utils for s3confstore UT
+  install_toml
 else
   while getopts "ah" x; do
       case "${x}" in

--- a/scripts/env/rpmbuild/init.sh
+++ b/scripts/env/rpmbuild/init.sh
@@ -26,6 +26,11 @@ BASEDIR=$(dirname "$SCRIPT_PATH")
 S3_SRC_DIR="$BASEDIR/../../../"
 CURRENT_DIR=`pwd`
 
+install_toml() {
+  echo "Installing toml"
+  pip3 install toml
+}
+
 usage() {
   echo "Usage: $0
   optional arguments:
@@ -35,6 +40,8 @@ usage() {
 
 if [[ $# -eq 0 ]] ; then
   source ${S3_SRC_DIR}/scripts/env/common/setup-yum-repos.sh
+  # install pip3 package toml if not present, needed by cortx-py-utils for s3confstore UT
+  install_toml
 else
   while getopts "ah" x; do
       case "${x}" in


### PR DESCRIPTION
commit d457679cf58f716352cd90c3aaef5f182b06c3c4
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Mon Jan 11 00:41:41 2021 -0700

        EOS-16257: Build s3confstore and run UTs with jenkins build job
            Change description:
                Added build step in rebuildall.sh script (just like s3recovery and s3backgrounddelete) for s3confstore.
                Added UT for s3confstore and made sure they run as part of jenkins job via runalltest.sh
            List of files:
                modified:   rebuildall.sh
                modified:   runalltest.sh
                new file:   s3cortxutils/s3confstore/scripts/run_all_ut.sh
                new file:   s3cortxutils/s3confstore/ut/s3confstore_unit_tests.py
            Testing:
            UT:
                    1. using rebuildall.sh, using console logs, verified s3confstore is being compiled.
                2. using ./jenkins-build.sh and ./runalltest.sh, verified s3confstore_unit_tests.py is being executed successfully.
                    Note: pip3 install  ./cortx_py_utils-1.0.0-py3-none-any.whl needed to install cortx-py-utils before running s3confstore unit test.

    Signed-off-by: pratyush-seagate <pratyush.k.khan@seagate.com>
