### PR TITLE
[Bug] EOS-19132:Auth: change constant key for s3cipher in authserver

### DIFF
--- a/auth/resources/authserver.properties.sample
+++ b/auth/resources/authserver.properties.sample
@@ -39,7 +39,7 @@ ldapLoginDN=cn=sgiamadmin,dc=seagate,dc=com
 # Use AuthPassEncryptCLI.jar CLI to encrypt the password
 ldapLoginPW=Rofaa+mJRYLVbuA2kF+CyVUJBjPx5IIFDBQfajmrn23o5aEZHonQj1ikUU9iMBoC6p/dZtVXMO1KFGzHXX3y1A==
 # ldap_const_key to decrypt ldap password
-ldap_const_key=openldap
+ldap_const_key=cortx
 consoleURL=https://console.s3.seagate.com:9292/sso
 enable_https=false
 enable_http=true

--- a/auth/resources/keystore.properties.sample
+++ b/auth/resources/keystore.properties.sample
@@ -23,7 +23,7 @@ s3KeyStorePath=/opt/seagate/cortx/auth/resources
 s3KeyStorePassword=seagate
 s3KeyPassword=seagate
 s3AuthCertAlias=s3auth_pass
-s3CipherUtil=s3cipher generate_key --use_base64 --key_len 12 --const_key openldap
+s3CipherUtil=s3cipher generate_key --const_key cortx
 
 # Uncomment this to override logging config file.
 #

--- a/scripts/create_auth_jks_password.sh
+++ b/scripts/create_auth_jks_password.sh
@@ -46,7 +46,7 @@ fi
 generate_keystore_password(){
   echo "Generating password for jks keystore used in authserver..."
   # Get password from cortx-utils
-  new_keystore_passwd=$(s3cipher generate_key --use_base64 --key_len  12 --const_key openldap)
+  new_keystore_passwd=$(s3cipher generate_key --const_key cortx)
   if [[ $? != 0 || -z "$new_keystore_passwd" ]] # Generate random password failed
   then
     echo "ERROR: failed to generate key using py-utils:Cipher utility, exiting."

--- a/scripts/enc_ldap_passwd_in_cfg.sh
+++ b/scripts/enc_ldap_passwd_in_cfg.sh
@@ -98,7 +98,7 @@ if [ "$change_ldap_passwd" = true ] ; then
 fi
 
 # Encrypt the password using s3cipher
-ldapcipherkey=$(s3cipher generate_key --const_key openldap)
+ldapcipherkey=$(s3cipher generate_key --const_key cortx)
 encrypted_pass=$(s3cipher encrypt --data "$ldap_passwd" --key "$ldapcipherkey")
 
 # Update the config


### PR DESCRIPTION
s3cipher constant key needs to be updated in authserver.
1) const_ldap_key is still ued as "openldap" but it should be "cortx"
2) keystore.properties has old s3cipher command 
Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>