### PR TITLE
EOS-16890:Support for get_all_keys in S3confstore

### DIFF
--- a/s3cortxutils/s3confstore/s3confstore/cortx_s3_confstore.py
+++ b/s3cortxutils/s3confstore/s3confstore/cortx_s3_confstore.py
@@ -54,6 +54,10 @@ class S3CortxConfStore:
       # Update the index backend.
       Conf.save(self.default_index)
 
+  def get_all_keys(self):
+    """Get all the key value pairs from confstore."""
+    return Conf.get_keys(self.default_index)
+
   @staticmethod
   def validate_configfile(configfile: str):
     """Validate the 'configfile' url, if its a valid file and of supported format."""
@@ -211,6 +215,8 @@ class S3CortxConfStore:
                                   type=str,
                                   required=True)
 
+    getallkeys = subparsers.add_parser('getallkeys', help='Get the list of all the Key Values in the file')
+
     args = parser.parse_args()
 
     s3conf_store = S3CortxConfStore(args.config)
@@ -261,6 +267,13 @@ class S3CortxConfStore:
         print("{}".format(s3instance_count))
       else:
         sys.exit("Failed to read s3instance count from confstore of machineid: {}".format(args.machineid))
+
+    elif args.command == 'getallkeys':
+      keyvalue = s3conf_store.get_all_keys()
+      if keyvalue:
+        print("{}".format(keyvalue))
+      else:
+        sys.exit("Failed to get key:{}'s value".format(args.key))
 
     else:
       sys.exit("Invalid command option passed, see help.")

--- a/s3cortxutils/s3confstore/s3confstore/cortx_s3_confstore.py
+++ b/s3cortxutils/s3confstore/s3confstore/cortx_s3_confstore.py
@@ -215,7 +215,7 @@ class S3CortxConfStore:
                                   type=str,
                                   required=True)
 
-    getallkeys = subparsers.add_parser('getallkeys', help='Get the list of all the Key Values in the file')
+    subparsers.add_parser('getallkeys', help='Get the list of all the Key Values in the file')
 
     args = parser.parse_args()
 

--- a/s3cortxutils/s3confstore/ut/s3confstore_unit_tests.py
+++ b/s3cortxutils/s3confstore/ut/s3confstore_unit_tests.py
@@ -119,6 +119,13 @@ class S3ConfStoreAPIsUT(unittest.TestCase):
     result_data = s3confstore.get_config('bridge')
     self.assertTrue('dummy_123' in result_data)
 
+  @mock.patch.object(Conf, 'get_keys')
+  def test_mock_getallkeys(self, mock_getallkeys_return):
+    s3confstore = S3CortxConfStore()
+    mock_getallkeys_return.return_value = "dummy_allkeys_return"
+    result_data = s3confstore.get_all_keys()
+    self.assertTrue('dummy_allkeys_return' in result_data)
+
   @mock.patch.object(Conf, 'load')
   @mock.patch.object(Conf, 'get')
   @mock.patch.object(Conf, 'set')


### PR DESCRIPTION
**### Issue**
Cortx-Utils had support for get_keys() which lists all the key-value pairs in a file.
Hooked up the support in s3confstore for get_keys API

### **Testing:**
[root@ssc-vm-c-1632 cortx-s3server]# s3confstore yaml:///opt/seagate/cortx/s3/s3backgrounddelete/config.yaml getallkeys

['version_config>version', 'cortx_s3>endpoint', 'cortx_s3>service', 'cortx_s3>default_region', 'cortx_s3>daemon_mode', 'cortx_s3>s3_instance_count', 'cortx_s3>messaging_platform', 'message_bus>topic', 'message_bus>consumer_group', 'message_bus>consumer_id_prefix', 'message_bus>producer_id', 'message_bus>producer_delivery_mechanism', 'message_bus>consumer_sleep', 'logconfig>scheduler_logger_name', 'logconfig>processor_logger_name', 'logconfig>logger_directory', 'logconfig>scheduler_log_file', 'logconfig>processor_log_file', 'logconfig>file_log_level', 'logconfig>console_log_level', 'logconfig>log_format', 'logconfig>max_bytes', 'logconfig>backup_count', 'rabbitmq>username', 'rabbitmq>password', 'rabbitmq>host', 'rabbitmq>queue', 'rabbitmq>exchange', 'rabbitmq>exchange_type', 'rabbitmq>mode', 'rabbitmq>durable', 'rabbitmq>schedule_interval_secs', 'indexid>probable_delete_index_id', 'indexid>global_instance_index_id', 'indexid>global_bucket_index_id', 'indexid>bucket_metadata_index_id', 'indexid>max_keys', 'leakconfig>leak_processing_delay_in_mins', 'leakconfig>version_processing_delay_in_mins', 'leakconfig>cleanup_enabled']

### **UT Result**
Running s3confstore UT's...
======================================== test session starts ========================================
platform linux -- Python 3.6.8, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /usr/bin/python36
cachedir: ../.cache
rootdir: /workspace/cortx-s3server/s3cortxutils/s3confstore, inifile:
collected 19 items

../ut/s3confstore_unit_tests.py::S3ConfStoreAPIsUT::test_get_nodecount_none PASSED
../ut/s3confstore_unit_tests.py::S3ConfStoreAPIsUT::test_get_nodecount_success PASSED
../ut/s3confstore_unit_tests.py::S3ConfStoreAPIsUT::test_get_nodenames_list_empty PASSED
../ut/s3confstore_unit_tests.py::S3ConfStoreAPIsUT::test_get_nodenames_list_exception PASSED
../ut/s3confstore_unit_tests.py::S3ConfStoreAPIsUT::test_get_nodenames_list_success PASSED
../ut/s3confstore_unit_tests.py::S3ConfStoreAPIsUT::test_get_privateip_emptystring PASSED
../ut/s3confstore_unit_tests.py::S3ConfStoreAPIsUT::test_get_privateip_success PASSED
../ut/s3confstore_unit_tests.py::S3ConfStoreAPIsUT::test_get_publicip_emptystring PASSED
../ut/s3confstore_unit_tests.py::S3ConfStoreAPIsUT::test_get_publicip_success PASSED
../ut/s3confstore_unit_tests.py::S3ConfStoreAPIsUT::test_get_s3instance_count_success PASSED
../ut/s3confstore_unit_tests.py::S3ConfStoreAPIsUT::test_json_conf PASSED
../ut/s3confstore_unit_tests.py::S3ConfStoreAPIsUT::test_mock_get PASSED
**../ut/s3confstore_unit_tests.py::S3ConfStoreAPIsUT::test_mock_getallkeys PASSED**
../ut/s3confstore_unit_tests.py::S3ConfStoreAPIsUT::test_mock_load PASSED
../ut/s3confstore_unit_tests.py::S3ConfStoreAPIsUT::test_mock_save PASSED
../ut/s3confstore_unit_tests.py::S3ConfStoreAPIsUT::test_mock_set PASSED
../ut/s3confstore_unit_tests.py::S3ConfStoreAPIsUT::test_validate_configfile_doesnotexist PASSED
../ut/s3confstore_unit_tests.py::S3ConfStoreAPIsUT::test_validate_configfile_unsupportedformat PASSED
../ut/s3confstore_unit_tests.py::S3ConfStoreAPIsUT::test_yaml_conf PASSED

===================================== 19 passed in 0.11 seconds =====================================
