### PR TITLE
EOS:16252 Changed debug log level for s3backgrounddelete in build-rpm.sh

### DIFF
--- a/rpms/s3/buildrpm.sh
+++ b/rpms/s3/buildrpm.sh
@@ -89,6 +89,7 @@ if ! [ -z "${GIT_VER}" ]; then
     if [ $ENABLE_DEBUG_LOG == 1 ]; then
         sed -i 's/#logLevel=DEBUG.*$/logLevel=DEBUG/g' auth/resources/authserver.properties.sample
         sed -i 's/S3_LOG_MODE:.*$/S3_LOG_MODE: DEBUG/g' s3config.release.yaml.sample
+        sed -i 's/file_log_level:.*$/file_log_level: 10/g' s3backgrounddelete/s3backgrounddelete/config/s3_background_delete_config.yaml.sample
     fi
     # For sake of test, attempt checkout of version
     git checkout ${GIT_VER}
@@ -99,6 +100,8 @@ elif ! [ -z "${PATH_SRC}" ]; then
     if [ $ENABLE_DEBUG_LOG == 1 ]; then
         sed -i 's/#logLevel=DEBUG.*$/logLevel=DEBUG/g' cortx-s3server-${S3_VERSION}-git${GIT_VER}/auth/resources/authserver.properties.sample
         sed -i 's/S3_LOG_MODE:.*$/S3_LOG_MODE: DEBUG/g' cortx-s3server-${S3_VERSION}-git${GIT_VER}/s3config.release.yaml.sample
+        sed -i 's/file_log_level:.*$/file_log_level: 10/g' cortx-s3server-${S3_VERSION}-git${GIT_VER}s3backgrounddelete/s3backgrounddelete/config/s3_background_delete_config.yaml.sample
+
     fi
     find ./cortx-s3server-${S3_VERSION}-git${GIT_VER} -type f -name CMakeCache.txt -delete;
 fi

--- a/s3-sanity-test.sh
+++ b/s3-sanity-test.sh
@@ -62,6 +62,9 @@ fi
 
 USAGE="USAGE: bash $(basename "$0")
 Run S3 sanity test.
+
+PRE-REQUISITES: s3cmd and s3iamcli need to be present
+
 where:
     -h     display this help and exit
     -c     clean s3 resources if present

--- a/s3backgrounddelete/s3backgrounddelete/config/s3_background_delete_config.yaml.sample
+++ b/s3backgrounddelete/s3backgrounddelete/config/s3_background_delete_config.yaml.sample
@@ -43,7 +43,7 @@ logconfig:                                  # Section for scheduler & processor 
    logger_directory: "/var/log/seagate/s3/s3backgrounddelete"                                 # Log directory location for background delete
    scheduler_log_file: "/var/log/seagate/s3/s3backgrounddelete/object_recovery_scheduler.log" # Log file path for background delete scheduler
    processor_log_file: "/var/log/seagate/s3/s3backgrounddelete/object_recovery_processor.log" # Log file path for background delete processor
-   file_log_level: 10                                                                         # Sets the threshold for above file loggers to level specified. https://docs.python.org/3/library/logging.html#levels
+   file_log_level: 20                                                                         # Sets the threshold for above file loggers to level specified. https://docs.python.org/3/library/logging.html#levels
    console_log_level: 40                                                                      # Sets the threshold for console loggers to level specified. https://docs.python.org/3/library/logging.html#levels
    log_format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"                         # Sets the specifed log format https://docs.python.org/3/library/logging.html#logging.Formatter
    max_bytes: 5242880                                                                         # Max size of a log files is set to 5mb


### PR DESCRIPTION
In s3 rpm build script, the default debug log level in s3_background_delete_config.yaml is taken.

While building the RPM , this level needs to be changed to DEBUG for s3backgrounddelete if ENABLE_DEBUG_LOG is set