### PR TITLE
EOS-17270: [MsgBus] Add create/delete topic in the s3 provisoner

### DIFF
--- a/s3backgrounddelete/s3backgrounddelete/config/s3_background_delete_config.yaml.sample
+++ b/s3backgrounddelete/s3backgrounddelete/config/s3_background_delete_config.yaml.sample
@@ -35,6 +35,8 @@ message_bus:
    producer_id: "S3MsgProducer"
    producer_delivery_mechanism: "sync"                      # sync, async
    consumer_sleep: 5
+   purge_sleep: 60
+   admin_id: "admin_s3_background_delete"
 
 logconfig:                                  # Section for scheduler & processor loggers.
 

--- a/s3backgrounddelete/s3backgrounddelete/cortx_s3_config.py
+++ b/s3backgrounddelete/s3backgrounddelete/cortx_s3_config.py
@@ -535,3 +535,23 @@ class CORTXS3Config(object):
             raise KeyError(
                 "Could not parse producer_delivery_mechanism from config file " +
                 self._conf_file)
+
+    def get_msgbus_admin_id(self):
+        """Return admin id from config file or KeyError."""
+        try:
+          msgbus_admin_id = self.s3confstore.get_config('message_bus>admin_id')
+          return msgbus_admin_id
+        except:
+            raise KeyError(
+                "Could not parse admin id from config file " +
+                self._conf_file)
+
+    def get_purge_sleep_time(self):
+        """Return purge sleep time from config file or KeyError."""
+        try:
+          msgbus_purge_sleep = self.s3confstore.get_config('message_bus>purge_sleep')
+          return int(msgbus_purge_sleep)
+        except:
+            raise KeyError(
+                "Could not parse purge sleep from config file " +
+                self._conf_file)

--- a/s3backgrounddelete/s3backgrounddelete/cortx_s3_constants.py
+++ b/s3backgrounddelete/s3backgrounddelete/cortx_s3_constants.py
@@ -1,2 +1,3 @@
 MESSAGE_BUS = "message_bus"
 RABBIT_MQ = "rabbit_mq"
+ADMIN_ID = "admin_s3_background_delete"

--- a/s3backgrounddelete/s3backgrounddelete/cortx_s3_constants.py
+++ b/s3backgrounddelete/s3backgrounddelete/cortx_s3_constants.py
@@ -1,3 +1,2 @@
 MESSAGE_BUS = "message_bus"
 RABBIT_MQ = "rabbit_mq"
-ADMIN_ID = "admin_s3_background_delete"

--- a/s3backgrounddelete/s3backgrounddelete/object_recovery_msgbus.py
+++ b/s3backgrounddelete/s3backgrounddelete/object_recovery_msgbus.py
@@ -238,8 +238,8 @@ class ObjectRecoveryMsgbus(object):
                     self._logger.debug("producer connection issues")
                     return False
             self.__msgbuslib.purge()
-            #Insert a delay of 1 min after purge, so that the messages are deleted
-            time.sleep(60)
+            #Insert a delay of 1 min (default) after purge, so that the messages are deleted
+            time.sleep(self._config.get_purge_sleep_time())
             self._logger.debug("Purged Messages")
         except Exception as exception:
             self._logger.error("Exception:{}".format(exception))

--- a/s3cortxutils/s3msgbus/s3msgbus/cortx_s3_msgbus.py
+++ b/s3cortxutils/s3msgbus/s3msgbus/cortx_s3_msgbus.py
@@ -24,7 +24,7 @@
 import os.path
 import errno
 import traceback
-from cortx.utils.message_bus import MessageBus, MessageProducer, MessageConsumer
+from cortx.utils.message_bus import MessageBus, MessageProducer, MessageConsumer, MessageBusAdmin
 
 class S3CortxMsgBus:
 
@@ -119,3 +119,52 @@ class S3CortxMsgBus:
         except:
             return 0
         return unread_count
