### PR TITLE
[EOS-16014] Remove 'create_timestamp' attribute in the JSON value in Global bucke…

### DIFF
--- a/server/s3_global_bucket_index_metadata.cc
+++ b/server/s3_global_bucket_index_metadata.cc
@@ -23,7 +23,6 @@
 #include <string>
 #include "s3_factory.h"
 #include "s3_iem.h"
-#include "s3_datetime.h"
 
 extern struct m0_uint128 global_bucket_list_index_oid;
 
@@ -252,10 +251,6 @@ std::string S3GlobalBucketIndexMetadata::to_json() {
   root["account_name"] = account_name;
   root["account_id"] = account_id;
   root["location_constraint"] = location_constraint;
-
-  S3DateTime current_time;
-  current_time.init_current_time();
-  root["create_timestamp"] = current_time.get_isoformat_string();
 
   Json::FastWriter fastWriter;
   return fastWriter.write(root);

--- a/ut/s3_global_bucket_index_metadata_test.cc
+++ b/ut/s3_global_bucket_index_metadata_test.cc
@@ -28,7 +28,6 @@
 #include "s3_global_bucket_index_metadata.h"
 #include "s3_callback_test_helpers.h"
 #include "s3_test_utils.h"
-#include <json/json.h>
 
 using ::testing::Invoke;
 using ::testing::AtLeast;
@@ -303,12 +302,10 @@ TEST_F(S3GlobalBucketIndexMetadataTest, ToJson) {
   std::string actual_acc_name = root["account_name"].asString();
   std::string actual_acc_id = root["account_id"].asString();
   std::string actual_loc = root["location_constraint"].asString();
-  std::string actual_timestamp = root["create_timestamp"].asString();
 
   EXPECT_STREQ("s3_test", actual_acc_name.c_str());
   EXPECT_STREQ("12345", actual_acc_id.c_str());
   EXPECT_STREQ("us-west-2", actual_loc.c_str());
-  EXPECT_STRNE("", actual_timestamp.c_str());
 }
 
 TEST_F(S3GlobalBucketIndexMetadataTest, Save) {


### PR DESCRIPTION
…t list index (Revert of recovery feature)
Signed-off-by: pranav <pranav.pawar@seagate.com>