### PR TITLE
Enable the EPEL repo before installing pip

### DIFF
--- a/docs/CORTX-S3 Server Quick Start Guide.md
+++ b/docs/CORTX-S3 Server Quick Start Guide.md
@@ -42,6 +42,7 @@ This guide provides a step-by-step walkthrough for getting you CORTX-S3 Server r
       * To install Python version 3.0, use: `$ yum install -y python3`
     * pip:
       * To check if pip is installed, use: `$ pip --version`
+      * Enable the EPEL repo, use:`$ yum --enablerepo=extras install epel-release`
       * To install pip use: `$ yum install python-pip`
     * Ansible: `$ yum install -y ansible`
     * Extra Packages for Enterprise Linux:


### PR DESCRIPTION
Signed-off-by: Patrick Hession <patrick.hession@seagate.com>


-----
Added a line to enable the EPEL repo before installing python-pip with yum.

[View rendered docs/CORTX-S3 Server Quick Start Guide.md](https://github.com/Seagate/cortx-s3server/blob/hessio-patch-1/docs/CORTX-S3 Server Quick Start Guide.md)