### PR TITLE
S3: Finalize and deliver fix for small "first read"

### DIFF
--- a/s3config-test.yaml
+++ b/s3config-test.yaml
@@ -101,6 +101,7 @@ S3_MOTR_CONFIG:                                     # Section for S3 Motr
    S3_MOTR_READ_POOL_MAX_THRESHOLD: 104857600         # 100 MB, The maximum memory threshold for the pool, multiple of S3_MOTR_UNIT_SIZE
    S3_MOTR_READ_MEMPOOL_ZERO_BUFFER: false            # Enable Motr Mempool 'zeroing' after use (like secure erase) - disabled by default
    S3_MOTR_OPERATION_WAIT_PERIOD: 90                  # 90 s, Maximum wait duration for sync motr operations.
+   S3_MOTR_FIRST_READ_SIZE: 4                         # Num of units of First Read Request to MOTR
 S3_THIRDPARTY_CONFIG:
    S3_LIBEVENT_POOL_BUFFER_SIZE: 4096                   # Pool buffer size
                                                         # For S3_MOTR_UNIT_SIZE of size 1MB, it is recommended to have S3_LIBEVENT_POOL_BUFFER_SIZE of size 16384

--- a/s3config.release.yaml.sample
+++ b/s3config.release.yaml.sample
@@ -101,6 +101,7 @@ S3_MOTR_CONFIG:                                     # Section for S3 Motr
    S3_MOTR_READ_POOL_MAX_THRESHOLD: 1048576000        # 1GB, The maximum memory threshold for the pool, multiple of S3_MOTR_UNIT_SIZE
    S3_MOTR_READ_MEMPOOL_ZERO_BUFFER: false           # Enable Motr Mempool 'zeroing' after use (like secure erase) - disabled by default
    S3_MOTR_OPERATION_WAIT_PERIOD: 90                  # 90 s, Maximum wait duration for sync motr operations.
+   S3_MOTR_FIRST_READ_SIZE: 4                         # Size in MB of the First Read Request to MOTR
 S3_THIRDPARTY_CONFIG:
    S3_LIBEVENT_POOL_BUFFER_SIZE: 16384                  # Pool buffer size, in case of S3_MOTR_UNIT_SIZE of size 1MB, it is recommended to have S3_LIBEVENT_POOL_BUFFER_SIZE of size 16384
    S3_LIBEVENT_MAX_READ_SIZE: 16384                     # Maximum read in a single read operation, as per libevent documentation in code, user should not try to read more than this value

--- a/s3config.yaml.sample
+++ b/s3config.yaml.sample
@@ -101,6 +101,7 @@ S3_MOTR_CONFIG:                                     # Section for S3 Motr
    S3_MOTR_READ_POOL_MAX_THRESHOLD: 524288000        # 500 MB, The maximum memory threshold for the pool, multiple of S3_MOTR_UNIT_SIZE
    S3_MOTR_READ_MEMPOOL_ZERO_BUFFER: false           # Enable Motr Mempool 'zeroing' after use (like secure erase) - disabled by default
    S3_MOTR_OPERATION_WAIT_PERIOD: 90                 # 90 s, Maximum wait duration for sync motr operations.
+   S3_MOTR_FIRST_READ_SIZE: 4                        # Size in MB of the First Read Request to MOTR
 S3_THIRDPARTY_CONFIG:
    S3_LIBEVENT_POOL_BUFFER_SIZE: 16384                  # Pool buffer size, in case of S3_MOTR_UNIT_SIZE of size 1MB, it is recommended to have S3_LIBEVENT_POOL_BUFFER_SIZE of size 16384
    S3_LIBEVENT_MAX_READ_SIZE: 16384                     # Maximum read in a single read operation, as per libevent documentation in code, user should not try to read more than this value

--- a/server/s3_option.cc
+++ b/server/s3_option.cc
@@ -258,6 +258,10 @@ bool S3Option::load_section(std::string section_name,
       motr_op_wait_period =
           s3_option_node["S3_MOTR_OPERATION_WAIT_PERIOD"].as<unsigned int>();
 
+      S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_MOTR_FIRST_READ_SIZE");
+      motr_first_obj_read_size =
+          s3_option_node["S3_MOTR_FIRST_READ_SIZE"].as<unsigned int>();
+
       std::string motr_read_pool_initial_buffer_count_str;
       std::string motr_read_pool_expandable_count_str;
       std::string motr_read_pool_max_threshold_str;
@@ -1317,4 +1321,8 @@ bool S3Option::get_motr_read_mempool_zeroed_buffer() {
 
 bool S3Option::get_libevent_mempool_zeroed_buffer() {
   return libevent_mempool_zeroed_buffer;
+}
+
+unsigned int S3Option::get_motr_first_read_size() {
+  return motr_first_obj_read_size;
 }

--- a/server/s3_option.h
+++ b/server/s3_option.h
@@ -133,6 +133,7 @@ class S3Option {
   bool log_buffering_enable;
   bool s3_enable_murmurhash_oid;
   int log_flush_frequency_sec;
+  unsigned int motr_first_obj_read_size;
 
   unsigned short motr_layout_id;
   unsigned short motr_units_per_request;
@@ -400,6 +401,7 @@ class S3Option {
   size_t get_motr_read_pool_initial_buffer_count();
   size_t get_motr_read_pool_expandable_count();
   size_t get_motr_read_pool_max_threshold();
+  unsigned int get_motr_first_read_size();
 
   size_t get_libevent_pool_initial_size();
   size_t get_libevent_pool_expandable_size();


### PR DESCRIPTION
In POC EOS-16558 we confirmed that reducing size of first read helps achieve better TTFB. 
This PR is to finalize the changes and deliver it to main