### PR TITLE
EOS-18823: Mini Provisioner: Restructure s3setup_prereqs.json by separating prerequistes sections for each phase

### DIFF
--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -120,14 +120,14 @@ step_4 () {
 step_5 () {
 	# Try to install rpm pkgs from s3 preqs file
 	json_prereqs_file="/opt/seagate/cortx/s3/mini-prov/s3setup_prereqs.json"
-	rpms_list=$(jq '.rpms' $json_prereqs_file)
+	rpms_list=$(jq '.post_install.rpms' $json_prereqs_file)
 	rpms_list=$(echo "$rpms_list" | tr -d '[]"\r\n')
 	IFS=', ' read -r -a rpms <<< "$rpms_list"
 	if [ ${#rpms[@]} -eq 0 ];then
-		die_with_error "jq '.rpms' $json_prereqs_file failed"
+		die_with_error "jq '.post_install.rpms' $json_prereqs_file failed"
 	fi
 	if [ "${rpms[0]}" == "null" ];then
-		die_with_error "jq '.rpms' $json_prereqs_file failed"
+		die_with_error "jq '.post_install.rpms' $json_prereqs_file failed"
 	fi
 
 	for rpm in "${rpms[@]}" ; do
@@ -154,14 +154,14 @@ step_7 () {
 }
 
 step_8 () {
-	services_list=$(jq '.services' $json_prereqs_file)
+	services_list=$(jq '.post_install.services' $json_prereqs_file)
 	services_list=$(echo "$services_list" | tr -d '[]"\r\n')
 	IFS=', ' read -r -a services <<< "$services_list"
 	if [ ${#services[@]} -eq 0 ];then
-		die_with_error "jq '.services' $json_prereqs_file failed"
+		die_with_error "jq '.post_install.services' $json_prereqs_file failed"
 	fi
 	if [ "${services[0]}" == "null" ];then
-		die_with_error "jq '.services' $json_prereqs_file failed"
+		die_with_error "jq '.post_install.services' $json_prereqs_file failed"
 	fi
 	# services=("$@")
 	for service in "${services[@]}" ; do

--- a/scripts/provisioning/_s3_setup
+++ b/scripts/provisioning/_s3_setup
@@ -25,7 +25,6 @@ import argparse
 import traceback
 import errno
 
-from postinstallcmd import PostInstallCmd
 
 def main():
   parser = argparse.ArgumentParser("S3server setup command")
@@ -54,11 +53,12 @@ def main():
 
   args = parser.parse_args()
   try:
-    # run post_install always, the failure will raise exception in PostInstallCmd class
-    PostInstallCmd().process()
-    sys.stdout.write('INFO: post_install validations successful.\n')
-    
-    if args.command == 'cleanup':
+    if args.command == 'post_install':
+      from postinstallcmd import PostInstallCmd
+      PostInstallCmd().process()
+      sys.stdout.write('INFO: post_install successful.\n')
+
+    elif args.command == 'cleanup':
       from cleanupcmd import CleanupCmd
       CleanupCmd(args.config).process()
       sys.stdout.write('INFO: cleanup successful.\n')

--- a/scripts/provisioning/cleanupcmd.py
+++ b/scripts/provisioning/cleanupcmd.py
@@ -67,6 +67,7 @@ class CleanupCmd(SetupCmd):
   def process(self):
     """Main processing function."""
     sys.stdout.write(f"Processing {self.name} {self.url}\n")
+    self.phase_prereqs_validate(self.name)
     try:
       # Check if reset phase was performed before this
       self.detect_if_reset_done()

--- a/scripts/provisioning/configcmd.py
+++ b/scripts/provisioning/configcmd.py
@@ -45,6 +45,7 @@ class ConfigCmd(SetupCmd):
   def process(self):
     """Main processing function."""
     sys.stdout.write(f"Processing {self.name} {self.url}\n")
+    self.phase_prereqs_validate(self.name)
 
     try:
       # Configure openldap and ldap-replication

--- a/scripts/provisioning/initcmd.py
+++ b/scripts/provisioning/initcmd.py
@@ -38,6 +38,7 @@ class InitCmd(SetupCmd):
   def process(self):
     """Main processing function."""
     sys.stdout.write(f"Processing {self.name} {self.url}\n")
+    self.phase_prereqs_validate(self.name)
     try:
       # Create background delete account
       bgdelete_acc_input_params_dict = {'account_name': "s3-background-delete-svc",

--- a/scripts/provisioning/preparecmd.py
+++ b/scripts/provisioning/preparecmd.py
@@ -36,3 +36,4 @@ class PrepareCmd(SetupCmd):
   def process(self):
     """Main processing function."""
     sys.stdout.write(f"Processing {self.name} {self.url}\n")
+    self.phase_prereqs_validate(self.name)

--- a/scripts/provisioning/resetcmd.py
+++ b/scripts/provisioning/resetcmd.py
@@ -39,6 +39,7 @@ class ResetCmd(SetupCmd):
   def process(self):
     """Main processing function."""
     sys.stdout.write(f"Processing {self.name} {self.url}\n")
+    self.phase_prereqs_validate(self.name)
     try:
       sys.stdout.write('INFO: Cleaning up log files.\n')
       self.CleanupLogs()

--- a/scripts/provisioning/s3setup_prereqs.json
+++ b/scripts/provisioning/s3setup_prereqs.json
@@ -1,4 +1,6 @@
 {
+"post_install" :
+  {
     "rpms": ["openldap-servers", "openldap-clients", "haproxy", "motr", "python36-ldap"],
     "pip3s": ["s3confstore", "cryptography", "s3haproxyconfig", "s3cipher"],
     "services": ["sshd", "rabbitmq-server", "haproxy", "slapd", "rsyslog"],
@@ -10,4 +12,38 @@
 		"file:/opt/seagate/cortx/s3/install/haproxy/logrotate/haproxy",
 		"file:/opt/seagate/cortx/s3/install/haproxy/rsyslog.d/haproxy.conf",
 		"file:/opt/seagate/cortx/s3/install/haproxy/logrotate/logrotate"]
+  },
+"config" :
+  {
+    "rpms": ["openldap-servers", "openldap-clients", "haproxy", "motr", "python36-ldap"],
+    "pip3s": ["s3confstore", "cryptography", "s3haproxyconfig", "s3cipher"],
+    "services": ["sshd", "rabbitmq-server", "haproxy", "slapd", "rsyslog"],
+    "exists": [
+		"file:/etc/machine-id",
+		"file:/etc/haproxy/haproxy.cfg",
+		"file:/etc/ssl/stx/stx.pem",
+		"file:/opt/seagate/cortx/s3/install/haproxy/503.http",
+		"file:/opt/seagate/cortx/s3/install/haproxy/logrotate/haproxy",
+		"file:/opt/seagate/cortx/s3/install/haproxy/rsyslog.d/haproxy.conf",
+		"file:/opt/seagate/cortx/s3/install/haproxy/logrotate/logrotate"]
+  },
+"init" :
+  {
+  },
+"reset" :
+  {
+  },
+"prepare" :
+  {
+  },
+"cleanup" :
+  {
+    "rpms": ["openldap-servers", "openldap-clients"],
+    "pip3s": ["s3confstore", "cryptography", "s3haproxyconfig", "s3cipher"],
+    "services": ["haproxy", "slapd"]
+  },
+"test" :
+  {
+    "services": ["slapd"]
+  }
 }

--- a/scripts/provisioning/s3setup_prereqs.json
+++ b/scripts/provisioning/s3setup_prereqs.json
@@ -53,13 +53,11 @@
 "cleanup" :
   {
     "rpms": ["openldap-servers", "openldap-clients", "haproxy", "cortx-motr", "python36-ldap"],
-    "pip3s": ["s3confstore", "cryptography", "s3haproxyconfig", "s3cipher"],
-    "services": ["haproxy", "slapd"]
+    "pip3s": ["s3confstore", "cryptography", "s3haproxyconfig", "s3cipher"]
   },
 "test" :
   {
     "rpms": ["openldap-servers", "openldap-clients", "haproxy", "cortx-motr", "python36-ldap"],
-    "pip3s": ["s3confstore", "cryptography", "s3haproxyconfig", "s3cipher"],
-    "services": ["slapd"]
+    "pip3s": ["s3confstore", "cryptography", "s3haproxyconfig", "s3cipher"]
   }
 }

--- a/scripts/provisioning/s3setup_prereqs.json
+++ b/scripts/provisioning/s3setup_prereqs.json
@@ -1,10 +1,9 @@
 {
 "post_install" :
   {
-    "rpms": ["openldap-servers", "openldap-clients", "haproxy", "motr", "python36-ldap"],
+    "rpms": ["openldap-servers", "openldap-clients", "haproxy", "cortx-motr", "python36-ldap"],
     "pip3s": ["s3confstore", "cryptography", "s3haproxyconfig", "s3cipher"],
-    "services": ["sshd", "rabbitmq-server", "haproxy", "slapd", "rsyslog"],
-    "exists": [
+    "files": [
 		"file:/etc/machine-id",
 		"file:/etc/haproxy/haproxy.cfg",
 		"file:/etc/ssl/stx/stx.pem",
@@ -15,10 +14,10 @@
   },
 "config" :
   {
-    "rpms": ["openldap-servers", "openldap-clients", "haproxy", "motr", "python36-ldap"],
+    "rpms": ["openldap-servers", "openldap-clients", "haproxy", "cortx-motr", "python36-ldap"],
     "pip3s": ["s3confstore", "cryptography", "s3haproxyconfig", "s3cipher"],
     "services": ["sshd", "rabbitmq-server", "haproxy", "slapd", "rsyslog"],
-    "exists": [
+    "files": [
 		"file:/etc/machine-id",
 		"file:/etc/haproxy/haproxy.cfg",
 		"file:/etc/ssl/stx/stx.pem",
@@ -29,21 +28,38 @@
   },
 "init" :
   {
+    "rpms": ["openldap-servers", "openldap-clients", "haproxy", "cortx-motr", "python36-ldap"],
+    "pip3s": ["s3confstore", "cryptography", "s3haproxyconfig", "s3cipher"],
+    "services": ["sshd", "rabbitmq-server", "haproxy", "slapd", "rsyslog"],
+    "files": [
+		"file:/etc/machine-id",
+		"file:/etc/haproxy/haproxy.cfg",
+		"file:/etc/ssl/stx/stx.pem",
+		"file:/opt/seagate/cortx/s3/install/haproxy/503.http",
+		"file:/opt/seagate/cortx/s3/install/haproxy/logrotate/haproxy",
+		"file:/opt/seagate/cortx/s3/install/haproxy/rsyslog.d/haproxy.conf",
+		"file:/opt/seagate/cortx/s3/install/haproxy/logrotate/logrotate"]
   },
 "reset" :
   {
+    "rpms": ["openldap-servers", "openldap-clients", "haproxy", "cortx-motr", "python36-ldap"],
+    "pip3s": ["s3confstore", "cryptography", "s3haproxyconfig", "s3cipher"]
   },
 "prepare" :
   {
+    "rpms": ["openldap-servers", "openldap-clients", "haproxy", "cortx-motr", "python36-ldap"],
+    "pip3s": ["s3confstore", "cryptography", "s3haproxyconfig", "s3cipher"]
   },
 "cleanup" :
   {
-    "rpms": ["openldap-servers", "openldap-clients"],
+    "rpms": ["openldap-servers", "openldap-clients", "haproxy", "cortx-motr", "python36-ldap"],
     "pip3s": ["s3confstore", "cryptography", "s3haproxyconfig", "s3cipher"],
     "services": ["haproxy", "slapd"]
   },
 "test" :
   {
+    "rpms": ["openldap-servers", "openldap-clients", "haproxy", "cortx-motr", "python36-ldap"],
+    "pip3s": ["s3confstore", "cryptography", "s3haproxyconfig", "s3cipher"],
     "services": ["slapd"]
   }
 }

--- a/scripts/provisioning/setupcmd.py
+++ b/scripts/provisioning/setupcmd.py
@@ -121,6 +121,7 @@ class SetupCmd(object):
                         services: list = None,
                         files: list = None):
     """Validate pre requisites using cortx-py-utils validator."""
+    sys.stdout.write(f'Validations running from {self._preqs_conf_file}\n')
     if pip3s:
       PkgV().validate('pip3s', pip3s)
     if services:
@@ -134,7 +135,7 @@ class SetupCmd(object):
     """Validate pre requisites using cortx-py-utils validator for the 'phase_name'."""
     if not os.path.isfile(self._preqs_conf_file):
       raise FileNotFoundError(f'pre-requisite json file: {self._preqs_conf_file} not found')
-    _prereqs_confstore = S3CortxConfStore(f'json://{self._preqs_conf_file}', f'phase_name')
+    _prereqs_confstore = S3CortxConfStore(f'json://{self._preqs_conf_file}', f'{phase_name}')
     try:
       prereqs_block = _prereqs_confstore.get_config(f'{phase_name}')
       if prereqs_block is not None:

--- a/scripts/provisioning/setupcmd.py
+++ b/scripts/provisioning/setupcmd.py
@@ -142,6 +142,6 @@ class SetupCmd(object):
         self.validate_pre_requisites(rpms=_prereqs_confstore.get_config(f'{phase_name}>rpms'),
                                 services=_prereqs_confstore.get_config(f'{phase_name}>services'),
                                 pip3s=_prereqs_confstore.get_config(f'{phase_name}>pip3s'),
-                                files=_prereqs_confstore.get_config(f'{phase_name}>exists'))
+                                files=_prereqs_confstore.get_config(f'{phase_name}>files'))
     except Exception as e:
       raise S3PROVError(f'ERROR: {phase_name} prereqs validations failed, exception: {e} \n')

--- a/scripts/provisioning/setupcmd.py
+++ b/scripts/provisioning/setupcmd.py
@@ -19,9 +19,13 @@
 #
 
 import sys
+import os
 from os import path
 from s3confstore.cortx_s3_confstore import S3CortxConfStore
 from s3cipher.cortx_s3_cipher import CortxS3Cipher
+from cortx.utils.validator.v_pkg import PkgV
+from cortx.utils.validator.v_service import ServiceV
+from cortx.utils.validator.v_path import PathV
 
 class S3PROVError(Exception):
   """Parent class for the s3 provisioner error classes."""
@@ -36,9 +40,13 @@ class SetupCmd(object):
   server_nodes_count = 0
   hosts_list = None
   s3_prov_config = "/opt/seagate/cortx/s3/mini-prov/s3_prov_config.yaml"
+  _preqs_conf_file = "/opt/seagate/cortx/s3/mini-prov/s3setup_prereqs.json"
 
   def __init__(self, config: str):
     """Constructor."""
+    if config is None:
+      return
+
     if not config.strip():
       sys.stderr.write(f'config url:[{config}] must be a valid url path\n')
       raise Exception('empty config URL path')
@@ -106,3 +114,33 @@ class SetupCmd(object):
       self.hosts_list = self.s3confstore.get_nodenames_list()
     except Exception as e:
       raise S3PROVError(f'unknown exception: {e}\n')
+
+  def validate_pre_requisites(self,
+                        rpms: list = None,
+                        pip3s: list = None,
+                        services: list = None,
+                        files: list = None):
+    """Validate pre requisites using cortx-py-utils validator."""
+    if pip3s:
+      PkgV().validate('pip3s', pip3s)
+    if services:
+      ServiceV().validate('isrunning', services)
+    if rpms:
+      PkgV().validate('rpms', rpms)
+    if files:
+      PathV().validate('exists', files)
+
+  def phase_prereqs_validate(self, phase_name: str):
+    """Validate pre requisites using cortx-py-utils validator for the 'phase_name'."""
+    if not os.path.isfile(self._preqs_conf_file):
+      raise FileNotFoundError(f'pre-requisite json file: {self._preqs_conf_file} not found')
+    _prereqs_confstore = S3CortxConfStore(f'json://{self._preqs_conf_file}', f'phase_name')
+    try:
+      prereqs_block = _prereqs_confstore.get_config(f'{phase_name}')
+      if prereqs_block is not None:
+        self.validate_pre_requisites(rpms=_prereqs_confstore.get_config(f'{phase_name}>rpms'),
+                                services=_prereqs_confstore.get_config(f'{phase_name}>services'),
+                                pip3s=_prereqs_confstore.get_config(f'{phase_name}>pip3s'),
+                                files=_prereqs_confstore.get_config(f'{phase_name}>exists'))
+    except Exception as e:
+      raise S3PROVError(f'ERROR: {phase_name} prereqs validations failed, exception: {e} \n')

--- a/scripts/provisioning/testcmd.py
+++ b/scripts/provisioning/testcmd.py
@@ -39,6 +39,7 @@ class TestCmd(SetupCmd):
   def process(self):
     """Main processing function."""
     sys.stdout.write(f"Processing {self.name} {self.url}\n")
+    self.phase_prereqs_validate(self.name)
 
     try:
       cmd = ['/opt/seagate/cortx/s3/scripts/s3-sanity-test.sh', '-p',  f'{self.ldap_passwd}']


### PR DESCRIPTION
commit 206feafa23c23fc0cc65c860c1c4f577b1e9af9c
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Mon Mar 22 03:23:33 2021 -0600

        EOS-18823: Mini Provisioner: Restructure s3setup_prereqs.json by separating prerequistes sections for each phase
        Change description:
                Restructure s3setup_prereqs.json for each phase as described in the ticket's DoD and assocaited code changes in the respective phases and in setupc
            Added/modified/deleted files:
                modified:   scripts/install_prereqs.sh
                modified:   scripts/provisioning/_s3_setup
                modified:   scripts/provisioning/cleanupcmd.py
                modified:   scripts/provisioning/configcmd.py
                modified:   scripts/provisioning/initcmd.py
                modified:   scripts/provisioning/postinstallcmd.py
                modified:   scripts/provisioning/preparecmd.py
                modified:   scripts/provisioning/resetcmd.py
                modified:   scripts/provisioning/s3setup_prereqs.json
                modified:   scripts/provisioning/setupcmd.py
                modified:   scripts/provisioning/testcmd.py
            Unit test:
                Full single node mini-provisioner deployment using install_prereqs.sh on local VM with various edits in s3setup_prereqs.json to test corner cases

    Signed-off-by: pratyush-seagate <pratyush.k.khan@seagate.com>

