### PR TITLE
EOS-16435 : Configure HAProxy as a part of S3 setup 3 Node VM component

### DIFF
--- a/s3cortxutils/s3confstore/s3confstore/cortx_s3_confstore.py
+++ b/s3cortxutils/s3confstore/s3confstore/cortx_s3_confstore.py
@@ -203,3 +203,4 @@ class S3CortxConfStore:
 
     else:
       sys.exit("Invalid command option passed, see help.")
+

--- a/s3cortxutils/s3confstore/s3confstore/cortx_s3_confstore.py
+++ b/s3cortxutils/s3confstore/s3confstore/cortx_s3_confstore.py
@@ -204,3 +204,28 @@ class S3CortxConfStore:
     else:
       sys.exit("Invalid command option passed, see help.")
 
+    elif args.command == 'getnodecount':
+      nodes_count = s3conf_store.get_nodecount()
+      if nodes_count:
+        print("{}".format(nodes_count))
+      else:
+        sys.exit("Failed to get nodes count from confstore")
+
+    elif args.command == 'getnodenames':
+      nodes_list = s3conf_store.get_nodenames_list()
+      if nodes_list:
+        # read the list, and create a space separated string to be return
+        nodes_str = " ".join(nodes_list)
+        print("{}".format(nodes_str))
+      else:
+        sys.exit("Failed to get nodes list from confstore")
+
+    elif args.command == 'getprivateip':
+      private_ip = s3conf_store.get_privateip(args.machineid)
+      if private_ip:
+        print("{}".format(private_ip))
+      else:
+        sys.exit("Failed to read private ip from confstore of machineid: {}".format(args.machineid))
+
+    else:
+      sys.exit("Invalid command option passed, see help.")

--- a/s3cortxutils/s3confstore/setup.py
+++ b/s3cortxutils/s3confstore/setup.py
@@ -21,6 +21,7 @@ from setuptools import setup
 files = ["VERSION"]
 
 # Load the version
+s3confstore_version = "1.0.0"
 current_script_path = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(current_script_path, 'VERSION')) as version_file:
     s3confstore_version = version_file.read().strip()

--- a/scripts/env/release/init.sh
+++ b/scripts/env/release/init.sh
@@ -25,7 +25,6 @@ BASEDIR=$(dirname "$SCRIPT_PATH")
 S3_SRC_DIR="$BASEDIR/../../../"
 CURRENT_DIR=`pwd`
 
-<<<<<<< HEAD
 #function to install/upgrade cortx-py-utils rpm
 install_cortx_py_utils() {
   #rpm -q cortx-py-utils && yum remove cortx-py-utils -y && yum install cortx-py-utils -y

--- a/scripts/env/rpmbuild/init.sh
+++ b/scripts/env/rpmbuild/init.sh
@@ -26,7 +26,6 @@ BASEDIR=$(dirname "$SCRIPT_PATH")
 S3_SRC_DIR="$BASEDIR/../../../"
 CURRENT_DIR=`pwd`
 
-<<<<<<< HEAD
 #function to install/upgrade cortx-py-utils rpm
 install_cortx_py_utils() {
   #rpm -q cortx-py-utils && yum remove cortx-py-utils -y && yum install cortx-py-utils -y

--- a/scripts/haproxy/s3haproxyconfig/s3haproxyconfig/s3_haproxy_config.py
+++ b/scripts/haproxy/s3haproxyconfig/s3haproxyconfig/s3_haproxy_config.py
@@ -62,13 +62,13 @@ class S3HaproxyConfig:
     cfg_file = '/etc/haproxy/haproxy.cfg'
     target = open(cfg_file, "a+")
 
-    n = 1
+    numS3Instances = 1
     env = s3conf_store.get_config("cluster>env_type")
 
     if env == 'VM':
-        n = 4
+        numS3Instances = 4
     elif env == 'HW':
-        n = 11
+        numS3Instances = 11
 
     s3inport = 28081
     s3auport = 28050
@@ -83,7 +83,7 @@ frontend s3-main
     #bind 0.0.0.0:443 ssl crt /etc/ssl/stx/stx.pem
 
     option forwardfor
-    default_backend app-main
+    default_backend s3-main
 
     # s3 auth server port
     bind 0.0.0.0:9080
@@ -129,12 +129,12 @@ backend s3-auth
 
     target.write(header_text)
     target.write(str1)
-    for i in range(0, n):
+    for i in range(0, numS3Instances):
         target.write(
         "    server s3-instance-%s %s:%s check maxconn 110        # s3 instance %s\n"
         % (i+1, pvt_ip, s3inport+i, i+1))
     target.write(str2)
-    for i in range(0, n):
+    for i in range(0, 1):
         target.write(
         "    server s3authserver-instance%s %s:%s #check ssl verify required ca-file /etc/ssl/stx-s3/s3auth/s3authserver.crt   # s3 auth server instance %s\n"
         % (i+1, pvt_ip, s3auport+i, i+1))


### PR DESCRIPTION
Modified the haproxy config script to add 'N' instances based on env_type read from confstore. Tested the changes by running multiple iterations and invoking s3confstore API's to get pvt_ip and env_type.