### PR TITLE
EOS-17952: Mini Provisioner: s3_setup Cleanup phase

### DIFF
--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -332,15 +332,6 @@ step_10 () {
 	if [ "$1" = "true" ];then
 		bash -x /opt/seagate/cortx/s3/bin/s3_setup cleanup --config "json://$s3_conf_file" &> /dev/null || die_with_error "s3:cleanup failed!"
 		echo "s3:cleanup passed!"
-		# Attempt ldap clean up since ansible openldap setup is not idempotent
-		systemctl stop slapd 2>/dev/null
-		yum remove -y openldap-servers openldap-clients || "openldap-servers openldap-clients removal failed"
-		rm -f /etc/openldap/slapd.d/cn\=config/cn\=schema/cn\=\{1\}s3user.ldif
-		rm -rf /var/lib/ldap/*
-		rm -f /etc/sysconfig/slapd* 2>/dev/null || /bin/true
-		rm -f /etc/openldap/slapd* 2>/dev/null || /bin/true
-		rm -rf /etc/openldap/slapd.d/*
-		yum install -y openldap-servers openldap-clients || "openldap-servers openldap-clients install failed"
 	fi
 }
 

--- a/scripts/provisioning/cleanupcmd.py
+++ b/scripts/provisioning/cleanupcmd.py
@@ -85,7 +85,6 @@ class CleanupCmd(SetupCmd):
 
       # cleanup ldap config and schemas
       self.delete_ldap_config()
-
     except Exception as e:
       raise e
 

--- a/scripts/provisioning/cleanupcmd.py
+++ b/scripts/provisioning/cleanupcmd.py
@@ -20,6 +20,7 @@
 
 import sys
 import os
+from pathlib import Path
 import shutil
 
 from setupcmd import SetupCmd
@@ -34,6 +35,24 @@ class CleanupCmd(SetupCmd):
                             "s3userId": "450"
                           }
                         }
+  # ldap config and schema related constants
+  ldap_configs = {
+                  "files": [
+                             "/etc/openldap/slapd.d/cn=config/cn=schema/cn={1}s3user.ldif",
+                             "/etc/openldap/slapd.d/cn=config/cn=module{0}.ldif",
+                             "/etc/openldap/slapd.d/cn=config/cn=module{1}.ldif",
+                             "/etc/openldap/slapd.d/cn=config/olcDatabase={2}mdb.ldif"
+                          ],
+                  "files_wild": [
+                             {
+                              "path": "/etc/openldap/slapd.d/cn=config/cn=schema/",
+                              "glob": "*ppolicy.ldif"
+                             }
+                          ],
+                  "dirs": [
+                             "/etc/openldap/slapd.d/cn=config/olcDatabase={2}mdb"
+                          ]
+                 }
 
   def __init__(self, config: str):
     """Constructor."""
@@ -49,16 +68,24 @@ class CleanupCmd(SetupCmd):
     """Main processing function."""
     sys.stdout.write(f"Processing {self.name} {self.url}\n")
     try:
+      # Check if reset phase was performed before this
+      self.detect_if_reset_done()
+
+      # cleanup ldap accounts related to S3
       ldap_action_obj = LdapAccountAction(self.ldap_user, self.ldap_passwd)
       ldap_action_obj.delete_account(self.account_cleanup_dict)
-      self.cleanup_haproxy_configurations()
-    except Exception as e:
-      raise e
 
-    try:
+      # Erase haproxy configurations
+      self.cleanup_haproxy_configurations()
+
+      # revert config files to their origional config state
       sys.stdout.write('INFO: Reverting config files.\n')
       self.revert_config_files()
       sys.stdout.write('INFO: Reverting config files successful.\n')
+
+      # cleanup ldap config and schemas
+      self.delete_ldap_config()
+
     except Exception as e:
       raise e
 
@@ -122,3 +149,35 @@ class CleanupCmd(SetupCmd):
     else:
         os.remove(dummy_file)
 
+  def detect_if_reset_done(self):
+    """TODO: Implement this handler, if reset not done, throw exception."""
+    sys.stdout.write(f"Processing {self.name} detect_if_reset_done, TODO: implement it\n")
+    # if reset_not_done
+        # raise S3PROVError("reset needs to be performed before cleanup can be processed\n")
+
+  def delete_ldap_config(self):
+    """Delete the ldap configs created by setup_ldap.sh during config phase."""
+    # Clean up old configuration if any
+    # Removing schemas
+    files = self.ldap_configs["files"]
+    files_wild = self.ldap_configs["files_wild"]
+    dirs = self.ldap_configs["dirs"]
+
+    for curr_file in files:
+      if os.path.isfile(curr_file):
+        os.remove(curr_file)
+        sys.stdout.write(f"{curr_file} removed\n")
+
+    for file_wild in files_wild:
+      for path in Path(f"{file_wild['path']}").glob(f"{file_wild['glob']}"):
+        if os.path.isfile(path):
+          os.remove(path)
+          sys.stdout.write(f"{path} removed\n")
+        elif os.path.isdir(path):
+          shutil.rmtree(path)
+          sys.stdout.write(f"{path} removed\n")
+
+    for curr_dir in dirs:
+      if os.path.isdir(curr_dir):
+        shutil.rmtree(curr_dir)
+        sys.stdout.write(f"{curr_dir} removed\n")


### PR DESCRIPTION
commit 1411b841026c952afae2149108b8da2c5a645ef3
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Tue Mar 16 01:42:30 2021 -0600

        EOS-17952: Mini Provisioner: s3_setup Cleanup phase
        Change description:
                Cleanup ldap config and schemas created by setup_ldap.sh during config phase
                Add hooks for step 1 and 3 as mentioned in EOS-17952 (TODO: implement the stub hooks and integrate with this code by respective developers)
                openldap related external cleanup code is removed from install_prereqs.sh
            Added/modified/deleted files:
                modified:   scripts/provisioning/cleanupcmd.py
                modified:   scripts/install_prereqs.sh
        Test:
                With the changes, single node mini-provisioner deployed on VM and tested multiple times using loop with cleanup.
                "post-install, config, init and cleanup" loop is verified to be idempotent without the external openldap removal as updated in install_prereqs.sh

    Signed-off-by: pratyush-seagate <pratyush.k.khan@seagate.com>