+
+    @staticmethod
+    def create_topic(admin_id: str, message_types: list, partitions: int):
+        """create topic."""
+        try:
+            if S3CortxMsgBus._message_bus:
+                mbadmin = MessageBusAdmin(S3CortxMsgBus._message_bus, admin_id)
+                mbadmin.register_message_type(message_types = message_types,
+                                            partitions = partitions)
+        except Exception as e:
+            raise Exception("Failed to create topic")
+
+    @staticmethod
+    def increase_partitions(admin_id: str, message_types: list, partitions: int):
+        """Increase partition count for given topic."""
+        try:
+            if S3CortxMsgBus._message_bus:
+                mbadmin = MessageBusAdmin(S3CortxMsgBus._message_bus, admin_id)
+                mbadmin.increase_parallelism(message_types = message_types, partitions = partitions)
+        except Exception as e:
+            raise Exception("Failed to increase partition")
+
+    @staticmethod
+    def delete_topic(admin_id: str, message_types: list):
+        """Delete given topic"""
+        try:
+            if S3CortxMsgBus._message_bus:
+                mbadmin = MessageBusAdmin(S3CortxMsgBus._message_bus,
+                                        admin_id)
+                mbadmin.deregister_message_type(message_types = message_types)
+        except Exception as e:
+            raise Exception("Failed to delete topic")
+
+    @staticmethod
+    def list_topics(admin_id: str):
+        """list all available topics"""
+        if S3CortxMsgBus._message_bus:
+            mbadmin = MessageBusAdmin(S3CortxMsgBus._message_bus, admin_id)
+            return mbadmin.list_message_types()
+
+    @staticmethod
+    def is_topic_exist(admin_id: str, topic_name: str):
+        """retuns true if topic exist else false"""
+        if S3CortxMsgBus._message_bus:
+            mbadmin = MessageBusAdmin(S3CortxMsgBus._message_bus, admin_id)
+            if topic_name in mbadmin.list_message_types():
+                return True
+            return False
+

--- a/s3cortxutils/s3msgbus/s3msgbus/cortx_s3_msgbus.py
+++ b/s3cortxutils/s3msgbus/s3msgbus/cortx_s3_msgbus.py
@@ -128,7 +128,7 @@ class S3CortxMsgBus:
                 mbadmin = MessageBusAdmin(S3CortxMsgBus._message_bus, admin_id)
                 mbadmin.register_message_type(message_types = message_types,
                                             partitions = partitions)
-        except Exception as e:
+        except:
             raise Exception("Failed to create topic")
 
     @staticmethod
@@ -138,7 +138,7 @@ class S3CortxMsgBus:
             if S3CortxMsgBus._message_bus:
                 mbadmin = MessageBusAdmin(S3CortxMsgBus._message_bus, admin_id)
                 mbadmin.increase_parallelism(message_types = message_types, partitions = partitions)
-        except Exception as e:
+        except:
             raise Exception("Failed to increase partition")
 
     @staticmethod
@@ -149,7 +149,7 @@ class S3CortxMsgBus:
                 mbadmin = MessageBusAdmin(S3CortxMsgBus._message_bus,
                                         admin_id)
                 mbadmin.deregister_message_type(message_types = message_types)
-        except Exception as e:
+        except:
             raise Exception("Failed to delete topic")
 
     @staticmethod

--- a/scripts/provisioning/cleanupcmd.py
+++ b/scripts/provisioning/cleanupcmd.py
@@ -82,11 +82,6 @@ class CleanupCmd(SetupCmd):
       # Erase haproxy configurations
       self.cleanup_haproxy_configurations()
 
-      # revert config files to their origional config state
-      sys.stdout.write('INFO: Reverting config files.\n')
-      self.revert_config_files()
-      sys.stdout.write('INFO: Reverting config files successful.\n')
-
       # cleanup ldap config and schemas
       self.delete_ldap_config()
 
