### PR TITLE
[EOS-17282]Multipart listing changes as per new design

### DIFF
--- a/server/s3_get_multipart_bucket_action.cc
+++ b/server/s3_get_multipart_bucket_action.cc
@@ -165,6 +165,7 @@ void S3GetMultipartBucketAction::get_next_objects_successful() {
   bool skip_marker_key = true;
   auto& kvps = motr_kv_reader->get_key_values();
   size_t length = kvps.size();
+  multipart_object_list.chop_uploadid_from_key();
   for (auto& kv : kvps) {
     s3_log(S3_LOG_DEBUG, request_id, "Read Object = %s\n", kv.first.c_str());
     auto object = object_metadata_factory->create_object_metadata_obj(request);

--- a/server/s3_object_list_response.cc
+++ b/server/s3_object_list_response.cc
@@ -32,6 +32,7 @@ S3ObjectListResponse::S3ObjectListResponse(std::string encoding_type)
       request_marker_uploadid(""),
       max_keys(""),
       response_is_truncated(false),
+      chop_uploadid(false),
       next_marker_key(""),
       max_uploads(""),
       next_marker_uploadid(""),
@@ -295,9 +296,15 @@ std::string& S3ObjectListResponse::get_multiupload_xml() {
   }
 
   for (auto&& object : object_list) {
+    std::string object_name = object->get_object_name();
+    if (chop_uploadid) {
+      // In case of multipart listing, chop uploadid from key
+      std::size_t pos = object_name.find("|");
+      object_name = object_name.substr(0, pos);
+    }
     response_xml += "<Upload>";
     response_xml += S3CommonUtilities::format_xml_string(
-        "Key", get_response_format_key_value(object->get_object_name()));
+        "Key", get_response_format_key_value(object_name));
     response_xml += S3CommonUtilities::format_xml_string(
         "UploadId", object->get_upload_id());
     response_xml += "<Initiator>";

--- a/server/s3_object_list_response.cc
+++ b/server/s3_object_list_response.cc
@@ -299,8 +299,12 @@ std::string& S3ObjectListResponse::get_multiupload_xml() {
     std::string object_name = object->get_object_name();
     if (chop_uploadid) {
       // In case of multipart listing, chop uploadid from key
-      std::size_t pos = object_name.find("|");
-      object_name = object_name.substr(0, pos);
+      // The flag gets set only in case of multipart listing, wherein
+      // we append |uploadid to object name
+      std::size_t pos = object_name.rfind("|");
+      if (pos != std::string::npos) {
+        object_name = object_name.substr(0, pos);
+      }
     }
     response_xml += "<Upload>";
     response_xml += S3CommonUtilities::format_xml_string(

--- a/server/s3_object_list_response.h
+++ b/server/s3_object_list_response.h
@@ -52,6 +52,7 @@ class S3ObjectListResponse {
   std::string request_marker_uploadid;
   std::string max_keys;
   bool response_is_truncated;
+  bool chop_uploadid;
   std::string next_marker_key;
 
   std::string max_uploads;
@@ -85,6 +86,7 @@ class S3ObjectListResponse {
   void set_response_is_truncated(bool flag);
   void set_next_marker_key(std::string next, bool url_encode = true);
   void set_next_marker_uploadid(std::string next);
+  void chop_uploadid_from_key() { chop_uploadid = true; }
   std::string& get_object_name();
   bool is_response_truncated() { return response_is_truncated; }
   std::vector<std::string> get_keys() {
@@ -148,6 +150,10 @@ class S3ObjectListResponse {
               ObjectListMultipartResponseWithValidObjectNotTruncated);
   FRIEND_TEST(S3ObjectListResponseTest,
               ObjectListMultipartResponseWithValidObjectTruncated);
+  FRIEND_TEST(S3ObjectListResponseTest,
+              ObjectListMultipartResponseWithUploadidChopped);
+  FRIEND_TEST(S3ObjectListResponseTest,
+              ObjectListMultipartResponseWithUploadid);
 };
 
 #endif

--- a/server/s3_object_list_response.h
+++ b/server/s3_object_list_response.h
@@ -86,7 +86,7 @@ class S3ObjectListResponse {
   void set_response_is_truncated(bool flag);
   void set_next_marker_key(std::string next, bool url_encode = true);
   void set_next_marker_uploadid(std::string next);
-  void chop_uploadid_from_key() { chop_uploadid = true; }
+  inline void chop_uploadid_from_key() { chop_uploadid = true; }
   std::string& get_object_name();
   bool is_response_truncated() { return response_is_truncated; }
   std::vector<std::string> get_keys() {

--- a/ut/s3_object_list_response_test.cc
+++ b/ut/s3_object_list_response_test.cc
@@ -196,6 +196,66 @@ TEST_F(S3ObjectListResponseTest, ObjectListResponseWithValidObjectsTruncated) {
   CHECK_XML_RESPONSE;
 }
 
+// Test get_xml response with valid object and all of the results were returned.
+TEST_F(S3ObjectListResponseTest,
+       ObjectListMultipartResponseWithUploadidChopped) {
+  response_under_test->set_request_marker_uploadid(
+      "test_request_marker_upload_id");
+  response_under_test->set_max_keys("test_max_keys");
+  response_under_test->set_next_marker_uploadid("test_next_marker_upload_id");
+  response_under_test->set_max_uploads("test_max_uploads");
+  response_under_test->set_response_is_truncated(true);
+  response_under_test->add_common_prefix("prefix1");
+  response_under_test->chop_uploadid_from_key();
+  std::shared_ptr<MockS3ObjectMetadata> mock_obj =
+      std::make_shared<MockS3ObjectMetadata>(mock_request);
+  mock_obj->set_object_list_index_oid(object_list_indx_oid);
+
+  response_under_test->add_object(mock_obj);
+
+  EXPECT_CALL(*mock_obj, get_object_name())
+      .WillOnce(Return("object_name|UploadID"));
+  EXPECT_CALL(*mock_obj, get_upload_id()).WillOnce(Return("upload_id"));
+  EXPECT_CALL(*mock_obj, get_last_modified_iso())
+      .WillRepeatedly(Return("last_modified"));
+  EXPECT_CALL(*mock_obj, get_user_id()).WillRepeatedly(Return("1"));
+  EXPECT_CALL(*mock_obj, get_user_name()).WillRepeatedly(Return("s3user"));
+  EXPECT_CALL(*mock_obj, get_storage_class())
+      .WillRepeatedly(Return("STANDARD"));
+  std::string response = response_under_test->get_multiupload_xml();
+  EXPECT_THAT(response, Not(HasSubstr("|UploadID")));
+  CHECK_MULTIUPLOAD_XML_RESPONSE;
+}
+
+// Test get_xml response with valid object.
+TEST_F(S3ObjectListResponseTest, ObjectListMultipartResponseWithUploadid) {
+  response_under_test->set_request_marker_uploadid(
+      "test_request_marker_upload_id");
+  response_under_test->set_max_keys("test_max_keys");
+  response_under_test->set_next_marker_uploadid("test_next_marker_upload_id");
+  response_under_test->set_max_uploads("test_max_uploads");
+  response_under_test->set_response_is_truncated(true);
+  response_under_test->add_common_prefix("prefix1");
+  std::shared_ptr<MockS3ObjectMetadata> mock_obj =
+      std::make_shared<MockS3ObjectMetadata>(mock_request);
+  mock_obj->set_object_list_index_oid(object_list_indx_oid);
+
+  response_under_test->add_object(mock_obj);
+
+  EXPECT_CALL(*mock_obj, get_object_name())
+      .WillOnce(Return("object_name|UploadID"));
+  EXPECT_CALL(*mock_obj, get_upload_id()).WillOnce(Return("upload_id"));
+  EXPECT_CALL(*mock_obj, get_last_modified_iso())
+      .WillRepeatedly(Return("last_modified"));
+  EXPECT_CALL(*mock_obj, get_user_id()).WillRepeatedly(Return("1"));
+  EXPECT_CALL(*mock_obj, get_user_name()).WillRepeatedly(Return("s3user"));
+  EXPECT_CALL(*mock_obj, get_storage_class())
+      .WillRepeatedly(Return("STANDARD"));
+  std::string response = response_under_test->get_multiupload_xml();
+  EXPECT_THAT(response, HasSubstr("|UploadID"));
+  CHECK_MULTIUPLOAD_XML_RESPONSE;
+}
+
 // Test get_xml response with valid object and results is truncated.
 TEST_F(S3ObjectListResponseTest,
        ObjectListResponseWithValidObjectsNotTruncated) {


### PR DESCRIPTION
Multipart listing to not disply uploadid which gets in as key
in the multipart table, listing to show same objects with diffferent
upload ids in case of simultaneous multipart upload of same object

Signed-off-by: Rajesh <rajesh.nambiar@seagate.com>