### PR TITLE
EOS-16872 : Configure HAProxy as a part of S3 setup 3 Node VM component provisioning

### DIFF
--- a/scripts/haproxy/s3haproxyconfig/s3haproxyconfig/s3_haproxy_config.py
+++ b/scripts/haproxy/s3haproxyconfig/s3haproxyconfig/s3_haproxy_config.py
@@ -102,7 +102,7 @@ frontend s3-main
 
     # s3 auth server port
     bind 0.0.0.0:9080
-    #bind 0.0.0.0:9443 ssl crt /etc/ssl/stx/stx.pem
+    bind 0.0.0.0:9443 ssl crt /etc/ssl/stx/stx.pem
 
     acl s3authbackendacl dst_port 9443
     acl s3authbackendacl dst_port 9080


### PR DESCRIPTION
Added fix to uncomment out the ssl crt statement.

File modified :
	scripts/haproxy/s3haproxyconfig/s3haproxyconfig/s3_haproxy_config.py

Signed-off-by: Mohammed Shahid <mohammed.shahid@seagate.com>