@@ -96,6 +91,11 @@ class CleanupCmd(SetupCmd):
         sys.stdout.write('INFO: Deleting topic.\n')
         self.delete_topic(ADMIN_ID, bgdeleteconfig.get_msgbus_topic())
         sys.stdout.write('INFO:Topic deletion successful.\n')
+
+      # revert config files to their origional config state
+      sys.stdout.write('INFO: Reverting config files.\n')
+      self.revert_config_files()
+      sys.stdout.write('INFO: Reverting config files successful.\n')
 
     except Exception as e:
       raise e

--- a/scripts/provisioning/cleanupcmd.py
+++ b/scripts/provisioning/cleanupcmd.py
@@ -27,7 +27,7 @@ from setupcmd import SetupCmd, S3PROVError
 from ldapaccountaction import LdapAccountAction
 from s3msgbus.cortx_s3_msgbus import S3CortxMsgBus
 from s3backgrounddelete.cortx_s3_config import CORTXS3Config
-from s3backgrounddelete.cortx_s3_constants import MESSAGE_BUS, ADMIN_ID
+from s3backgrounddelete.cortx_s3_constants import MESSAGE_BUS
 
 class CleanupCmd(SetupCmd):
   """Cleanup Setup Cmd."""
@@ -89,7 +89,7 @@ class CleanupCmd(SetupCmd):
       bgdeleteconfig = CORTXS3Config()
       if bgdeleteconfig.get_messaging_platform() == MESSAGE_BUS:
         sys.stdout.write('INFO: Deleting topic.\n')
-        self.delete_topic(ADMIN_ID, bgdeleteconfig.get_msgbus_topic())
+        self.delete_topic(bgdeleteconfig.get_msgbus_admin_id, bgdeleteconfig.get_msgbus_topic())
         sys.stdout.write('INFO:Topic deletion successful.\n')
 
       # revert config files to their origional config state

--- a/scripts/provisioning/configcmd.py
+++ b/scripts/provisioning/configcmd.py
@@ -28,7 +28,7 @@ from setupcmd import SetupCmd, S3PROVError
 from cortx.utils.process import SimpleProcess
 from s3msgbus.cortx_s3_msgbus import S3CortxMsgBus
 from s3backgrounddelete.cortx_s3_config import CORTXS3Config
-from s3backgrounddelete.cortx_s3_constants import MESSAGE_BUS, ADMIN_ID
+from s3backgrounddelete.cortx_s3_constants import MESSAGE_BUS
 
 class ConfigCmd(SetupCmd):
   """Config Setup Cmd."""
@@ -63,7 +63,7 @@ class ConfigCmd(SetupCmd):
       if bgdeleteconfig.get_messaging_platform() == MESSAGE_BUS:
         sys.stdout.write('INFO: Creating topic.\n')
         # TODO Partition count should be ( number of hosts * 2 )
-        self.create_topic(ADMIN_ID, bgdeleteconfig.get_msgbus_topic(), 2)
+        self.create_topic(bgdeleteconfig.get_msgbus_admin_id, bgdeleteconfig.get_msgbus_topic(), 3)
         sys.stdout.write('INFO:Topic creation successful.\n')
     except Exception as e:
       raise S3PROVError(f'process() failed with exception: {e}\n')

--- a/scripts/provisioning/configcmd.py
+++ b/scripts/provisioning/configcmd.py
@@ -26,6 +26,9 @@ from  ast import literal_eval
 
 from setupcmd import SetupCmd, S3PROVError
 from cortx.utils.process import SimpleProcess
+from s3msgbus.cortx_s3_msgbus import S3CortxMsgBus
+from s3backgrounddelete.cortx_s3_config import CORTXS3Config
+from s3backgrounddelete.cortx_s3_constants import MESSAGE_BUS, ADMIN_ID
 
 class ConfigCmd(SetupCmd):
   """Config Setup Cmd."""
