### PR TITLE
EOS:18227 - Add python36-ldap package as requirment in s3rpm spec file.

### DIFF
--- a/rpms/s3/s3rpm.spec
+++ b/rpms/s3/s3rpm.spec
@@ -107,6 +107,7 @@ Requires: pkgconfig
 Requires: log4cxx_cortx log4cxx_cortx-devel
 # Required by S3 background delete based on python
 Requires: python36
+Requires: python36-ldap
 Requires: python%{py_short_ver}-yaml
 Requires: python%{py_short_ver}-pika
 %if 0%{?el7}


### PR DESCRIPTION
s3_setup script needs python36-ldap package to do openldap configuration and cleanup.

Signed-off-by: Amit Kumar <amit.kumar@seagate.com>