### PR TITLE
Update CORTX-S3 Server Quick Start Guide.md

### DIFF
--- a/docs/CORTX-S3 Server Quick Start Guide.md
+++ b/docs/CORTX-S3 Server Quick Start Guide.md
@@ -122,7 +122,7 @@ Refer to the image below to view the output of a successful `$ init.sh -a` run, 
 
 ![Successful run](../images/init_script_output.png)
 
-If you still see errors or a failed status, please [reach out to us for support](#Reach-Out-to-Us)
+If you still see errors or a failed status, please [reach out to us for support](https://github.com/Seagate/cortx/blob/main/SUPPORT.md)
 
 Please read our [FAQs](https://github.com/Seagate/cortx/blob/master/doc/Build-Installation-FAQ.md) for troubleshooting errors.
 
@@ -353,7 +353,7 @@ Refer to our [CORTX Contribution Guide](https://github.com/Seagate/cortx/blob/ma
 
 ### Reach Out to Us
 
-Please refer to the [Support](../SUPPORT.md) section to reach out to us with your questions, contributions, and feedback.
+Please refer to the [Support](https://github.com/Seagate/cortx/blob/main/SUPPORT.md) section to reach out to us with your questions, contributions, and feedback.
 
 Tested by:
 


### PR DESCRIPTION
The s3 specific SUPPORT.md page -> https://github.com/Seagate/cortx-s3server/blob/main/SUPPORT.md needs updating. 

I think it's better to just point to the main general support.md page in the main CORTX repo and keep it updated in one place and so I've made changes to point there for support.

Signed-off-by: Justin Woo <justin.woo@seagate.com>

-----
[View rendered docs/CORTX-S3 Server Quick Start Guide.md](https://github.com/Seagate/cortx-s3server/blob/justinzw-patch-1/docs/CORTX-S3 Server Quick Start Guide.md)