@@ -54,6 +57,14 @@ class ConfigCmd(SetupCmd):
       # Configure haproxy
       self.configure_haproxy()
       sys.stdout.write("INFO: Successfully configured haproxy on the node.\n")
+
+      # create topic for background delete
+      bgdeleteconfig = CORTXS3Config()
+      if bgdeleteconfig.get_messaging_platform() == MESSAGE_BUS:
+        sys.stdout.write('INFO: Creating topic.\n')
+        # TODO Partition count should be ( number of hosts * 2 )
+        self.create_topic(ADMIN_ID, bgdeleteconfig.get_msgbus_topic(), 2)
+        sys.stdout.write('INFO:Topic creation successful.\n')
     except Exception as e:
       raise S3PROVError(f'process() failed with exception: {e}\n')
 
@@ -149,3 +160,16 @@ class ConfigCmd(SetupCmd):
     stdout, stderr, retcode = handler.run()
     if retcode != 0:
       raise S3PROVError(f"{cmd} failed with err: {stderr}, out: {stdout}, ret: {retcode}\n")
+
+  def create_topic(self, admin_id: str, topic_name:str, partitions: int):
+    """create topic for background delete services."""
+    try:
+      s3MessageBus = S3CortxMsgBus()
+      s3MessageBus.connect()
+      if not S3CortxMsgBus.is_topic_exist(admin_id, topic_name):
+        S3CortxMsgBus.create_topic(admin_id, [topic_name], partitions)
+    except Exception as e:
+      raise e
+
+
+

--- a/scripts/provisioning/resetcmd.py
+++ b/scripts/provisioning/resetcmd.py
@@ -52,11 +52,10 @@ class ResetCmd(SetupCmd):
       bgdeleteconfig = CORTXS3Config()
       if bgdeleteconfig.get_messaging_platform() == MESSAGE_BUS:
         sys.stdout.write('INFO: Purging messages from message bus.\n')
-        producer_id = bgdeleteconfig.get_msgbus_producer_id()
-        msg_type = bgdeleteconfig.get_msgbus_topic()
-        delivery_mechanism = bgdeleteconfig.get_msgbus_producer_delivery_mechanism()
-        purge_sleep_time = bgdeleteconfig.get_purge_sleep_time()
-        self.purge_messages(producer_id, msg_type, delivery_mechanism, purge_sleep_time)
+        self.purge_messages(bgdeleteconfig.get_msgbus_producer_id(),
+                            bgdeleteconfig.get_msgbus_topic(),
+                            bgdeleteconfig.get_msgbus_producer_delivery_mechanism(),
+                            bgdeleteconfig.get_purge_sleep_time())
         sys.stdout.write('INFO:Purge message successful.\n')
 
     except Exception as e:

--- a/scripts/provisioning/resetcmd.py
+++ b/scripts/provisioning/resetcmd.py
@@ -55,7 +55,8 @@ class ResetCmd(SetupCmd):
         producer_id = bgdeleteconfig.get_msgbus_producer_id()
         msg_type = bgdeleteconfig.get_msgbus_topic()
         delivery_mechanism = bgdeleteconfig.get_msgbus_producer_delivery_mechanism()
-        self.purge_messages(producer_id, msg_type, delivery_mechanism)
+        purge_sleep_time = bgdeleteconfig.get_purge_sleep_time()
+        self.purge_messages(producer_id, msg_type, delivery_mechanism, purge_sleep_time)
         sys.stdout.write('INFO:Purge message successful.\n')
 
     except Exception as e:
@@ -131,7 +132,7 @@ class ResetCmd(SetupCmd):
           sys.stderr.write(f'ERROR: DeleteFileOrDirWithRegex(): Failed to delete: {file}, error: {str(e)}\n')
           raise e
 
-  def purge_messages(self, producer_id: str, msg_type: str, delivery_mechanism: str):
+  def purge_messages(self, producer_id: str, msg_type: str, delivery_mechanism: str, sleep_time: int):
     """purge messages on message bus."""
     try:
       s3MessageBus = S3CortxMsgBus()
