### PR TITLE
EOS-18618 - Fix memory leaks from evhttp_uridecode and replace deprecated evhttp_decode_uri

### DIFF
--- a/server/s3_copy_object_action.cc
+++ b/server/s3_copy_object_action.cc
@@ -91,7 +91,10 @@ void S3CopyObjectAction::get_source_bucket_and_object() {
       source_object_name = source.substr(separator_pos + 1);
     }
   }
-  source_object_name = evhttp_decode_uri(source_object_name.c_str());
+  char* decode_uri = evhttp_uridecode(source_object_name.c_str(), 0, NULL);
+  source_object_name = decode_uri;
+  free(decode_uri);
+  decode_uri = NULL;
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 

--- a/server/s3_post_multipartobject_action.cc
+++ b/server/s3_post_multipartobject_action.cc
@@ -171,7 +171,7 @@ void S3PostMultipartObjectAction::parse_x_amz_tagging_header(
     for (struct evkeyval* header = key_value.tqh_first; header;
          header = header->next.tqe_next) {
 
-      decoded_key = evhttp_decode_uri(header->key);
+      decoded_key = evhttp_uridecode(header->key, 0, NULL);
       s3_log(S3_LOG_DEBUG, request_id,
              "Successfully parsed the Key Values=%s %s", decoded_key,
              header->value);

--- a/server/s3_post_multipartobject_action.cc
+++ b/server/s3_post_multipartobject_action.cc
@@ -176,6 +176,8 @@ void S3PostMultipartObjectAction::parse_x_amz_tagging_header(
              "Successfully parsed the Key Values=%s %s", decoded_key,
              header->value);
       new_object_tags_map[decoded_key] = header->value;
+      free(decoded_key);
+      decoded_key = NULL;
     }
     validate_tags();
   } else {

--- a/server/s3_put_chunk_upload_object_action.cc
+++ b/server/s3_put_chunk_upload_object_action.cc
@@ -213,6 +213,8 @@ void S3PutChunkUploadObjectAction::parse_x_amz_tagging_header(
              "Successfully parsed the Key Values=%s %s", decoded_key,
              header->value);
       new_object_tags_map[decoded_key] = header->value;
+      free(decoded_key);
+      decoded_key = NULL;
     }
     validate_tags();
   } else {

--- a/server/s3_put_chunk_upload_object_action.cc
+++ b/server/s3_put_chunk_upload_object_action.cc
@@ -208,7 +208,7 @@ void S3PutChunkUploadObjectAction::parse_x_amz_tagging_header(
     for (struct evkeyval* header = key_value.tqh_first; header;
          header = header->next.tqe_next) {
 
-      decoded_key = evhttp_decode_uri(header->key);
+      decoded_key = evhttp_uridecode(header->key, 0, NULL);
       s3_log(S3_LOG_DEBUG, request_id,
              "Successfully parsed the Key Values=%s %s", decoded_key,
              header->value);

--- a/server/s3_put_object_action.cc
+++ b/server/s3_put_object_action.cc
@@ -178,6 +178,8 @@ void S3PutObjectAction::parse_x_amz_tagging_header(std::string content) {
              "Successfully parsed the Key Values=%s %s", decoded_key,
              header->value);
       new_object_tags_map[decoded_key] = header->value;
+      free(decoded_key);
+      decoded_key = NULL;
     }
     validate_tags();
   } else {

--- a/server/s3_put_object_action.cc
+++ b/server/s3_put_object_action.cc
@@ -173,7 +173,7 @@ void S3PutObjectAction::parse_x_amz_tagging_header(std::string content) {
     for (struct evkeyval* header = key_value.tqh_first; header;
          header = header->next.tqe_next) {
 
-      decoded_key = evhttp_decode_uri(header->key);
+      decoded_key = evhttp_uridecode(header->key, 0, NULL);
       s3_log(S3_LOG_DEBUG, request_id,
              "Successfully parsed the Key Values=%s %s", decoded_key,
              header->value);


### PR DESCRIPTION
EOS-18618 - Fix memory leaks from evhttp_uridecode and replace deprecated evhttp_decode_uri

Files modified :
   server/s3_copy_object_action.cc
   server/s3_post_multipartobject_action.cc
   server/s3_put_chunk_upload_object_action.cc
   server/s3_put_object_action.cc

Testing :
On CLI :
`put-object pbucket1/object - result(PASS)`
`copy-object pbucket1/object - result(PASS)`
End result : put-object and copy-object via CLI is successful for regular objects.

Signed-off-by: Mohammed Shahid <mohammed.shahid@seagate.com>