### PR TITLE
[mini-provisioning:cleanup]EOS-18718:Revert config files

### DIFF
--- a/scripts/provisioning/cleanupcmd.py
+++ b/scripts/provisioning/cleanupcmd.py
@@ -19,6 +19,8 @@
 #
 
 import sys
+import os
+import shutil
 
 from setupcmd import SetupCmd
 from ldapaccountaction import LdapAccountAction
@@ -50,4 +52,32 @@ class CleanupCmd(SetupCmd):
       ldap_action_obj = LdapAccountAction(self.ldap_user, self.ldap_passwd)
       ldap_action_obj.delete_account(self.account_cleanup_dict)
     except Exception as e:
+      raise e
+    try:
+      self.revert_config_files()
+    except Exception as e:
+      raise e
+
+  def revert_config_files(self):
+    """Revert config files to their origional config state."""
+    auth_config="/opt/seagate/cortx/auth/resources/authserver.properties"
+    auth_keystore_config="/opt/seagate/cortx/auth/resources/keystore.properties"
+    auth_jksstore="/opt/seagate/cortx/auth/resources/s3authserver.jks"
+    auth_jksstore_template="/opt/seagate/cortx/auth/scripts/s3authserver.jks_template"
+    s3_config="/opt/seagate/cortx/s3/conf/s3config.yaml"
+    s3_bgdelete_config="/opt/seagate/cortx/s3/s3backgrounddelete/config.yaml"
+
+    try:
+      if os.path.isfile(auth_config):
+        shutil.copy(auth_config+".sample", auth_config)
+      if os.path.isfile(auth_keystore_config):
+        shutil.copy(auth_keystore_config+".sample", auth_keystore_config)
+      if os.path.isfile(auth_jksstore):
+        shutil.copy(auth_jksstore_template, auth_jksstore)
+      if os.path.isfile(s3_config):
+        shutil.copy(s3_config+".sample", s3_config)
+      if os.path.isfile(s3_bgdelete_config):
+        shutil.copy(s3_bgdelete_config+".sample", s3_bgdelete_config)
+    except Exception as e:
+      sys.stderr.write(f'Failed to revert config files in Cleanup phase, error: {e}\n')
       raise e


### PR DESCRIPTION
Below are the config files which will be **reverted** in **Cleanup phase**

auth_config="/opt/seagate/cortx/auth/resources/authserver.properties"
auth_keystore_config="/opt/seagate/cortx/auth/resources/keystore.properties"
auth_jksstore="/opt/seagate/cortx/auth/resources/s3authserver.jks"
auth_jksstore_template="/opt/seagate/cortx/auth/scripts/s3authserver.jks_template"
s3_config="/opt/seagate/cortx/s3/conf/s3config.yaml"
s3_bgdelete_config="/opt/seagate/cortx/s3/s3backgrounddelete/config.yaml"

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>