### PR TITLE
EOS-17079:S3: cortx-py-utils algorithm changed from upgrade to remove and install

### DIFF
--- a/ansible/files/yum.repos.d/centos7.8.2003/cortx_py_utils.repo
+++ b/ansible/files/yum.repos.d/centos7.8.2003/cortx_py_utils.repo
@@ -1,5 +1,5 @@
 [releases_cortx_py_utils]
-baseurl = http://cortx-storage.colo.seagate.com/releases/cortx/components/github/main/centos-7.8.2003/dev/cortx-utils/last_successful/
+baseurl = http://cortx-storage.colo.seagate.com/releases/cortx/components/github/stable/centos-7.8.2003/dev/cortx-utils/last_successful/
 gpgcheck = 0
 name = Yum repo for CORTX Python Utilities build - OS Centos 7.8.2003
 priority = 1

--- a/scripts/env/dev/init.sh
+++ b/scripts/env/dev/init.sh
@@ -54,7 +54,8 @@ check_supported_kernel() {
 install_cortx_py_utils() {
   #rpm -q cortx-py-utils && yum remove cortx-py-utils -y && yum install cortx-py-utils -y
   if rpm -q cortx-py-utils ; then
-    yum upgrade cortx-py-utils -y
+    yum remove cortx-py-utils -y
+    yum install cortx-py-utils -y
   else
     yum install cortx-py-utils -y
   fi

--- a/scripts/env/release/init.sh
+++ b/scripts/env/release/init.sh
@@ -34,7 +34,8 @@ install_toml() {
 install_cortx_py_utils() {
   #rpm -q cortx-py-utils && yum remove cortx-py-utils -y && yum install cortx-py-utils -y
   if rpm -q cortx-py-utils ; then
-    yum upgrade cortx-py-utils -y
+    yum remove cortx-py-utils -y
+    yum install cortx-py-utils -y
   else
     yum install cortx-py-utils -y
   fi

--- a/scripts/env/rpmbuild/init.sh
+++ b/scripts/env/rpmbuild/init.sh
@@ -30,7 +30,8 @@ CURRENT_DIR=`pwd`
 install_cortx_py_utils() {
   #rpm -q cortx-py-utils && yum remove cortx-py-utils -y && yum install cortx-py-utils -y
   if rpm -q cortx-py-utils ; then
-    yum upgrade cortx-py-utils -y
+    yum remove cortx-py-utils -y
+    yum install cortx-py-utils -y
   else
     yum install cortx-py-utils -y
   fi


### PR DESCRIPTION
Jenkins job:  
http://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/S3server-7.8.2003/482/
http://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/S3server-7.8.2003/483/
http://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/S3server-7.8.2003/484/

Jenkins job log:
`cortx-py-utils-1.0.0-99_23eb199.noarch
18:10:46  Loaded plugins: fastestmirror, priorities, product-id, search-disabled-repos,
18:10:46                : subscription-manager
18:10:47  Resolving Dependencies
18:10:47  --> Running transaction check
18:10:47  ---> Package cortx-py-utils.noarch 0:1.0.0-99_23eb199 will be erased
18:10:49  --> Finished Dependency Resolution
18:10:49  
18:10:49  Dependencies Resolved
18:10:49  
18:10:49  ================================================================================
18:10:49   Package Arch   Version          Repository                                Size
18:10:49  ================================================================================
18:10:49  Removing:
18:10:49   cortx-py-utils
18:10:49           noarch 1.0.0-99_23eb199 @/cortx-py-utils-1.0.0-99_23eb199.noarch 1.1 M
18:10:49  
18:10:49  Transaction Summary
18:10:49  ================================================================================
18:10:49  Remove  1 Package
18:10:49  
18:10:49  Installed size: 1.1 M
18:10:49  Downloading packages:
18:10:49  Running transaction check
18:10:49  Running transaction test
18:10:49  Transaction test succeeded
18:10:49  Running transaction
18:10:52  Uninstalling aiohttp-3.6.1:
18:10:52    Successfully uninstalled aiohttp-3.6.1
18:10:52  Uninstalling elasticsearch-dsl-6.4.0:
18:10:52    Successfully uninstalled elasticsearch-dsl-6.4.0
18:10:52  Uninstalling python-consul-1.1.0:
18:10:52    Successfully uninstalled python-consul-1.1.0
18:10:52  Uninstalling schematics-2.1.0:
18:10:52    Successfully uninstalled schematics-2.1.0
18:10:52  Uninstalling toml-0.10.0:
18:10:52    Successfully uninstalled toml-0.10.0
18:10:52  Uninstalling cryptography-3.2:
18:10:52    Successfully uninstalled cryptography-3.2
18:10:52  Uninstalling PyYAML-5.1.2:
18:10:52    Successfully uninstalled PyYAML-5.1.2
18:10:52  Uninstalling configparser-4.0.2:
18:10:52    Successfully uninstalled configparser-4.0.2
18:10:52  Uninstalling networkx-2.4:
18:10:52    Successfully uninstalled networkx-2.4
18:10:52  Uninstalling matplotlib-3.1.3:
18:10:52    Successfully uninstalled matplotlib-3.1.3
18:10:52  Uninstalling argparse-1.4.0:
18:10:52    Successfully uninstalled argparse-1.4.0
18:10:52  Uninstalling confluent-kafka-1.5.0:
18:10:52    Successfully uninstalled confluent-kafka-1.5.0
18:10:52  Uninstalling python-crontab-2.5.1:
18:10:52    Successfully uninstalled python-crontab-2.5.1
18:10:52  Uninstalling elasticsearch-6.8.1:
18:10:52    Successfully uninstalled elasticsearch-6.8.1
18:10:52  Uninstalling paramiko-2.7.1:
18:10:52    Successfully uninstalled paramiko-2.7.1
18:10:52    Erasing    : cortx-py-utils-1.0.0-99_23eb199.noarch                       1/1 
18:10:52  Loaded plugins: fastestmirror, priorities, product-id, subscription-manager
18:10:53    Verifying  : cortx-py-utils-1.0.0-99_23eb199.noarch                       1/1 
18:10:53  
18:10:53  Removed:
18:10:53    cortx-py-utils.noarch 0:1.0.0-99_23eb199                                      
18:10:53  
18:10:53  Complete!
18:10:53  Loaded plugins: fastestmirror, priorities, product-id, search-disabled-repos,
18:10:53                : subscription-manager
18:10:53  Loading mirror speeds from cached hostfile
18:10:53   * epel: mirrors.lug.mtu.edu
18:10:56  28 packages excluded due to repository priority protections
18:10:57  Resolving Dependencies
18:10:57  --> Running transaction check
18:10:57  ---> Package cortx-py-utils.noarch 0:1.0.0-90_8b3c613 will be installed
18:10:58  --> Finished Dependency Resolution
18:10:58  
18:10:58  Dependencies Resolved
18:10:58  
18:10:58  ================================================================================
18:10:58   Package          Arch     Version              Repository                 Size
18:10:58  ================================================================================
18:10:58  Installing:
18:10:58   cortx-py-utils   noarch   1.0.0-90_8b3c613     releases_cortx_py_utils   191 k
18:10:58  
18:10:58  Transaction Summary
18:10:58  ================================================================================
18:10:58  Install  1 Package
18:10:58  
18:10:58  Total download size: 191 k
18:10:58  Installed size: 989 k
18:10:58  Downloading packages:
18:10:58  Running transaction check
18:10:58  Running transaction test
18:10:58  Transaction test succeeded
18:10:58  Running transaction
18:11:10    Installing : cortx-py-utils-1.0.0-90_8b3c613.noarch                       1/1 
18:11:10  WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3.6 install --user` instead.
18:11:10  Collecting aiohttp==3.6.1 (from -r /opt/seagate/cortx/utils/conf/requirements.txt (line 1))
18:11:10    Using cached https://files.pythonhosted.org/packages/e0/cb/5fa1d7722488995358d6092a7d2ccceb9011ab78842ccd336fbb5ec0d878/aiohttp-3.6.1-cp36-cp36m-manylinux1_x86_64.whl
18:11:10  Collecting elasticsearch-dsl==6.4.0 (from -r /opt/seagate/cortx/utils/conf/requirements.txt (line 2))
18:11:10    Using cached https://files.pythonhosted.org/packages/4f/73/580e648ab72a19c26c815931ce2b2dda67454f557e72ce7ae90fd3b7887d/elasticsearch_dsl-6.4.0-py2.py3-none-any.whl
18:11:10  Collecting python-consul==1.1.0 (from -r /opt/seagate/cortx/utils/conf/requirements.txt (line 3))
18:11:10    Using cached https://files.pythonhosted.org/packages/3f/d0/59bc5f1c6c4d4b498c41d8ce7052ee9e9d68be19e16038a55252018a6c4d/python_consul-1.1.0-py2.py3-none-any.whl
18:11:10  Collecting schematics==2.1.0 (from -r /opt/seagate/cortx/utils/conf/requirements.txt (line 4))
18:11:10    Using cached https://files.pythonhosted.org/packages/97/2f/2c5f0dc4dab5e5ca54e4d783f7f618bfc65d8788771876713d42eb8515aa/schematics-2.1.0-py2.py3-none-any.whl
18:11:10  Collecting toml==0.10.0 (from -r /opt/seagate/cortx/utils/conf/requirements.txt (line 5))
18:11:10    Using cached https://files.pythonhosted.org/packages/a2/12/ced7105d2de62fa7c8fb5fce92cc4ce66b57c95fb875e9318dba7f8c5db0/toml-0.10.0-py2.py3-none-any.whl
18:11:10  Collecting cryptography==2.8 (from -r /opt/seagate/cortx/utils/conf/requirements.txt (line 6))
18:11:10    Using cached https://files.pythonhosted.org/packages/45/73/d18a8884de8bffdcda475728008b5b13be7fbef40a2acc81a0d5d524175d/cryptography-2.8-cp34-abi3-manylinux1_x86_64.whl
18:11:10  Collecting PyYAML==5.1.2 (from -r /opt/seagate/cortx/utils/conf/requirements.txt (line 7))
18:11:10  Collecting configparser==4.0.2 (from -r /opt/seagate/cortx/utils/conf/requirements.txt (line 8))
18:11:10    Using cached https://files.pythonhosted.org/packages/7a/2a/95ed0501cf5d8709490b1d3a3f9b5cf340da6c433f896bbe9ce08dbe6785/configparser-4.0.2-py2.py3-none-any.whl
18:11:10  Collecting networkx==2.4 (from -r /opt/seagate/cortx/utils/conf/requirements.txt (line 9))
18:11:10    Using cached https://files.pythonhosted.org/packages/41/8f/dd6a8e85946def36e4f2c69c84219af0fa5e832b018c970e92f2ad337e45/networkx-2.4-py3-none-any.whl
18:11:10  Collecting matplotlib==3.1.3 (from -r /opt/seagate/cortx/utils/conf/requirements.txt (line 10))
18:11:10    Using cached https://files.pythonhosted.org/packages/7e/07/4b361d6d0f4e08942575f83a11d33f36897e1aae4279046606dd1808778a/matplotlib-3.1.3-cp36-cp36m-manylinux1_x86_64.whl
18:11:10  Collecting argparse==1.4.0 (from -r /opt/seagate/cortx/utils/conf/requirements.txt (line 11))
18:11:10    Using cached https://files.pythonhosted.org/packages/f2/94/3af39d34be01a24a6e65433d19e107099374224905f1e0cc6bbe1fd22a2f/argparse-1.4.0-py2.py3-none-any.whl
18:11:10  Collecting confluent-kafka==1.5.0 (from -r /opt/seagate/cortx/utils/conf/requirements.txt (line 12))
18:11:10    Using cached https://files.pythonhosted.org/packages/74/04/b131250b88c80201c4a648af1ab098798e1dcbf20807f79e3ce6e72c4ef4/confluent_kafka-1.5.0-cp36-cp36m-manylinux1_x86_64.whl
18:11:10  Collecting python-crontab==2.5.1 (from -r /opt/seagate/cortx/utils/conf/requirements.txt (line 13))
18:11:10  Collecting elasticsearch==6.8.1 (from -r /opt/seagate/cortx/utils/conf/requirements.txt (line 14))
18:11:10    Using cached https://files.pythonhosted.org/packages/78/1b/498aa74c244c5c9d578c1a1a2f16b0db61ac178ec4f1a33d3785f86a052d/elasticsearch-6.8.1-py2.py3-none-any.whl
18:11:10  Collecting paramiko==2.7.1 (from -r /opt/seagate/cortx/utils/conf/requirements.txt (line 15))
18:11:10    Using cached https://files.pythonhosted.org/packages/06/1e/1e08baaaf6c3d3df1459fd85f0e7d2d6aa916f33958f151ee1ecc9800971/paramiko-2.7.1-py2.py3-none-any.whl
18:11:10  Requirement already satisfied: chardet<4.0,>=2.0 in /usr/local/lib/python3.6/site-packages (from aiohttp==3.6.1->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 1))
18:11:10  Requirement already satisfied: idna-ssl>=1.0; python_version < "3.7" in /usr/local/lib/python3.6/site-packages (from aiohttp==3.6.1->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 1))
18:11:10  Requirement already satisfied: yarl<2.0,>=1.0 in /usr/local/lib64/python3.6/site-packages (from aiohttp==3.6.1->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 1))
18:11:10  Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.6/site-packages (from aiohttp==3.6.1->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 1))
18:11:10  Requirement already satisfied: multidict<5.0,>=4.5 in /usr/local/lib64/python3.6/site-packages (from aiohttp==3.6.1->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 1))
18:11:10  Requirement already satisfied: async-timeout<4.0,>=3.0 in /usr/local/lib/python3.6/site-packages (from aiohttp==3.6.1->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 1))
18:11:10  Requirement already satisfied: typing-extensions>=3.6.5; python_version < "3.7" in /usr/local/lib/python3.6/site-packages (from aiohttp==3.6.1->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 1))
18:11:10  Requirement already satisfied: python-dateutil in /usr/lib/python3.6/site-packages (from elasticsearch-dsl==6.4.0->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 2))
18:11:10  Requirement already satisfied: six in /usr/lib/python3.6/site-packages (from elasticsearch-dsl==6.4.0->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 2))
18:11:10  Requirement already satisfied: requests>=2.0 in /usr/local/lib/python3.6/site-packages (from python-consul==1.1.0->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 3))
18:11:10  Requirement already satisfied: cffi!=1.11.3,>=1.8 in /usr/local/lib64/python3.6/site-packages (from cryptography==2.8->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 6))
18:11:10  Requirement already satisfied: decorator>=4.3.0 in /usr/local/lib/python3.6/site-packages (from networkx==2.4->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 9))
18:11:10  Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib64/python3.6/site-packages (from matplotlib==3.1.3->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 10))
18:11:10  Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /usr/local/lib/python3.6/site-packages (from matplotlib==3.1.3->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 10))
18:11:10  Requirement already satisfied: numpy>=1.11 in /usr/lib64/python3.6/site-packages (from matplotlib==3.1.3->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 10))
18:11:10  Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.6/site-packages (from matplotlib==3.1.3->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 10))
18:11:10  Requirement already satisfied: urllib3>=1.21.1 in /usr/local/lib/python3.6/site-packages/urllib3-1.25.10-py3.6.egg (from elasticsearch==6.8.1->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 14))
18:11:10  Requirement already satisfied: bcrypt>=3.1.3 in /usr/local/lib64/python3.6/site-packages (from paramiko==2.7.1->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 15))
18:11:10  Requirement already satisfied: pynacl>=1.0.1 in /usr/local/lib64/python3.6/site-packages (from paramiko==2.7.1->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 15))
18:11:10  Requirement already satisfied: idna>=2.0 in /usr/local/lib/python3.6/site-packages (from idna-ssl>=1.0; python_version < "3.7"->aiohttp==3.6.1->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 1))
18:11:10  Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.6/site-packages (from requests>=2.0->python-consul==1.1.0->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 3))
18:11:10  Requirement already satisfied: pycparser in /usr/local/lib/python3.6/site-packages (from cffi!=1.11.3,>=1.8->cryptography==2.8->-r /opt/seagate/cortx/utils/conf/requirements.txt (line 6))
18:11:10  Installing collected packages: aiohttp, elasticsearch, elasticsearch-dsl, python-consul, schematics, toml, cryptography, PyYAML, configparser, networkx, matplotlib, argparse, confluent-kafka, python-crontab, paramiko
18:11:10  Successfully installed PyYAML-5.1.2 aiohttp-3.6.1 argparse-1.4.0 configparser-4.0.2 confluent-kafka-1.5.0 cryptography-2.8 elasticsearch-6.8.1 elasticsearch-dsl-6.4.0 matplotlib-3.1.3 networkx-2.4 paramiko-2.7.1 python-consul-1.1.0 python-crontab-2.5.1 schematics-2.1.0 toml-0.10.0
18:11:10  Loaded plugins: fastestmirror, priorities, product-id, subscription-manager
18:11:10    Verifying  : cortx-py-utils-1.0.0-90_8b3c613.noarch                       1/1 
18:11:10  
18:11:10  Installed:
18:11:10    cortx-py-utils.noarch 0:1.0.0-90_8b3c613                                      
18:11:10  
18:11:10  Complete!`