### PR TITLE
EOS-17389: LR R2: Mini Provisioner - Convert s3_setup to python - config phase <patch 1: changes in setup_ldap.sh>

### DIFF
--- a/scripts/ldap/setup_ldap.sh
+++ b/scripts/ldap/setup_ldap.sh
@@ -101,8 +101,9 @@ chgrp ldap /etc/openldap/certs/password # onlyif: grep -q ldap /etc/group && tes
 
 if [ -z "$LDAPADMINPASS" ]
 then
+    # If --defaultpasswd is set, use it. Else ask from user as input
     if [[ $defaultpasswd == true ]]
-    then # Use same default password for both for empty ones
+    then
         LDAPADMINPASS=$defaultpasswds
     else
         # Fetch password from User
@@ -113,8 +114,9 @@ fi
 
 if [ -z "$ROOTDNPASSWORD" ]
 then
+    # If --defaultpasswd is set, use it. Else ask from user as input
     if [[ $defaultpasswd == true ]]
-    then # Use same default password for both for empty ones
+    then
         ROOTDNPASSWORD=$defaultpasswds
     else
         # Fetch password from User

--- a/scripts/provisioning/s3_setup
+++ b/scripts/provisioning/s3_setup
@@ -182,7 +182,7 @@ create_auth_jks_password()
 # Install and Configure Openldap over Non-SSL.
 configure_openldap()
 {
-    /opt/seagate/cortx/s3/install/ldap/setup_ldap.sh --confurl "$confstore_config_url" --defaultpasswd --skipssl
+    /opt/seagate/cortx/s3/install/ldap/setup_ldap.sh --ldapadminpasswd ldapadmin --rootdnpasswd seagate --skipssl
     if [ $? -ne 0 ]
     then
         echo "ERROR: Failed to configure openldap."

--- a/scripts/provisioning/s3_setup
+++ b/scripts/provisioning/s3_setup
@@ -182,7 +182,7 @@ create_auth_jks_password()
 # Install and Configure Openldap over Non-SSL.
 configure_openldap()
 {
-    /opt/seagate/cortx/s3/install/ldap/setup_ldap.sh --ldapadminpasswd ldapadmin --rootdnpasswd seagate --skipssl
+    /opt/seagate/cortx/s3/install/ldap/setup_ldap.sh --ldapadminpasswd $ldappasswd --rootdnpasswd $rootdnpasswd --skipssl
     if [ $? -ne 0 ]
     then
         echo "ERROR: Failed to configure openldap."


### PR DESCRIPTION
commit 6f6e6cfa2019ea1753a747a4470ec28253779c44
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Fri Feb 12 01:26:46 2021 -0700

        EOS-17389: LR R2: Mini Provisioner - Convert s3_setup to python - config phase <patch 1: changes in setup_ldap.sh>
        Change description:
                As described in ticket EOS-17389 for setup_ldap.sh and in caller in s3_setup
        Added/modified/deleted files:
                modified:   scripts/ldap/setup_ldap.sh
                modified:   scripts/provisioning/s3_setup
            Unit test:
                    Run "s3_setup config" with these changes and verified steps worked. Performed complete mini-provisioner s3 steps

    Signed-off-by: pratyush-seagate <pratyush.k.khan@seagate.com>
