### PR TITLE
EOS-16667:S3: Changes required for main to pass pre-merge and mini-provisioner changes

### DIFF
--- a/ansible/files/yum.repos.d/centos7.8.2003/cortx_py_utils.repo
+++ b/ansible/files/yum.repos.d/centos7.8.2003/cortx_py_utils.repo
@@ -1,5 +1,5 @@
 [releases_cortx_py_utils]
-baseurl = http://cortx-storage.colo.seagate.com/releases/cortx/components/github/stable/centos-7.8.2003/dev/cortx-utils/last_successful/
+baseurl = http://cortx-storage.colo.seagate.com/releases/cortx/components/github/main/centos-7.8.2003/dev/cortx-utils/last_successful/
 gpgcheck = 0
 name = Yum repo for CORTX Python Utilities build - OS Centos 7.8.2003
 priority = 1

--- a/scripts/env/dev/init.sh
+++ b/scripts/env/dev/init.sh
@@ -70,9 +70,6 @@ install_pre_requisites() {
   #create topic
   sh ${S3_SRC_DIR}/scripts/kafka/create-topic.sh -c 1 -i $HOSTNAME
 
-  #install confluent_kafka
-  pip3 install confluent_kafka
-
   #install toml
   pip3 install toml
 

--- a/scripts/env/release/init.sh
+++ b/scripts/env/release/init.sh
@@ -50,9 +50,6 @@ install_pre_requisites() {
   #create topic
   sh ${S3_SRC_DIR}/scripts/kafka/create-topic.sh -c 1 -i $HOSTNAME
 
-  #install confluent_kafka
-  pip3 install confluent_kafka
-
   #install toml
   pip3 install toml
 

--- a/scripts/env/rpmbuild/init.sh
+++ b/scripts/env/rpmbuild/init.sh
@@ -46,9 +46,6 @@ install_pre_requisites() {
   #create topic
   sh ${S3_SRC_DIR}/scripts/kafka/create-topic.sh -c 1 -i $HOSTNAME
 
-  #install confluent_kafka
-  pip3 install confluent_kafka
-
   #install toml
   pip3 install toml
 

--- a/scripts/kafka/install-kafka.sh
+++ b/scripts/kafka/install-kafka.sh
@@ -24,7 +24,7 @@ set -e
 
 #Variables
 KAFKA_INSTALL_PATH=/opt
-KAFKA_DOWNLOAD_URL="http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/centos/centos-7.8.2003-1.0.0-3/commons/kafka/kafka_2.13-2.7.0.tgz"
+KAFKA_DOWNLOAD_URL="http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/centos/centos-7.8.2003-2.0.0-latest/commons/kafka/kafka_2.13-2.7.0.tgz"
 KAFKA_DIR_NAME="kafka"
 consumer_count=0
 hosts=""
@@ -40,6 +40,8 @@ install_prerequisite() {
   echo "Installing Pre-requisites"
   yum install java -y
   yum install java-devel -y
+  #install confluent_kafka 1.5.0 version as this is compatible with kafka_2.13-2.7.0
+  pip3 install confluent_kafka==1.5.0
   echo "Pre-requisites installed successfully."
 }
 


### PR DESCRIPTION
- changed cortx-py-utils path from stable to main
- hard-coded the confluent-kafka version to 1.5.0
- changed location of confluent-kafka installation from init.sh to kafka-install.py
- kafka download url was changed to correct location