### PR TITLE
GitIssue-759:s3:St failure fix, pkg configobj was not installed

### DIFF
--- a/scripts/env/dev/init.sh
+++ b/scripts/env/dev/init.sh
@@ -131,6 +131,8 @@ else
               easy_install pip
               read -p "Git Access Token:" git_access_token
               source ${S3_SRC_DIR}/scripts/env/common/create-cortx-repo.sh -G $git_access_token
+              # install configobj
+              pip3 install configobj
               ;;
           s)
              source ${S3_SRC_DIR}/scripts/env/common/setup-yum-repos.sh

--- a/scripts/env/release/init.sh
+++ b/scripts/env/release/init.sh
@@ -56,6 +56,9 @@ install_pre_requisites() {
 
   # install or upgrade cortx-py-utils
   install_cortx_py_utils
+
+  # install configobj
+  pip3 install configobj
 }
 
 usage() {
@@ -77,6 +80,8 @@ else
               easy_install pip
               read -p "Git Access Token:" git_access_token
               source ${S3_SRC_DIR}/scripts/env/common/create-cortx-repo.sh -G $git_access_token
+              # install configobj
+              pip3 install configobj
               ;;
           *)
               usage

--- a/scripts/env/rpmbuild/init.sh
+++ b/scripts/env/rpmbuild/init.sh
@@ -49,6 +49,9 @@ install_pre_requisites() {
 
   # install or upgrade cortx-py-utils
   install_cortx_py_utils
+
+  # install configobj
+  pip3 install configobj
 }
 
 usage() {
@@ -70,6 +73,8 @@ else
               easy_install pip
               read -p "Git Access Token:" git_access_token
               source ${S3_SRC_DIR}/scripts/env/common/create-cortx-repo.sh -G $git_access_token
+              # install configobj
+              pip3 install configobj
               ;;
           *)
               usage


### PR DESCRIPTION
Root cause : configobj package installation is missing in case of opensource ansible script, hence ST are breaking if someone use opensource setup. (i.e. running ansible script with "-a" option)
Fix : pip3 install configobj
I have tested the patch locally on this setup and tests were successful.

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>