### PR TITLE
EOS-17536:JClient: Upgrade log4j version 1.2.17 -> 2.14.0 (log4j-core)

### DIFF
--- a/auth-utils/jclient/pom.xml
+++ b/auth-utils/jclient/pom.xml
@@ -46,9 +46,9 @@
             <version>2.5</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.14.0</version>
         </dependency>
     </dependencies>
 

--- a/auth-utils/jclient/src/main/java/com/seagates3/javaclient/JavaClient.java
+++ b/auth-utils/jclient/src/main/java/com/seagates3/javaclient/JavaClient.java
@@ -38,8 +38,8 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.log4j.Level;
-import org.apache.log4j.LogManager;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
 
 public class JavaClient {
 
@@ -156,7 +156,7 @@ public class JavaClient {
             throw new Exception("Incorrect logging level");
         }
 
-        LogManager.getRootLogger().setLevel(level);
+        LogManager.getRootLogger().atLevel(level);
     }
 
     /**


### PR DESCRIPTION
log4j package is moved to log4j-core
hence updating log4j version in jclient code.
Link : https://mvnrepository.com/artifact/log4j/log4j
JIRA : https://jts.seagate.com/browse/EOS-17536

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>