@@ -140,7 +141,7 @@ class ResetCmd(SetupCmd):
       try:
         s3MessageBus.purge()
         #Insert a delay of 1 min after purge, so that the messages are deleted
-        time.sleep(60)
+        time.sleep(sleep_time)
       except:
         sys.stdout.write('Exception during purge. May be there are no messages to purge\n')
     except Exception as e:

--- a/st/clitests/s3_background_delete_config_test.yaml
+++ b/st/clitests/s3_background_delete_config_test.yaml
@@ -36,6 +36,8 @@ message_bus:
    producer_id: "S3MsgProducer"
    producer_delivery_mechanism: "sync"                      # sync, async
    consumer_sleep: 5
+   purge_sleep: 60
+   admin_id: "admin_s3_background_delete"
 
 s3_recovery:                               # Section for S3 recovery config config
    recovery_account_access_key: "A9IAJPINPFRBTPASATAZ"                     # Access Key corresponding to account-name "s3-recovery-svc"


### PR DESCRIPTION
Implemented following things

- Topic create - config phase
- Purge - 'reset phase'
- topic delete - 'cleanup phase'

Unit testing result:
[root@ssc-vm-2859 cortx-s3server]# /opt/seagate/cortx/s3/bin/s3_setup config --config "yaml:///opt/seagate/cortx/s3/conf/s3.config.tmpl.1-node"
INFO: Creating random jks password for Auth server..
Generating password for jks keystore used in authserver...

Warning:
The JKS keystore uses a proprietary format. It is recommended to migrate to PKCS12 which is an industry standard format using "keytool -importkeystore -srckeystore /opt/seagate/cortx/auth/resources/s3authserver.jks -destkeystore /opt/seagate/cortx/auth/resources/s3authserver.jks -deststoretype pkcs12".

Warning:
The JKS keystore uses a proprietary format. It is recommended to migrate to PKCS12 which is an industry standard format using "keytool -importkeystore -srckeystore /opt/seagate/cortx/auth/resources/s3authserver.jks -destkeystore /opt/seagate/cortx/auth/resources/s3authserver.jks -deststoretype pkcs12".

Warning:
The JKS keystore uses a proprietary format. It is recommended to migrate to PKCS12 which is an industry standard format using "keytool -importkeystore -srckeystore /opt/seagate/cortx/auth/resources/s3authserver.jks -destkeystore /opt/seagate/cortx/auth/resources/s3authserver.jks -deststoretype pkcs12".

Warning:
The generated certificate uses a 512-bit RSA key which is considered a security risk.
The JKS keystore uses a proprietary format. It is recommended to migrate to PKCS12 which is an industry standard format using "keytool -importkeystore -srckeystore /opt/seagate/cortx/auth/resources/s3authserver.jks -destkeystore /opt/seagate/cortx/auth/resources/s3authserver.jks -deststoretype pkcs12".
Updated the JKS Keystore.
INFO: running config...
/usr/local/lib64/python3.6/site-packages/cryptography/hazmat/backends/openssl/hmac.py:59: UserWarning: implicit cast from 'char *' to a different pointer type: will be forbidden in the future (check that the types are as you expect; use an explicit ffi.cast() if they are correct)
  res = self._backend._lib.HMAC_Update(self._ctx, data_ptr, len(data))
/usr/local/lib64/python3.6/site-packages/cryptography/hazmat/backends/openssl/ciphers.py:114: UserWarning: implicit cast from 'char *' to a different pointer type: will be forbidden in the future (check that the types are as you expect; use an explicit ffi.cast() if they are correct)
  operation
/usr/local/lib64/python3.6/site-packages/cryptography/hazmat/backends/openssl/ciphers.py:140: UserWarning: implicit cast from 'char *' to a different pointer type: will be forbidden in the future (check that the types are as you expect; use an explicit ffi.cast() if they are correct)
  self._backend._ffi.from_buffer(data), len(data)
