### PR TITLE
EOS-16423: S3 Mini-provisioner: Validations in post_install

### DIFF
--- a/installhelper.sh
+++ b/installhelper.sh
@@ -55,6 +55,7 @@ NODEJS_DIR_LOCATION=$INSTALL_PREFIX/opt/seagate/cortx/s3/nodejs
 RSYSLOG_CFG_DIR_LOCATION=$INSTALL_PREFIX/etc/rsyslog.d
 LOGROTATE_CFG_DIR_LOCATION=$INSTALL_PREFIX/etc/logrotate.d/
 KEEPALIVED_CFG_DIR_LOCATION=$INSTALL_PREFIX/etc/keepalived
+S3_MINI_PROV_CFG_LOCATION=$INSTALL_PREFIX/opt/seagate/cortx/s3/mini-prov
 
 rm -rf $AUTH_INSTALL_LOCATION
 rm -rf $S3_INSTALL_LOCATION
@@ -91,6 +92,7 @@ mkdir -p $LOG_DIR_LOCATION/auth/tools
 mkdir -p $NODEJS_DIR_LOCATION
 mkdir -p $RSYSLOG_CFG_DIR_LOCATION
 mkdir -p $LOGROTATE_CFG_DIR_LOCATION
+mkdir -p $S3_MINI_PROV_CFG_LOCATION
 
 # Copy the haproxy dependencies
 cp -R scripts/haproxy/* $S3_INSTALL_LOCATION/install/haproxy
@@ -100,6 +102,9 @@ cp scripts/provisioning/setup.yaml $S3_INSTALL_LOCATION/conf
 
 # Copy the provisioning script
 cp scripts/provisioning/s3_setup $S3_INSTALL_LOCATION/bin
+
+# Copy the mini-provisioner pre-reqs validation check config files
+cp scripts/provisioning/s3setup_prereqs.json ${S3_MINI_PROV_CFG_LOCATION}/
 
 # Copy the S3 reset scripts
 cp scripts/reset/* $S3_INSTALL_LOCATION/reset

--- a/rpms/s3/s3rpm.spec
+++ b/rpms/s3/s3rpm.spec
@@ -365,6 +365,7 @@ rm -rf %{buildroot}
 /opt/seagate/cortx/auth/resources/keystore_unsafe_attributes.yaml
 /opt/seagate/cortx/s3/conf/s3config_unsafe_attributes.yaml
 /opt/seagate/cortx/s3/s3backgrounddelete/s3backgrounddelete_unsafe_attributes.yaml
+/opt/seagate/cortx/s3/mini-prov/s3setup_prereqs.json
 %attr(755, root, root) /opt/seagate/cortx/s3/bin/s3_setup
 %attr(755, root, root) /opt/seagate/cortx/s3/s3backgrounddelete/s3backgroundconsumer
 %attr(755, root, root) /opt/seagate/cortx/s3/s3backgrounddelete/s3backgroundproducer

--- a/scripts/provisioning/s3_setup
+++ b/scripts/provisioning/s3_setup
@@ -48,6 +48,7 @@ where:
 --updateclusterid        Fetch and update cluster id in S3 config
 --cleanup                Cleanup S3 accounts created for backgroundelete.
 --createauthjkspassword  Setup random jks password for Auth server
+--validateprerequisites  Perform validation of the mini provisioning pre-requisites for S3 during post_install
 --help                   Display this help and exit"
 
 set -e
@@ -72,6 +73,7 @@ update_cluster_id=false
 is_rabbitmq_clustered=false
 cleanup_s3_accounts_schema=false
 create_auth_jks_passwrd=false
+validate_prerequisites=false
 encrypt_cli="/opt/seagate/cortx/auth/AuthPassEncryptCLI-1.0-0.jar"
 
 if [ $# -lt 1 ]
@@ -135,6 +137,9 @@ do
         ;;
     --createauthjkspassword )
         create_auth_jks_passwrd=true
+        ;;
+    --validateprerequisites)
+        validate_prerequisites=true
         ;;
     --help | -h )
         echo "$USAGE"
@@ -266,6 +271,13 @@ if [[ $create_auth_jks_passwrd == true ]]
 then
     echo "Creating random jks password for Auth server"
     create_auth_jks_password
+fi
+
+# Perform validation of the mini provisioning pre-requisites for S3 during post_install
+if [[ $validate_prerequisites == true ]]
+then
+    echo "Performing validation of the mini provisioning pre-requisites"
+    s3setup --validateprerequisites --preqs_conf_file /opt/seagate/cortx/s3/mini-prov/s3setup_prereqs.json
 fi
 
 cipherkey=$(s3cipher --generate_key --const_key  openldap 2>/dev/null)

--- a/scripts/provisioning/s3_setup
+++ b/scripts/provisioning/s3_setup
@@ -48,7 +48,6 @@ where:
 --updateclusterid        Fetch and update cluster id in S3 config
 --cleanup                Cleanup S3 accounts created for backgroundelete.
 --createauthjkspassword  Setup random jks password for Auth server
---validateprerequisites  Perform validation of the mini provisioning pre-requisites for S3 during post_install
 --help                   Display this help and exit"
 
 set -e
@@ -73,7 +72,6 @@ update_cluster_id=false
 is_rabbitmq_clustered=false
 cleanup_s3_accounts_schema=false
 create_auth_jks_passwrd=false
-validate_prerequisites=false
 encrypt_cli="/opt/seagate/cortx/auth/AuthPassEncryptCLI-1.0-0.jar"
 
 if [ $# -lt 1 ]
@@ -137,9 +135,6 @@ do
         ;;
     --createauthjkspassword )
         create_auth_jks_passwrd=true
-        ;;
-    --validateprerequisites)
-        validate_prerequisites=true
         ;;
     --help | -h )
         echo "$USAGE"
@@ -271,13 +266,6 @@ if [[ $create_auth_jks_passwrd == true ]]
 then
     echo "Creating random jks password for Auth server"
     create_auth_jks_password
-fi
-
-# Perform validation of the mini provisioning pre-requisites for S3 during post_install
-if [[ $validate_prerequisites == true ]]
-then
-    echo "Performing validation of the mini provisioning pre-requisites"
-    s3setup --validateprerequisites --preqs_conf_file /opt/seagate/cortx/s3/mini-prov/s3setup_prereqs.json
 fi
 
 cipherkey=$(s3cipher --generate_key --const_key  openldap 2>/dev/null)

--- a/scripts/provisioning/s3setup/s3setup/cortx_s3_setup.py
+++ b/scripts/provisioning/s3setup/s3setup/cortx_s3_setup.py
@@ -140,11 +140,17 @@ class S3CortxSetup:
 
   def run(self):
     parser = argparse.ArgumentParser(description='Cortx S3 Setup')
+    # parser.add_argument("post_install", help='Perform S3setup mini-provisioner post_install actions', action="store_true", default=False)
+    parser.add_argument("action", type=str, help='Perform S3setup mini-provisioner actions',nargs='*', choices=['post_install', 'cleanup' ])
     parser.add_argument("--cleanup", help='Cleanup S3 accounts and dependencies. Valid values: all/accounts/dependencies')
     # Future functionalities to be added here.
     parser.add_argument("--ldappasswd", help='ldap password, needed for --cleanup')
     parser.add_argument("--validateprerequisites", help='validate prerequisites for mini-provisioner setup', action="store_true")
     parser.add_argument("--preqs_conf_file", help='optional conf file location used with --validateprerequisites')
+    parser.add_argument("--config",
+                        help='config file url, check cortx-py-utils::confstore for supported formats.',
+                        type=str)
+
 
     args = parser.parse_args()
 
@@ -168,7 +174,7 @@ class S3CortxSetup:
         print("Invalid input for cleanup {}. Valid values: all/accounts/dependencies".format(args.cleanup))
         exit (-2)
 
-    if args.validateprerequisites:
+    if args.validateprerequisites or args.action == "post_install":
 
       if args.preqs_conf_file:
         self.__preqs_conf_file = args.preqs_conf_file

--- a/scripts/provisioning/s3setup/s3setup/cortx_s3_setup.py
+++ b/scripts/provisioning/s3setup/s3setup/cortx_s3_setup.py
@@ -18,16 +18,21 @@
 
 import argparse
 import subprocess
-from s3backgrounddelete.cortx_s3_cipher import CortxS3Cipher
 import logging
 import re
-from s3backgrounddelete.cortx_cluster_config import CORTXClusterConfig, CipherInvalidToken
+import os
+import json
+from s3backgrounddelete.cortx_s3_cipher import CortxS3Cipher
+from s3backgrounddelete.cortx_cluster_config import CipherInvalidToken
+from cortx.utils.validator.v_pkg import PkgV
+from cortx.utils.validator.v_service import ServiceV
 
 logging.basicConfig(level=logging.INFO)
 # logging.basicConfig(level=logging.DEBUG)
 log=logging.getLogger('=>')
 
 class S3CortxSetup:
+  __preqs_conf_file="/opt/seagate/cortx/s3/mini-prov/s3setup_prereqs.json"
 
   def __init__(self):
     """Instantiate S3CortxSetup."""
@@ -94,11 +99,8 @@ class S3CortxSetup:
     print ("Delete s3recovery tool account failed with: {}".format(error))
     return False
 
-  def accounts_cleanup(self, ldappasswd: str = None, s3background_cofig:str = "/opt/seagate/cortx/s3/s3backgrounddelete/config.yaml"):
+  def accounts_cleanup(self, ldappasswd, s3background_cofig:str = "/opt/seagate/cortx/s3/s3backgrounddelete/config.yaml"):
     """Clean up s3 accounts."""
-    if ldappasswd == None:
-      S3Cipher = CortxS3Cipher(None, True, 12, "openldap")
-      ldappasswd = S3Cipher.get_key()
     rc1 = self.delete_background_delete_account(ldappasswd, 22, "s3backgroundaccesskey", s3background_cofig)
     rc2 = self.delete_recovery_tool_account(ldappasswd, 22, "s3recoveryaccesskey", s3background_cofig)
     return rc1 & rc2
@@ -123,11 +125,26 @@ class S3CortxSetup:
     log.debug("\ncmd:{0},\noutput:{1},\nerror:{2}".format(cmd, output, error))
     return True
 
+  def validate_pre_requisites(self, rpms: list = [], pip3s: list = [], services: list = []):
+    try:
+      if pip3s:
+        PkgV().validate('pip3s', pip3s)
+      if services:
+        ServiceV().validate('isrunning', services)
+      if rpms:
+        PkgV().validate('rpms', rpms)
+    except Exception as e:
+      print(f"{e}")
+      return False
+    return True
+
   def run(self):
     parser = argparse.ArgumentParser(description='Cortx S3 Setup')
     parser.add_argument("--cleanup", help='Cleanup S3 accounts and dependencies. Valid values: all/accounts/dependencies')
     # Future functionalities to be added here.
     parser.add_argument("--ldappasswd", help='ldap password, needed for --cleanup')
+    parser.add_argument("--validateprerequisites", help='validate prerequisites for mini-provisioner setup', action="store_true")
+    parser.add_argument("--preqs_conf_file", help='optional conf file location used with --validateprerequisites')
 
     args = parser.parse_args()
 
@@ -138,8 +155,6 @@ class S3CortxSetup:
       if args.cleanup == "accounts":
         if args.ldappasswd:
           rc = self.accounts_cleanup(args.ldappasswd)
-        else:
-          rc = self.accounts_cleanup()
         exit (not rc)
       elif args.cleanup == "dependencies":
         rc = self.dependencies_cleanup()
@@ -147,10 +162,27 @@ class S3CortxSetup:
       elif args.cleanup == "all":
         if args.ldappasswd: 
           rc1 = self.accounts_cleanup(args.ldappasswd)
-        else:
-          rc1 = self.accounts_cleanup()
         rc2 = self.dependencies_cleanup()
         exit (not (rc1 & rc2))
       else:
         print("Invalid input for cleanup {}. Valid values: all/accounts/dependencies".format(args.cleanup))
         exit (-2)
+
+    if args.validateprerequisites:
+
+      if args.preqs_conf_file:
+        self.__preqs_conf_file = args.preqs_conf_file
+
+      if not os.path.isfile(self.__preqs_conf_file):
+        print(f"preqs config file {self.__preqs_conf_file} not found")
+        exit (-2)
+
+      try:
+        with open(self.__preqs_conf_file) as preqs_conf:
+          preqs_conf_json = json.load(preqs_conf)
+      except Exception as e:
+        print(f"open() or json.load() failed: {e}")
+        exit (-2)
+
+      rc = self.validate_pre_requisites(rpms=preqs_conf_json['rpms'], services=preqs_conf_json['services'], pip3s=preqs_conf_json['pip3s'])
+      exit(not rc)

--- a/scripts/provisioning/s3setup_prereqs.json
+++ b/scripts/provisioning/s3setup_prereqs.json
@@ -1,0 +1,5 @@
+{
+    "rpms": ["openldap-servers", "openldap-clients", "haproxy"],
+    "pip3s": ["toml", "s3confstore", "crypto"],
+    "services": ["sshd", "rabbitmq-server"]
+}

--- a/scripts/provisioning/setup.yaml
+++ b/scripts/provisioning/setup.yaml
@@ -23,7 +23,8 @@
 s3:
   post_install:
     script: /opt/seagate/cortx/s3/bin/s3_setup
-    args: null
+    args:
+      - --validateprerequisites
   init:
     script: /opt/seagate/cortx/s3/bin/s3_setup
     args:

--- a/scripts/provisioning/setup.yaml
+++ b/scripts/provisioning/setup.yaml
@@ -22,9 +22,8 @@
 # called on all nodes before server is run
 s3:
   post_install:
-    script: /opt/seagate/cortx/s3/bin/s3_setup
-    args:
-      - --validateprerequisites
+    cmd: s3_setup post_install
+    --config $URL
   init:
     script: /opt/seagate/cortx/s3/bin/s3_setup
     args:


### PR DESCRIPTION
commit 5861f9de96e2a281ab0bafae004853596a1c0ec1
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Thu Jan 21 11:42:50 2021 -0700

            EOS-16423: S3 Mini-provisioner: Validations in post_install
            Change description:
                Integrate the new validator APIs from py-utils in s3setup
                Add new s3setup option for validation based on optional external config file for rpms, pip3s and services
                Relevant changes in S3 rpm scripts
                Relevant changes in s3_setup and setup.yaml for post_install
            Files edited/added:
                modified:   installhelper.sh
                modified:   rpms/s3/s3rpm.spec
                modified:   scripts/provisioning/s3_setup
                modified:   scripts/provisioning/s3setup/s3setup/cortx_s3_setup.py
                new file:   scripts/provisioning/s3setup_prereqs.json
                modified:   scripts/provisioning/setup.yaml
            Testing done:
                Unit tested s3setup and s3_setup changes on VM

    Signed-off-by: pratyush-seagate <pratyush.k.khan@seagate.com>
