### PR TITLE
[Draft] EOS-18890:[s3-mini-provisioner:reset phase]: Delete ldap records

### DIFF
--- a/scripts/ldap/ldapaccountaction.py
+++ b/scripts/ldap/ldapaccountaction.py
@@ -242,6 +242,23 @@ class LdapAccountAction:
       sys.stderr.write(f'ERROR: Failed to get count of ldap account, error: {str(e)}\n')
       raise e
 
+  def delete_s3_ldap_data(self):
+    """Delete all s3 data entries from ldap."""
+    cleanup_records = ["ou=accesskeys,dc=s3,dc=seagate,dc=com",
+                        "ou=accounts,dc=s3,dc=seagate,dc=com",
+                        "ou=idp,dc=s3,dc=seagate,dc=com"]
+    try:
+      self.__connect_to_ldap_server()
+      for entry in cleanup_records:
+        self.ldap_conn.delete_s(entry)
+      self.__disconnect_from_ldap()
+
+    except Exception as e:
+      if self.ldap_conn:
+        self.__disconnect_from_ldap()
+      sys.stderr.write(f'ERROR: Failed to delete ldap data, error: {str(e)}\n')
+      raise e
+
   @staticmethod
   def __is_account_present(ldap_conn: SimpleLDAPObject, account_name: str):
     """Checks if account is present in ldap db."""

--- a/scripts/ldap/ldapaccountaction.py
+++ b/scripts/ldap/ldapaccountaction.py
@@ -251,7 +251,7 @@ class LdapAccountAction:
       sys.stdout.write('INFO:Deletion of ldap data started.')
       self.__connect_to_ldap_server()
       for entry in cleanup_records:
-        sys.stdout.write(f'INFO: deleting all entries from {str(entry) & its sub-ordinate tree}\n')
+        sys.stdout.write(f'INFO: deleting all entries from {str(entry)} & its sub-ordinate tree\n')
         try:
           self.ldap_delete_recursive(self.ldap_conn, entry)
         except ldap.NO_SUCH_OBJECT:

--- a/scripts/provisioning/resetcmd.py
+++ b/scripts/provisioning/resetcmd.py
@@ -53,14 +53,14 @@ class ResetCmd(SetupCmd):
       self.DeleteLdapAccountsUsers()
       sys.stdout.write('INFO: LDAP Accounts and Users Cleanup successful.\n')
     except Exception as e:
-      sys.stderr.write(f'Failed to cleanup LDAP Accounts and Users, error: {e}\n')
+      sys.stderr.write(f'ERROR:Failed to cleanup LDAP Accounts and Users, error: {e}\n')
       raise e
 
     try:
-      sys.stdout.write("Shutting down s3 services...\n")
+      sys.stdout.write("INFO:Shutting down s3 services...\n")
       self.shutdown_services(services_list)
     except Exception as e:
-      sys.stderr.write(f'Failed to stop s3services, error: {e}\n')
+      sys.stderr.write(f'ERROR:Failed to stop s3services, error: {e}\n')
       raise e
 
     try:
@@ -79,7 +79,7 @@ class ResetCmd(SetupCmd):
         sys.stdout.write('INFO:Purge message successful.\n')
 
     except Exception as e:
-      sys.stderr.write(f'Failed to cleanup log directories or files, error: {e}\n')
+      sys.stderr.write(f'ERROR: Failed to cleanup log directories or files, error: {e}\n')
       raise e
 
 
@@ -167,14 +167,14 @@ class ResetCmd(SetupCmd):
       raise e
 
   def DeleteLdapAccountsUsers(self):
-    """Deletes all LDAP accounts and users."""
+    """Deletes all LDAP data entries e.g. accounts, users, access keys using admin credentials."""
     self.read_ldap_credentials()
 
     try:
-      # Delete data directories e.g. ou=accesskeys, ou=accounts,ou=idp from dc=seagate,dc=com tree"
-      LdapAccountAction(self.ldap_user, self.ldap_passwd).delete_s3_ldap_data()
+      # Delete data directories e.g. ou=accesskeys, ou=accounts,ou=idp from dc=s3,dc=seagate,dc=com tree"
+      LdapAccountAction(self.ldap_root_user, self.rootdn_passwd).delete_s3_ldap_data()
     except Exception as e:
-      sys.stderr.write(f'Failed to delete s3 data exists in ldap, error: {e}\n')
+      sys.stderr.write(f'ERROR: Failed to delete s3 recoards exists in ldap, error: {e}\n')
       raise e
 
     try:
@@ -189,5 +189,5 @@ class ResetCmd(SetupCmd):
                                 }
       LdapAccountAction(self.ldap_user, self.ldap_passwd).create_account(bgdelete_acc_input_params_dict)
     except Exception as e:
-      sys.stderr.write(f'Failed to create backgrounddelete service account, error: {e}\n')
+      sys.stderr.write(f'ERROR: Failed to create backgrounddelete service account, error: {e}\n')
       raise e

--- a/scripts/provisioning/setupcmd.py
+++ b/scripts/provisioning/setupcmd.py
@@ -37,6 +37,7 @@ class SetupCmd(object):
   """Base class for setup commands."""
   ldap_user = None
   ldap_passwd = None
+  ldap_root_user = None
   rootdn_passwd = None
   cluster_id = None
   machine_id = None
@@ -112,6 +113,8 @@ class SetupCmd(object):
       self.ldap_user = self.get_confvalue(self.get_confkey('CONFSTORE_LDAPADMIN_USER_KEY'))
 
       encrypted_ldapadmin_pass = self.get_confvalue(self.get_confkey('CONFSTORE_LDAPADMIN_PASSWD_KEY'))
+
+      self.ldap_root_user = self.get_confvalue(self.get_confkey('CONFSTORE_ROOTDN_USER_KEY'))
 
       encrypted_rootdn_pass = self.get_confvalue(self.get_confkey('CONFSTORE_ROOTDN_PASSWD_KEY'))
 


### PR DESCRIPTION
 Delete data directories e.g. ou=accesskeys, ou=accounts,ou=idp from dc=seagate,dc=com tree"

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>