### PR TITLE
EOS:16437 - Add new python provisioning script '_s3_setup' with 'post_install' and 'cleanup'

### DIFF
--- a/installhelper.sh
+++ b/installhelper.sh
@@ -96,11 +96,22 @@ cp -R scripts/haproxy/* $S3_INSTALL_LOCATION/install/haproxy
 # Copy the provisioning config
 cp scripts/provisioning/setup.yaml $S3_INSTALL_LOCATION/conf
 
-# Copy the provisioning script
+# Copy the provisioning shell script
 cp scripts/provisioning/s3_setup $S3_INSTALL_LOCATION/bin
 
-# Copy the mini-provisioner pre-reqs validation check config files
-cp scripts/provisioning/s3setup_prereqs.json ${S3_MINI_PROV_CFG_LOCATION}/
+# Copy the provisioning python scripts
+cp scripts/provisioning/_s3_setup $S3_INSTALL_LOCATION/bin
+cp scripts/provisioning/postinstallcmd.py $S3_INSTALL_LOCATION/bin
+cp scripts/provisioning/configcmd.py $S3_INSTALL_LOCATION/bin
+cp scripts/provisioning/initcmd.py $S3_INSTALL_LOCATION/bin
+cp scripts/provisioning/cleanupcmd.py $S3_INSTALL_LOCATION/bin
+cp scripts/provisioning/testcmd.py $S3_INSTALL_LOCATION/bin
+cp scripts/provisioning/resetcmd.py $S3_INSTALL_LOCATION/bin
+cp scripts/provisioning/setupcmd.py $S3_INSTALL_LOCATION/bin
+
+# Copy the mini-provisioner config files
+cp scripts/provisioning/s3setup_prereqs.json $S3_MINI_PROV_CFG_LOCATION/
+cp scripts/provisioning/s3_prov_config.yaml $S3_MINI_PROV_CFG_LOCATION/
 
 # Copy the S3 reset scripts
 cp scripts/reset/* $S3_INSTALL_LOCATION/reset

--- a/rpms/s3/s3rpm.spec
+++ b/rpms/s3/s3rpm.spec
@@ -376,7 +376,16 @@ rm -rf %{buildroot}
 /opt/seagate/cortx/s3/conf/s3config_unsafe_attributes.yaml
 /opt/seagate/cortx/s3/s3backgrounddelete/s3backgrounddelete_unsafe_attributes.yaml
 /opt/seagate/cortx/s3/mini-prov/s3setup_prereqs.json
+/opt/seagate/cortx/s3/mini-prov/s3_prov_config.yaml
+/opt/seagate/cortx/s3/bin/setupcmd.py
+/opt/seagate/cortx/s3/bin/postinstallcmd.py
+/opt/seagate/cortx/s3/bin/configcmd.py
+/opt/seagate/cortx/s3/bin/initcmd.py
+/opt/seagate/cortx/s3/bin/testcmd.py
+/opt/seagate/cortx/s3/bin/resetcmd.py
+/opt/seagate/cortx/s3/bin/cleanupcmd.py
 %attr(755, root, root) /opt/seagate/cortx/s3/bin/s3_setup
+%attr(755, root, root) /opt/seagate/cortx/s3/bin/_s3_setup
 %attr(755, root, root) /opt/seagate/cortx/s3/s3backgrounddelete/s3backgroundconsumer
 %attr(755, root, root) /opt/seagate/cortx/s3/s3backgrounddelete/s3backgroundproducer
 /etc/rsyslog.d/rsyslog-tcp-audit.conf

--- a/scripts/haproxy/s3haproxyconfig/s3haproxyconfig/s3_haproxy_config.py
+++ b/scripts/haproxy/s3haproxyconfig/s3haproxyconfig/s3_haproxy_config.py
@@ -20,9 +20,7 @@
 
 import os
 import sys
-import fileinput
 import argparse
-from cortx.utils.conf_store import Conf
 from s3confstore.cortx_s3_confstore import S3CortxConfStore
 
 class S3HaproxyConfig:

--- a/scripts/provisioning/_s3_setup
+++ b/scripts/provisioning/_s3_setup
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+# TODO: change name of this python script to 's3_setup' when shell script of the same name is EOL'ed
+
+import sys
+import argparse
+import traceback
+import errno
+
+from postinstallcmd import PostInstallCmd
+from cleanupcmd import CleanupCmd
+from configcmd import ConfigCmd
+from testcmd import TestCmd
+from resetcmd import ResetCmd
+from initcmd import InitCmd
+
+def main():
+  parser = argparse.ArgumentParser("S3server setup command")
+  subparsers = parser.add_subparsers(dest = 'command')
+
+  postinstallCmd = subparsers.add_parser('post_install', help='setup post_install')
+  postinstallCmd.add_argument("--config", help='config URL', type=str)
+
+  configCmd = subparsers.add_parser('config', help='setup config')
+  configCmd.add_argument("--config", help='config URL', type=str, required=True)
+
+  initCmd = subparsers.add_parser('init', help='setup init')
+  initCmd.add_argument("--config", help='config URL', type=str, required=True)
+
+  cleanupCmd = subparsers.add_parser('cleanup', help='setup cleanup')
+  cleanupCmd.add_argument("--config", help='config URL', type=str, required=True)
+
+  testCmd = subparsers.add_parser('test', help='setup test')
+  testCmd.add_argument("--config", help='config URL', type=str, required=True)
+
+  testCmd = subparsers.add_parser('reset', help='setup reset')
+  testCmd.add_argument("--config", help='config URL', type=str, required=True)
+
+  args = parser.parse_args()
+  try:
+    # run post_install always, the failure will raise exception in PostInstallCmd class
+    PostInstallCmd().process()
+    sys.stdout.write('INFO: post_install validations successful.\n')
+    
+    if args.command == 'cleanup':
+      CleanupCmd(args.config).process()
+      sys.stdout.write('INFO: cleanup successful.\n')
+      
+    elif args.command == 'config':
+      ConfigCmd(args.config).process()
+      sys.stdout.write('INFO: config successful.\n')
+      
+    elif args.command == 'init':
+      InitCmd(args.config).process()
+      sys.stdout.write('INFO: init successful.\n')
+      
+    elif args.command == 'test':
+      TestCmd(args.config).process()
+      sys.stdout.write('PASS: S3-Sanity test passed.\n')
+      
+    elif args.command == 'reset':
+      ResetCmd(args.config).process()
+      sys.stdout.write('INFO: reset successful.\n')
+
+  except Exception as e:
+    sys.stderr.write(f"\n{str(e)}\n\n")
+    sys.stderr.write(f"{traceback.format_exc()}\n")
+    return errno.EINVAL
+
+  return 0
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/scripts/provisioning/cleanupcmd.py
+++ b/scripts/provisioning/cleanupcmd.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+import sys
+import ldap
+import yaml
+from yaml.error import YAMLError
+
+from s3cipher.cortx_s3_cipher import CortxS3Cipher
+from setupcmd import SetupCmd
+
+class CleanupCmd(SetupCmd):
+  """Cleanup Setup Cmd."""
+  name = "cleanup"
+
+  # map with key as 'account-name', and value as the account related constants
+  account_cleanup_dict = {
+                          "s3-background-delete-svc": {
+                            "cipherConstKey": "s3backgroundaccesskey",
+                            "s3userId": "450"
+                          }
+                        }
+  ldap_conn = None
+  ldap_url = None
+  ldap_cn = None
+
+  def __init__(self, config: str):
+    """Constructor."""
+    try:
+      super(CleanupCmd, self).__init__(config)
+
+      self.read_ldap_credentials()
+
+      with open(self.s3_prov_config) as provconfig:
+        s3_prov_config_yaml = yaml.safe_load(provconfig)
+        self.ldap_url = s3_prov_config_yaml['LDAP_URL']
+        self.ldap_cn = s3_prov_config_yaml['LDAP_USER']
+
+    except IOError as ioe:
+      sys.stderr.write(f'failed to open config file: {self.s3_prov_config}, err: {ioe}\n')
+      raise ioe
+    except YAMLError as ye:
+      sys.stderr.write(f'yaml load failed for file: {self.s3_prov_config}, err: {ye}\n')
+      raise ye
+    except Exception as e:
+      sys.stderr.write(f'unknown exception: {e}\n')
+      raise e
+
+  def process(self):
+    """Main processing function."""
+    sys.stdout.write(f"Processing {self.name} {self.url}\n")
+
+    # remove accounts in account_cleanup_list
+    # 1. Check if the account exists or not
+    # 2. Delete the account if it exists, else do nothing
+    self.create_ldap_connection()
+
+    for acc in self.account_cleanup_dict.keys():
+      if(self.if_ldap_account_exists(acc)):
+        sys.stdout.write(f'deleting ldap account: {acc}\n')
+        try:
+          self.delete_ldap_account(acc)
+        except Exception as e:
+          raise e
+      else:
+        sys.stdout.write(f'INFO: ldap account: {acc} does not exist, nothing to do.\n')
+
+    # close ldap connection
+    self.delete_ldap_connection()
+
+  def create_ldap_connection(self):
+    """Open ldap connection."""
+    self.ldap_conn = ldap.initialize(self.ldap_url)
+
+    self.ldap_conn.protocol_version = ldap.VERSION3
+    self.ldap_conn.set_option(ldap.OPT_REFERRALS, 0)
+    self.ldap_conn.simple_bind_s(self.ldap_cn.format(self.ldap_user), self.ldap_passwd)
+
+  def delete_ldap_connection(self):
+    """Delete ldap connection."""
+    self.ldap_conn.unbind_s()
+
+  def if_ldap_account_exists(self, ldap_acc: str):
+    """Check if given s3 account exists."""
+    try:
+      self.ldap_conn.search_s(f'o={ldap_acc},ou=accounts,dc=s3,dc=seagate,dc=com',
+                            ldap.SCOPE_SUBTREE)
+    except ldap.NO_SUCH_OBJECT:
+      return False
+    except Exception as e:
+      sys.stderr.write(f'INFO: Failed to find ldap account: {ldap_acc}, error: {str(e)}\n')
+      raise e
+    return True
+
+  def delete_ldap_account(self, ldap_acc: str):
+    """Delete the given s3 account."""
+    try:
+      acc_attributes_dict = self.account_cleanup_dict[ldap_acc]
+      s3cipher_obj = CortxS3Cipher(None, True, 22, acc_attributes_dict["cipherConstKey"])
+      access_key = s3cipher_obj.generate_key()
+      # delete the access key
+      try:
+        self.ldap_conn.delete_s(f'ak={access_key},ou=accesskeys,dc=s3,dc=seagate,dc=com')
+      except ldap.NO_SUCH_OBJECT:
+        pass
+
+      # delete the 'ldap_acc' account's subordinate objects
+      try:
+        self.ldap_conn.delete_s(f'ou=roles,o={ldap_acc},ou=accounts,dc=s3,dc=seagate,dc=com')
+      except ldap.NO_SUCH_OBJECT:
+        pass
+      try:
+        self.ldap_conn.delete_s(f's3UserId={acc_attributes_dict["s3userId"]},ou=users,o={ldap_acc},ou=accounts,dc=s3,dc=seagate,dc=com')
+      except ldap.NO_SUCH_OBJECT:
+        pass
+      try:
+        self.ldap_conn.delete_s(f'ou=users,o={ldap_acc},ou=accounts,dc=s3,dc=seagate,dc=com')
+      except ldap.NO_SUCH_OBJECT:
+        pass
+      try:
+        self.ldap_conn.delete_s(f'ou=groups,o={ldap_acc},ou=accounts,dc=s3,dc=seagate,dc=com')
+      except ldap.NO_SUCH_OBJECT:
+        pass
+      try:
+        self.ldap_conn.delete_s(f'ou=policies,o={ldap_acc},ou=accounts,dc=s3,dc=seagate,dc=com')
+      except ldap.NO_SUCH_OBJECT:
+        pass
+
+      # delete the 'ldap_acc' account
+      self.ldap_conn.delete_s(f'o={ldap_acc},ou=accounts,dc=s3,dc=seagate,dc=com')
+    except Exception as e:
+      sys.stderr.write(f'failed to delete account: {ldap_acc}, err: {e}\n')
+      raise e

--- a/scripts/provisioning/configcmd.py
+++ b/scripts/provisioning/configcmd.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import sys
+
+from setupcmd import SetupCmd
+
+class ConfigCmd(SetupCmd):
+  """Config Setup Cmd."""
+  name = "config"
+
+  def __init__(self, config: str):
+    """Constructor."""
+    try:
+      super(ConfigCmd, self).__init__(config)
+    except Exception as e:
+      raise e
+
+  def process(self):
+    """Main processing function."""
+    retval = 0
+    sys.stdout.write(f"Processing {self.name} {self.url}\n")
+    return retval

--- a/scripts/provisioning/initcmd.py
+++ b/scripts/provisioning/initcmd.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import sys
+
+from setupcmd import SetupCmd
+
+class InitCmd(SetupCmd):
+  """Init Setup Cmd."""
+  name = "init"
+
+  def __init__(self, config: str):
+    """Constructor."""
+    try:
+      super(InitCmd, self).__init__(config)
+    except Exception as e:
+      raise e
+
+  def process(self):
+    """Main processing function."""
+    retval = 0
+    sys.stdout.write(f"Processing {self.name} {self.url}\n")
+    return retval

--- a/scripts/provisioning/postinstallcmd.py
+++ b/scripts/provisioning/postinstallcmd.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+from json.decoder import JSONDecodeError
+import sys
+import json
+import os
+
+from cortx.utils.validator.v_pkg import PkgV
+from cortx.utils.validator.v_service import ServiceV
+from cortx.utils.validator.v_path import PathV
+
+class PostInstallCmd:
+  """PostInstall Setup Cmd."""
+  name = "post_install"
+  _preqs_conf_file = "/opt/seagate/cortx/s3/mini-prov/s3setup_prereqs.json"
+
+  def __init__(self):
+    """Constructor."""
+    if not os.path.isfile(self._preqs_conf_file):
+      raise FileNotFoundError(f'pre-requisite json file: {self._preqs_conf_file} not found')
+
+  def process(self):
+    """Main processing function."""
+    sys.stdout.write(f"Processing {self.name}\n")
+    try:
+      with open(self._preqs_conf_file) as preqs_conf:
+        preqs_conf_json = json.load(preqs_conf)
+      self.validate_pre_requisites(rpms=preqs_conf_json['rpms'],
+                              services=preqs_conf_json['services'],
+                              pip3s=preqs_conf_json['pip3s'],
+                              files=preqs_conf_json['exists']
+                            )
+    except IOError as e:
+      print(f'{self._preqs_conf_file} open failed, error: {e}')
+      raise e
+    except JSONDecodeError as e:
+      print(f'fail to decode json file:{self._preqs_conf_file}, error: {e}')
+      raise e
+    except Exception as e:
+      # exception in validation
+      raise e
+
+  def validate_pre_requisites(self,
+                        rpms: list = None,
+                        pip3s: list = None,
+                        services: list = None,
+                        files: list = None):
+    """Validate pre requisites using cortx-py-utils validator."""
+    try:
+      if pip3s:
+        PkgV().validate('pip3s', pip3s)
+      if services:
+        ServiceV().validate('isrunning', services)
+      if rpms:
+        PkgV().validate('rpms', rpms)
+      if files:
+        PathV().validate('exists', files)
+    except Exception as e:
+      sys.stderr.write('ERROR: post_install validations failed.\n')
+      sys.stderr.write(f"{e}, config:{self._preqs_conf_file}\n")
+      raise e

--- a/scripts/provisioning/resetcmd.py
+++ b/scripts/provisioning/resetcmd.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import sys
+
+from setupcmd import SetupCmd
+
+class ResetCmd(SetupCmd):
+  """Reset Setup Cmd."""
+  name = "reset"
+
+  def __init__(self, config: str):
+    """Constructor."""
+    try:
+      super(ResetCmd, self).__init__(config)
+    except Exception as e:
+      raise e
+
+  def process(self):
+    """Main processing function."""
+    retval = 0
+    sys.stdout.write(f"Processing {self.name} {self.url}\n")
+    return retval

--- a/scripts/provisioning/s3_prov_config.yaml
+++ b/scripts/provisioning/s3_prov_config.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+LDAP_USER: "cn={},dc=seagate,dc=com"
+LDAP_URL: "ldapi:///"
+CONFSTORE_OPENLDAP_CONST_KEY: 'openldap'
+CONFSTORE_LDAPADMIN_USER_KEY: 'openldap>sgiam>user'
+CONFSTORE_LDAPADMIN_PASSWD_KEY: 'openldap>sgiam>secret'
+CONFSTORE_ROOTDN_USER_KEY: 'openldap>root>user'
+CONFSTORE_ROOTDN_PASSWD_KEY: 'openldap>root>secret'

--- a/scripts/provisioning/s3_setup
+++ b/scripts/provisioning/s3_setup
@@ -47,6 +47,7 @@ cleanup                  cleanup S3 account created for backgrounddelete service
 
 set -e
 
+install_dir='/opt/seagate/cortx/s3/bin'
 access_key=""
 secret_key=""
 
@@ -63,28 +64,6 @@ rootadminpasswd=""
 
 ldappasswd=""
 rootpasswd=""
-
-encrypt_cli="/opt/seagate/cortx/auth/AuthPassEncryptCLI-1.0-0.jar"
-
-# check if s3cipher, s3confstore and s3setup are installed on the system
-if ! command -v s3cipher &>/dev/null
-then
-    echo "ERROR: s3cipher not installed on the system, exiting."
-    exit 1
-fi
-
-if ! command -v s3confstore &>/dev/null
-then
-    echo "ERROR: s3confstore not installed on the system, exiting."
-    exit 1
-fi
-
-if ! command -v s3setup &>/dev/null
-then
-    echo "ERROR: s3setup not installed on the system, exiting."
-    exit 1
-fi
-
 
 while test $# -gt 0
 do
@@ -291,19 +270,19 @@ then
     systemctl restart haproxy slapd rabbitmq-server rsyslog
 
     echo "INFO: running post_install..."
-    # we already have 'exit' statement in 's3setup' binary at failure scenario,
+    # we already have 'exit' statement in '_s3_setup' binary at failure scenario,
     # no need to add 'exit' here.   
-    s3setup post_install
+    $install_dir/_s3_setup post_install
     echo "INFO: All pre-requisites are in place."
 fi
 
 if [ $s3config == true ]
 then
     # validate pre-requisites before proceeding
-    # we already have 'exit' statement in 's3setup' binary at failure scenario,
+    # we already have 'exit' statement in '_s3_setup' binary at failure scenario,
     # no need to add 'exit' here.
     echo "INFO: validating pre-requisites for provisioning s3server.."
-    s3setup post_install
+    $install_dir/_s3_setup post_install
 
     # Fetch and update cluster id
     # To decrypt openldap passwords, we need 'cluster_id' updated in s3_cluster.yaml
@@ -334,10 +313,10 @@ fi
 if [ $s3init == true ]
 then
     # validate pre-requisites before proceeding
-    # we already have 'exit' statement in 's3setup' binary at failure scenario,
+    # we already have 'exit' statement in '_s3_setup' binary at failure scenario,
     # no need to add 'exit' here.
     echo "INFO: validating pre-requisites for provisioning s3server.."
-    s3setup post_install
+    $install_dir/_s3_setup post_install
 
     # get openldap password from confstore
     echo "INFO: Get openldap passwords from confstore.."
@@ -369,5 +348,5 @@ then
     echo "INFO: Get openldap passwords from confstore.."
     get_ldap_password
 
-    s3setup cleanup --ldappasswd "$ldappasswd"
+    $install_dir/_s3_setup cleanup --config "$confstore_config_url"
 fi

--- a/scripts/provisioning/s3setup_prereqs.json
+++ b/scripts/provisioning/s3setup_prereqs.json
@@ -1,6 +1,6 @@
 {
     "rpms": ["openldap-servers", "openldap-clients", "haproxy", "motr"],
-    "pip3s": ["toml", "s3confstore", "crypto", "s3setup", "s3haproxyconfig"],
+    "pip3s": ["toml", "s3confstore", "crypto", "s3haproxyconfig", "s3cipher"],
     "services": ["sshd", "rabbitmq-server", "haproxy", "slapd", "rsyslog"],
     "exists": [
 		"file:/etc/machine-id",

--- a/scripts/provisioning/setupcmd.py
+++ b/scripts/provisioning/setupcmd.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+#
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import sys
+import yaml
+from yaml.error import YAMLError
+
+from s3confstore.cortx_s3_confstore import S3CortxConfStore
+from s3cipher.cortx_s3_cipher import CortxS3Cipher
+
+class SetupCmd(object):
+  """Base class for setup commands."""
+  ldap_user = None
+  ldap_passwd = None
+  s3_prov_config = "/opt/seagate/cortx/s3/mini-prov/s3_prov_config.yaml"
+
+  def __init__(self, config: str):
+    """Constructor."""
+    if not config.strip():
+      sys.stderr.write(f'config url:[{config}] must be a valid url path\n')
+      raise Exception('empty config URL path')
+
+    self._url = config
+    self._s3confstore = S3CortxConfStore(self._url)
+
+  @property
+  def url(self) -> str:
+    return self._url
+
+  @property
+  def s3confstore(self) -> str:
+    return self._s3confstore
+
+  def read_ldap_credentials(self):
+    """Get 'ldapadmin' user name and password from confstore."""
+    prov_config_yaml = None
+
+    try:
+      with open(self.s3_prov_config) as provconf:
+        prov_config_yaml = yaml.safe_load(provconf)
+
+      s3cipher_obj = CortxS3Cipher(None, False, 0, prov_config_yaml['CONFSTORE_OPENLDAP_CONST_KEY'])
+      cipher_key = s3cipher_obj.generate_key()
+
+      encrypted_ldapadmin_pass = self.s3confstore.get_config(prov_config_yaml['CONFSTORE_LDAPADMIN_PASSWD_KEY'])
+      self.ldap_passwd = s3cipher_obj.decrypt(cipher_key, encrypted_ldapadmin_pass)
+
+      self.ldap_user = self.s3confstore.get_config(prov_config_yaml['CONFSTORE_LDAPADMIN_USER_KEY'])
+    except IOError as ioe:
+      sys.stderr.write(f'failed to open config file: {self.s3_prov_config}, err: {ioe}\n')
+      raise ioe
+    except YAMLError as ye:
+      sys.stderr.write(f'yaml load failed for config file: {self.s3_prov_config}, err: {ye}\n')
+      raise ye
+    except Exception as e:
+      sys.stderr.write(f'unknown exception: {e}\n')
+      raise e

--- a/scripts/provisioning/testcmd.py
+++ b/scripts/provisioning/testcmd.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import sys
+
+from setupcmd import SetupCmd
+
+class TestCmd(SetupCmd):
+  """Test Setup Cmd."""
+  name = "test"
+
+  def __init__(self, config: str):
+    """Constructor."""
+    try:
+      super(TestCmd, self).__init__(config)
+    except Exception as e:
+      raise e
+
+  def process(self):
+    """Main processing function."""
+    retval = 0
+    sys.stdout.write(f"Processing {self.name} {self.url}\n")
+    return retval


### PR DESCRIPTION
We need to replace present 's3_setup', which is a shell based script, with a python based script.

As of now keeping the new python provisioning script name as '_s3_setup', but its name will
be replaces as soon as we EOL the shell script with same name.

Signed-off-by: Amit Kumar <amit.kumar@seagate.com>