Processing config yaml:///opt/seagate/cortx/s3/conf/s3.config.tmpl.1-node
Validations running from /opt/seagate/cortx/s3/mini-prov/s3setup_prereqs.json
INFO: Successfully configured openldap on the node.
INFO: Successfully configured haproxy on the node.
INFO: Creating topic.
Server node count : 1
Partition count : 2
INFO:Topic creation successful.
INFO: config successful.
[root@ssc-vm-2859 cortx-s3server]# /opt/kafka/bin/kafka-topics.sh --list --bootstrap-server localhost:9092
bgdelete
[root@ssc-vm-2859 cortx-s3server]# 

[root@ssc-vm-2859 cortx-s3server]# /opt/seagate/cortx/s3/bin/s3_setup reset --config "yaml:///opt/seagate/cortx/s3/conf/s3.reset.tmpl.1-node"
Processing reset yaml:///opt/seagate/cortx/s3/conf/s3.reset.tmpl.1-node
Validations running from /opt/seagate/cortx/s3/mini-prov/s3setup_prereqs.json
INFO: Cleaning up log files.
INFO:Log files cleanup successful.
INFO: Purging messages from message bus.
INFO:Purge message successful.
INFO: reset successful.
[root@ssc-vm-2859 cortx-s3server]# 

[root@ssc-vm-2859 cortx-s3server]# /opt/seagate/cortx/s3/bin/s3_setup cleanup --config "yaml:///opt/seagate/cortx/s3/conf/s3.cleanup.tmpl.1-node"
/usr/local/lib64/python3.6/site-packages/cryptography/hazmat/backends/openssl/hmac.py:59: UserWarning: implicit cast from 'char *' to a different pointer type: will be forbidden in the future (check that the types are as you expect; use an explicit ffi.cast() if they are correct)
  res = self._backend._lib.HMAC_Update(self._ctx, data_ptr, len(data))
/usr/local/lib64/python3.6/site-packages/cryptography/hazmat/backends/openssl/ciphers.py:114: UserWarning: implicit cast from 'char *' to a different pointer type: will be forbidden in the future (check that the types are as you expect; use an explicit ffi.cast() if they are correct)
  operation
/usr/local/lib64/python3.6/site-packages/cryptography/hazmat/backends/openssl/ciphers.py:140: UserWarning: implicit cast from 'char *' to a different pointer type: will be forbidden in the future (check that the types are as you expect; use an explicit ffi.cast() if they are correct)
  self._backend._ffi.from_buffer(data), len(data)
Processing cleanup yaml:///opt/seagate/cortx/s3/conf/s3.cleanup.tmpl.1-node
Validations running from /opt/seagate/cortx/s3/mini-prov/s3setup_prereqs.json
Processing cleanup detect_if_reset_done
INFO:Validating ldap account entries
INFO:Validation of ldap account entries successful.
Processing cleanup detect_if_reset_done completed successfully..
/etc/openldap/slapd.d/cn=config/cn=schema/cn={1}s3user.ldif removed
/etc/openldap/slapd.d/cn=config/cn=module{0}.ldif removed
/etc/openldap/slapd.d/cn=config/cn=module{1}.ldif removed
/etc/openldap/slapd.d/cn=config/olcDatabase={2}mdb.ldif removed
/etc/openldap/slapd.d/cn=config/cn=schema/cn={2}ppolicy.ldif removed
/etc/openldap/slapd.d/cn=config/olcDatabase={2}mdb removed
INFO: Deleting topic.
INFO:Topic deletion successful.
INFO: Reverting config files.
INFO: Reverting config files successful.
INFO: cleanup successful.
[root@ssc-vm-2859 cortx-s3server]# /opt/kafka/bin/kafka-topics.sh --list --bootstrap-server localhost:9092

[root@ssc-vm-2859 cortx-s3server]#
