### PR TITLE
EOS-19183: Remove multipart re-design changes from FaultTolerence branch

### DIFF
--- a/server/s3_addb_map_auto.c
+++ b/server/s3_addb_map_auto.c
@@ -25,7 +25,7 @@
 
 #include "s3_addb_map.h"
 
-const uint64_t g_s3_to_addb_idx_func_name_map_size = 208;
+const uint64_t g_s3_to_addb_idx_func_name_map_size = 209;
 
 const char* g_s3_to_addb_idx_func_name_map[] = {
     "Action::check_authentication",
@@ -157,7 +157,8 @@ const char* g_s3_to_addb_idx_func_name_map[] = {
     "S3PostCompleteAction::save_metadata",
     "S3PostCompleteAction::send_response_to_s3_client",
     "S3PostCompleteActionTest::func_callback_one",
-    "S3PostMultipartObjectAction::check_bucket_object_state",
+    "S3PostMultipartObjectAction::check_upload_is_inprogress",
+    "S3PostMultipartObjectAction::create_object",
     "S3PostMultipartObjectAction::create_part_meta_index",
     "S3PostMultipartObjectAction::save_upload_metadata",
     "S3PostMultipartObjectAction::send_response_to_s3_client",

--- a/server/s3_object_metadata.cc
+++ b/server/s3_object_metadata.cc
@@ -99,6 +99,7 @@ void S3ObjectMetadata::initialize() {
   if (is_multipart) {
     index_name = get_multipart_index_name();
     system_defined_attribute["Upload-ID"] = upload_id;
+    (void)system_defined_attribute["Part-One-Size"];
   } else {
     index_name = get_object_list_index_name();
   }
@@ -128,11 +129,6 @@ S3ObjectMetadata::S3ObjectMetadata(
     object_name = request->get_object_name();
   } else {
     object_name = std::move(objectname);
-  }
-  if (upload_id.size() != 0) {
-    // for multipart uoload object name is appended with
-    // upload id
-    object_name += "|" + upload_id;
   }
   if (motr_api) {
     s3_motr_api = std::move(motr_api);
@@ -173,10 +169,6 @@ std::string S3ObjectMetadata::get_owner_name() {
 }
 
 std::string S3ObjectMetadata::get_object_name() { return object_name; }
-
-void S3ObjectMetadata::rename_object_name(std::string new_object_name) {
-  object_name = new_object_name;
-}
 
 void S3ObjectMetadata::set_object_list_index_oid(struct m0_uint128 id) {
   object_list_index_oid.u_hi = id.u_hi;
@@ -274,11 +266,10 @@ std::string S3ObjectMetadata::get_content_length_str() {
   return system_defined_attribute["Content-Length"];
 }
 
-// TODO - Remove it later
 void S3ObjectMetadata::set_part_one_size(const size_t& part_size) {
   system_defined_attribute["Part-One-Size"] = std::to_string(part_size);
 }
-// TODO - Remove it later
+
 size_t S3ObjectMetadata::get_part_one_size() {
   if (system_defined_attribute["Part-One-Size"] == "") {
     return 0;

--- a/server/s3_object_metadata.h
+++ b/server/s3_object_metadata.h
@@ -228,7 +228,6 @@ class S3ObjectMetadata : private S3ObjectMetadataCopyable {
   virtual void set_content_length(std::string length);
   virtual size_t get_content_length();
   virtual size_t get_part_one_size();
-  virtual void rename_object_name(std::string new_object_name);
   virtual std::string get_content_length_str();
   virtual void set_content_type(std::string content_type);
   virtual std::string get_content_type();

--- a/server/s3_post_multipartobject_action.cc
+++ b/server/s3_post_multipartobject_action.cc
@@ -39,6 +39,7 @@ S3PostMultipartObjectAction::S3PostMultipartObjectAction(
     std::shared_ptr<S3ObjectMultipartMetadataFactory> object_mp_meta_factory,
     std::shared_ptr<S3ObjectMetadataFactory> object_meta_factory,
     std::shared_ptr<S3PartMetadataFactory> part_meta_factory,
+    std::shared_ptr<S3MotrWriterFactory> motr_s3_factory,
     std::shared_ptr<S3PutTagsBodyFactory> put_tags_body_factory,
     std::shared_ptr<MotrAPI> motr_api,
     std::shared_ptr<S3MotrKVSWriterFactory> kv_writer_factory)
@@ -74,12 +75,19 @@ S3PostMultipartObjectAction::S3PostMultipartObjectAction(
       S3MotrLayoutMap::get_instance()->get_best_layout_for_object_size();
 
   multipart_index_oid = {0ULL, 0ULL};
+  salt = "uri_salt_";
 
   if (object_mp_meta_factory) {
     object_mp_metadata_factory = std::move(object_mp_meta_factory);
   } else {
     object_mp_metadata_factory =
         std::make_shared<S3ObjectMultipartMetadataFactory>();
+  }
+
+  if (motr_s3_factory) {
+    motr_writer_factory = std::move(motr_s3_factory);
+  } else {
+    motr_writer_factory = std::make_shared<S3MotrWriterFactory>();
   }
 
   if (part_meta_factory) {
@@ -110,16 +118,16 @@ void S3PostMultipartObjectAction::setup_steps() {
     ACTION_TASK_ADD(
         S3PostMultipartObjectAction::validate_x_amz_tagging_if_present, this);
   }
-  ACTION_TASK_ADD(S3PostMultipartObjectAction::check_bucket_object_state, this);
+  ACTION_TASK_ADD(S3PostMultipartObjectAction::check_upload_is_inprogress,
+                  this);
+  ACTION_TASK_ADD(S3PostMultipartObjectAction::create_object, this);
   ACTION_TASK_ADD(S3PostMultipartObjectAction::create_part_meta_index, this);
   ACTION_TASK_ADD(S3PostMultipartObjectAction::save_upload_metadata, this);
   ACTION_TASK_ADD(S3PostMultipartObjectAction::send_response_to_s3_client,
                   this);
   // ...
 }
-
 void S3PostMultipartObjectAction::fetch_object_info_failed() { next(); }
-
 void S3PostMultipartObjectAction::fetch_bucket_info_failed() {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
@@ -138,7 +146,6 @@ void S3PostMultipartObjectAction::fetch_bucket_info_failed() {
   send_response_to_s3_client();
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
-
 void S3PostMultipartObjectAction::fetch_object_info_success() { next(); }
 
 void S3PostMultipartObjectAction::validate_x_amz_tagging_if_present() {
@@ -196,10 +203,9 @@ void S3PostMultipartObjectAction::validate_tags() {
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
-void S3PostMultipartObjectAction::check_bucket_object_state() {
+void S3PostMultipartObjectAction::check_upload_is_inprogress() {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
-  S3BucketMetadataState bucket_state = bucket_metadata->get_state();
-  if (bucket_state == S3BucketMetadataState::present) {
+  if (bucket_metadata->get_state() == S3BucketMetadataState::present) {
     S3Uuid uuid;
     upload_id = uuid.get_string_uuid();
     multipart_index_oid = bucket_metadata->get_multipart_index_oid();
@@ -215,46 +221,165 @@ void S3PostMultipartObjectAction::check_bucket_object_state() {
              S3_IEM_METADATA_CORRUPTED_JSON);
       set_s3_error("MetaDataCorruption");
       send_response_to_s3_client();
-      return;
-    }
-    object_multipart_metadata->set_oid(oid);
-    S3ObjectMetadataState object_state = object_metadata->get_state();
-    if (object_state == S3ObjectMetadataState::present) {
-      s3_log(S3_LOG_DEBUG, request_id, "S3ObjectMetadataState::present\n");
-      old_oid = object_metadata->get_oid();
-      old_layout_id = object_metadata->get_layout_id();
-      s3_log(S3_LOG_DEBUG, request_id,
-             "Object with oid "
-             "%" SCNx64 " : %" SCNx64 " already exists, creating new oid\n",
-             old_oid.u_hi, old_oid.u_lo);
-
-      object_multipart_metadata->set_old_oid(old_oid);
-      object_multipart_metadata->set_old_layout_id(old_layout_id);
-      object_multipart_metadata->set_old_version_id(
-          object_metadata->get_obj_version_id());
-
-      next();
-    } else if (object_state == S3ObjectMetadataState::missing) {
-      s3_log(S3_LOG_DEBUG, request_id, "S3ObjectMetadataState::missing\n");
-      next();
     } else {
-      s3_log(S3_LOG_DEBUG, request_id, "Failed to look up metadata.\n");
-      set_s3_error("InternalError");
-      send_response_to_s3_client();
+      // Check if multipart upload is in progress for this upload.
+      object_multipart_metadata->load(
+          std::bind(
+              &S3PostMultipartObjectAction::check_multipart_object_info_status,
+              this),
+          std::bind(
+              &S3PostMultipartObjectAction::check_multipart_object_info_status,
+              this));
     }
   } else {
-    if (bucket_state == S3BucketMetadataState::missing) {
-      s3_log(S3_LOG_DEBUG, request_id, "Bucket not found\n");
-      set_s3_error("NoSuchBucket");
-    } else {
-    set_s3_error("InternalError");
-    send_response_to_s3_client();
-    }
+    // Should never be here.
+    assert(false);
+    s3_log(S3_LOG_ERROR, request_id, "Bug: Report issue to Support team.\n");
   }
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
-#if 0
+void S3PostMultipartObjectAction::check_multipart_object_info_status() {
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
+  if (object_multipart_metadata->get_state() !=
+      S3ObjectMetadataState::present) {
+    if (object_multipart_metadata->get_state() ==
+        S3ObjectMetadataState::failed_to_launch) {
+      s3_log(
+          S3_LOG_ERROR, request_id,
+          "Object metadata load operation failed due to pre launch failure\n");
+      set_s3_error("ServiceUnavailable");
+      send_response_to_s3_client();
+      s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+      return;
+    }
+    // Multipart upload not in progress for this object_name
+    s3_log(S3_LOG_DEBUG, request_id,
+           "Multipart upload not in progress for this object_name [%s]\n",
+           request->get_object_name().c_str());
+    if (object_list_oid.u_hi == 0ULL && object_list_oid.u_lo == 0ULL) {
+      // object_list_oid is null only when bucket metadata is corrupted.
+      // user has to delete and recreate the bucket again to make it work.
+      s3_log(S3_LOG_ERROR, request_id, "Bucket(%s) metadata is corrupted.\n",
+             request->get_bucket_name().c_str());
+      s3_iem(LOG_ERR, S3_IEM_METADATA_CORRUPTED, S3_IEM_METADATA_CORRUPTED_STR,
+             S3_IEM_METADATA_CORRUPTED_JSON);
+      set_s3_error("MetaDataCorruption");
+      send_response_to_s3_client();
+    } else {
+      check_object_state();
+    }
+  } else {
+    //++
+    // Bailing out in case if the multipart upload is already in progress,
+    // this will ensure that object doesn't go to inconsistent state
+
+    // Once multipart is taken care in motr, it may not be needed
+    // Note - Currently as per aws doc.
+    // (http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListMPUpload.html)
+    // multipart upload details
+    // of the same key initiated at different times is allowed.
+    //--
+    set_s3_error("InvalidObjectState");
+    send_response_to_s3_client();
+  }
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
+
+void S3PostMultipartObjectAction::check_object_state() {
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
+  S3ObjectMetadataState object_state = object_metadata->get_state();
+  if (object_state == S3ObjectMetadataState::present) {
+    s3_log(S3_LOG_DEBUG, request_id, "S3ObjectMetadataState::present\n");
+    old_oid = object_metadata->get_oid();
+    old_layout_id = object_metadata->get_layout_id();
+    s3_log(S3_LOG_DEBUG, request_id,
+           "Object with oid "
+           "%" SCNx64 " : %" SCNx64 " already exists, creating new oid\n",
+           old_oid.u_hi, old_oid.u_lo);
+    create_new_oid(old_oid);
+
+    object_multipart_metadata->set_old_oid(old_oid);
+    object_multipart_metadata->set_old_layout_id(old_layout_id);
+    object_multipart_metadata->set_old_version_id(
+        object_metadata->get_obj_version_id());
+
+    next();
+  } else if (object_state == S3ObjectMetadataState::missing) {
+    s3_log(S3_LOG_DEBUG, request_id, "S3ObjectMetadataState::missing\n");
+    next();
+  } else {
+    s3_log(S3_LOG_DEBUG, request_id, "Failed to look up metadata.\n");
+    set_s3_error("InternalError");
+    send_response_to_s3_client();
+  }
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
+
+void S3PostMultipartObjectAction::create_object() {
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
+  create_object_timer.start();
+  if (tried_count == 0) {
+    motr_writer = motr_writer_factory->create_motr_writer(request, oid);
+  } else {
+    motr_writer->set_oid(oid);
+  }
+
+  motr_writer->create_object(
+      std::bind(&S3PostMultipartObjectAction::create_object_successful, this),
+      std::bind(&S3PostMultipartObjectAction::create_object_failed, this),
+      layout_id);
+
+  // for shutdown testcases, check FI and set shutdown signal
+  S3_CHECK_FI_AND_SET_SHUTDOWN_SIGNAL(
+      "post_multipartobject_action_create_object_shutdown_fail");
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
+
+void S3PostMultipartObjectAction::create_object_successful() {
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
+  create_object_timer.stop();
+  const size_t time_in_millisecond =
+      create_object_timer.elapsed_time_in_millisec();
+  LOG_PERF("create_object_successful_ms", request_id.c_str(),
+           time_in_millisecond);
+  s3_stats_timing("multipart_create_object_success", time_in_millisecond);
+  object_multipart_metadata->set_oid(oid);
+  add_task_rollback(
+      std::bind(&S3PostMultipartObjectAction::rollback_create, this));
+  next();
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
+
+void S3PostMultipartObjectAction::create_object_failed() {
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
+
+  create_object_timer.stop();
+  LOG_PERF("create_object_failed_ms", request_id.c_str(),
+           create_object_timer.elapsed_time_in_millisec());
+  s3_stats_timing("multipart_create_object_failed",
+                  create_object_timer.elapsed_time_in_millisec());
+
+  if (check_shutdown_and_rollback()) {
+    s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+    return;
+  }
+
+  if (motr_writer->get_state() == S3MotrWiterOpState::exists) {
+    collision_occured();
+  } else if (motr_writer->get_state() == S3MotrWiterOpState::failed_to_launch) {
+    s3_log(S3_LOG_WARN, request_id, "Create object failed.\n");
+    set_s3_error("ServiceUnavailable");
+    send_response_to_s3_client();
+  } else {
+    s3_log(S3_LOG_WARN, request_id, "Create object failed.\n");
+    // Any other error report failure.
+    set_s3_error("InternalError");
+    send_response_to_s3_client();
+  }
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
+
 void S3PostMultipartObjectAction::collision_occured() {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   if (check_shutdown_and_rollback()) {
@@ -283,11 +408,25 @@ void S3PostMultipartObjectAction::collision_occured() {
       // S3_IEM_COLLISION_RES_FAIL_STR,
       //     S3_IEM_COLLISION_RES_FAIL_JSON);
     }
+    set_s3_error("InternalError");
     send_response_to_s3_client();
   }
-  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
-#endif
+
+void S3PostMultipartObjectAction::create_new_oid(
+    struct m0_uint128 current_oid) {
+  int salt_counter = 0;
+  std::string salted_uri;
+  do {
+    salted_uri = request->get_object_uri() + salt +
+                 std::to_string(salt_counter) + std::to_string(tried_count);
+
+    S3UriToMotrOID(s3_motr_api, salted_uri.c_str(), request_id, &oid);
+    ++salt_counter;
+  } while ((oid.u_hi == current_oid.u_hi) && (oid.u_lo == current_oid.u_lo));
+
+  return;
+}
 
 void S3PostMultipartObjectAction::create_part_meta_index() {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
@@ -372,9 +511,7 @@ void S3PostMultipartObjectAction::rollback_create_part_meta_index_failed() {
 
 void S3PostMultipartObjectAction::save_upload_metadata() {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
-  std::string multipart_object_name =
-      request->get_object_name() + "|" + upload_id;
-  object_multipart_metadata->rename_object_name(multipart_object_name);
+
   object_multipart_metadata->set_layout_id(layout_id);
 
   for (auto it : request->get_in_headers_copy()) {

--- a/server/s3_post_multipartobject_action.h
+++ b/server/s3_post_multipartobject_action.h
@@ -44,15 +44,17 @@ class S3PostMultipartObjectAction : public S3ObjectAction {
   std::string salt;
   std::shared_ptr<S3ObjectMetadata> object_multipart_metadata;
   std::shared_ptr<S3PartMetadata> part_metadata;
+  std::shared_ptr<S3MotrWiter> motr_writer;
   std::shared_ptr<S3MotrKVSWriter> motr_kv_writer;
   std::string upload_id;
+
+  S3Timer create_object_timer;
 
   std::shared_ptr<S3ObjectMultipartMetadataFactory> object_mp_metadata_factory;
   std::shared_ptr<S3PartMetadataFactory> part_metadata_factory;
   std::shared_ptr<S3MotrWriterFactory> motr_writer_factory;
   std::shared_ptr<S3PutTagsBodyFactory> put_object_tag_body_factory;
   std::shared_ptr<S3MotrKVSWriterFactory> mote_kv_writer_factory;
-  std::shared_ptr<S3MotrWiter> motr_writer;
   std::shared_ptr<MotrAPI> s3_motr_api;
   std::map<std::string, std::string> new_object_tags_map;
 
@@ -70,6 +72,7 @@ class S3PostMultipartObjectAction : public S3ObjectAction {
           nullptr,
       std::shared_ptr<S3ObjectMetadataFactory> object_meta_factory = nullptr,
       std::shared_ptr<S3PartMetadataFactory> part_meta_factory = nullptr,
+      std::shared_ptr<S3MotrWriterFactory> motr_writer_factory = nullptr,
       std::shared_ptr<S3PutTagsBodyFactory> put_tags_body_factory = nullptr,
       std::shared_ptr<MotrAPI> motr_api = nullptr,
       std::shared_ptr<S3MotrKVSWriterFactory> kv_writer_factory = nullptr);
@@ -80,10 +83,15 @@ class S3PostMultipartObjectAction : public S3ObjectAction {
   void parse_x_amz_tagging_header(std::string content);
   void validate_tags();
   void fetch_bucket_info_failed();
-  void check_bucket_object_state();
+  void check_multipart_object_info_status();
+  void check_object_state();
   void fetch_object_info_success();
   void fetch_object_info_failed();
   void check_upload_is_inprogress();
+  void create_object();
+  void create_object_successful();
+  void create_object_failed();
+  virtual void collision_occured();
   void create_new_oid(struct m0_uint128 current_oid);
   void save_upload_metadata();
   void save_upload_metadata_failed();

--- a/ut/s3_post_multipartobject_action_test.cc
+++ b/ut/s3_post_multipartobject_action_test.cc
@@ -74,6 +74,8 @@ class S3PostMultipartObjectTest : public testing::Test {
 
     part_meta_factory = std::make_shared<MockS3PartMetadataFactory>(
         ptr_mock_request, oid, upload_id, 0);
+    motr_writer_factory = std::make_shared<MockS3MotrWriterFactory>(
+        ptr_mock_request, oid, ptr_mock_s3_motr_api);
     bucket_tag_body_factory_mock = std::make_shared<MockS3PutTagBodyFactory>(
         MockObjectTagsStr, MockRequestId);
     motr_kvs_writer_factory = std::make_shared<MockS3MotrKVSWriterFactory>(
@@ -87,8 +89,9 @@ class S3PostMultipartObjectTest : public testing::Test {
 
     action_under_test.reset(new S3PostMultipartObjectAction(
         ptr_mock_request, bucket_meta_factory, object_mp_meta_factory,
-        object_meta_factory, part_meta_factory, bucket_tag_body_factory_mock,
-        ptr_mock_s3_motr_api, motr_kvs_writer_factory));
+        object_meta_factory, part_meta_factory, motr_writer_factory,
+        bucket_tag_body_factory_mock, ptr_mock_s3_motr_api,
+        motr_kvs_writer_factory));
   }
 
   std::shared_ptr<MockS3RequestObject> ptr_mock_request;
@@ -97,6 +100,7 @@ class S3PostMultipartObjectTest : public testing::Test {
   std::shared_ptr<MockS3ObjectMetadataFactory> object_meta_factory;
   std::shared_ptr<MockS3PartMetadataFactory> part_meta_factory;
   std::shared_ptr<MockS3ObjectMultipartMetadataFactory> object_mp_meta_factory;
+  std::shared_ptr<MockS3MotrWriterFactory> motr_writer_factory;
   std::shared_ptr<MockS3MotrKVSWriterFactory> motr_kvs_writer_factory;
   std::shared_ptr<MockS3PutTagBodyFactory> bucket_tag_body_factory_mock;
   std::shared_ptr<S3PostMultipartObjectAction> action_under_test;
@@ -117,6 +121,7 @@ class S3PostMultipartObjectTest : public testing::Test {
 
 TEST_F(S3PostMultipartObjectTest, ConstructorTest) {
   EXPECT_EQ(0, action_under_test->tried_count);
+  EXPECT_EQ("uri_salt_", action_under_test->salt);
   EXPECT_NE(0, action_under_test->number_of_tasks());
 }
 
@@ -146,6 +151,223 @@ TEST_F(S3PostMultipartObjectTest, VaidateEmptyTags) {
   action_under_test->validate_x_amz_tagging_if_present();
   EXPECT_STREQ("InvalidTagError",
                action_under_test->get_s3_error_code().c_str());
+}
+
+TEST_F(S3PostMultipartObjectTest, UploadInProgress) {
+  struct m0_uint128 oid = {0xffff, 0xffff};
+
+  action_under_test->bucket_metadata =
+      bucket_meta_factory->mock_bucket_metadata;
+
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata), get_state())
+      .WillRepeatedly(Return(S3BucketMetadataState::present));
+  action_under_test->bucket_metadata->set_multipart_index_oid(oid);
+  EXPECT_CALL(*(object_mp_meta_factory->mock_object_mp_metadata), load(_, _))
+      .Times(1);
+  action_under_test->check_upload_is_inprogress();
+}
+
+TEST_F(S3PostMultipartObjectTest, UploadInProgressMetadataCorrupt) {
+  struct m0_uint128 empty_oid = {0ULL, 0ULL};
+
+  action_under_test->bucket_metadata =
+      bucket_meta_factory->mock_bucket_metadata;
+
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata), get_state())
+      .WillRepeatedly(Return(S3BucketMetadataState::present));
+  EXPECT_CALL(*(object_mp_meta_factory->mock_object_mp_metadata), get_state())
+      .WillOnce(Return(S3ObjectMetadataState::empty));
+  action_under_test->clear_tasks();
+  ACTION_TASK_ADD_OBJPTR(action_under_test,
+                         S3PostMultipartObjectTest::func_callback_one, this);
+  action_under_test->bucket_metadata->set_multipart_index_oid(empty_oid);
+  EXPECT_CALL(*(object_mp_meta_factory->mock_object_mp_metadata), load(_, _))
+      .Times(0);
+
+  EXPECT_CALL(*ptr_mock_request, set_out_header_value(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(*ptr_mock_request, send_response(500, _)).Times(1);
+
+  action_under_test->check_upload_is_inprogress();
+
+  EXPECT_STREQ("MetaDataCorruption",
+               action_under_test->get_s3_error_code().c_str());
+}
+
+TEST_F(S3PostMultipartObjectTest, FetchObjectInfoStatusObjectPresent) {
+  action_under_test->object_metadata =
+      object_meta_factory->mock_object_metadata;
+  action_under_test->object_multipart_metadata =
+      object_mp_meta_factory->mock_object_mp_metadata;
+  EXPECT_CALL(*(object_mp_meta_factory->mock_object_mp_metadata), get_state())
+      .WillRepeatedly(Return(S3ObjectMetadataState::present));
+  EXPECT_CALL(*ptr_mock_request, set_out_header_value(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(*ptr_mock_request, send_response(403, _)).Times(1);
+
+  action_under_test->check_multipart_object_info_status();
+}
+
+TEST_F(S3PostMultipartObjectTest, FetchObjectInfoStatusObjectNotPresent) {
+  struct m0_uint128 zero_oid = {0ULL, 0ULL};
+  action_under_test->object_metadata =
+      object_meta_factory->mock_object_metadata;
+  action_under_test->object_multipart_metadata =
+      object_mp_meta_factory->mock_object_mp_metadata;
+  EXPECT_CALL(*(object_mp_meta_factory->mock_object_mp_metadata), get_state())
+      .Times(2)
+      .WillRepeatedly(Return(S3ObjectMetadataState::missing));
+  action_under_test->object_list_oid = {0xfff, 0xf1ff};
+  EXPECT_CALL(*(object_meta_factory->mock_object_metadata), get_state())
+      .Times(1)
+      .WillRepeatedly(Return(S3ObjectMetadataState::missing));
+
+  action_under_test->clear_tasks();
+  ACTION_TASK_ADD_OBJPTR(action_under_test,
+                         S3PostMultipartObjectTest::func_callback_one, this);
+  action_under_test->check_multipart_object_info_status();
+  EXPECT_EQ(1, call_count_one);
+  EXPECT_OID_EQ(zero_oid, action_under_test->old_oid);
+}
+
+TEST_F(S3PostMultipartObjectTest, CreateObject) {
+  action_under_test->bucket_metadata =
+      bucket_meta_factory->mock_bucket_metadata;
+  action_under_test->object_multipart_metadata =
+      object_mp_meta_factory->mock_object_mp_metadata;
+
+  action_under_test->tried_count = 0;
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), create_object(_, _, _))
+      .Times(1);
+  action_under_test->create_object();
+
+  action_under_test->tried_count = 1;
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), create_object(_, _, _))
+      .Times(1);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), set_oid(_)).Times(1);
+  action_under_test->create_object();
+}
+
+TEST_F(S3PostMultipartObjectTest, CreateObjectFailed) {
+  S3Option::get_instance()->set_is_s3_shutting_down(true);
+  EXPECT_CALL(*ptr_mock_request, pause()).Times(1);
+  EXPECT_CALL(*ptr_mock_request, set_out_header_value(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(*ptr_mock_request, send_response(503, _)).Times(1);
+
+  action_under_test->create_object_failed();
+  EXPECT_TRUE(action_under_test->motr_writer == NULL);
+  S3Option::get_instance()->set_is_s3_shutting_down(false);
+
+  action_under_test->motr_writer = motr_writer_factory->mock_motr_writer;
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), get_state())
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(S3MotrWiterOpState::failed));
+  EXPECT_CALL(*ptr_mock_request, set_out_header_value(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(*ptr_mock_request, send_response(500, _)).Times(1);
+  action_under_test->create_object_failed();
+  EXPECT_STREQ("InternalError", action_under_test->get_s3_error_code().c_str());
+}
+
+TEST_F(S3PostMultipartObjectTest, CreateObjectFailedToLaunch) {
+  S3Option::get_instance()->set_is_s3_shutting_down(true);
+  EXPECT_CALL(*ptr_mock_request, pause()).Times(1);
+  EXPECT_CALL(*ptr_mock_request, set_out_header_value(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(*ptr_mock_request, send_response(503, _)).Times(1);
+
+  action_under_test->create_object_failed();
+  EXPECT_TRUE(action_under_test->motr_writer == NULL);
+  S3Option::get_instance()->set_is_s3_shutting_down(false);
+
+  action_under_test->motr_writer = motr_writer_factory->mock_motr_writer;
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), get_state())
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(S3MotrWiterOpState::failed_to_launch));
+  EXPECT_CALL(*ptr_mock_request, set_out_header_value(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(*ptr_mock_request, send_response(503, _)).Times(1);
+  action_under_test->create_object_failed();
+  EXPECT_STREQ("ServiceUnavailable",
+               action_under_test->get_s3_error_code().c_str());
+}
+
+TEST_F(S3PostMultipartObjectTest, CreateObjectFailedDueToCollision) {
+  S3Option::get_instance()->set_is_s3_shutting_down(false);
+  action_under_test->motr_writer = motr_writer_factory->mock_motr_writer;
+
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), get_state())
+      .Times(AtLeast(1))
+      .WillRepeatedly(Return(S3MotrWiterOpState::exists));
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), set_oid(_)).Times(1);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), create_object(_, _, _))
+      .Times(1);
+  action_under_test->tried_count = 1;
+  action_under_test->create_object_failed();
+  EXPECT_EQ(2, action_under_test->tried_count);
+}
+
+TEST_F(S3PostMultipartObjectTest, CollisionOccured) {
+  S3Option::get_instance()->set_is_s3_shutting_down(false);
+  action_under_test->motr_writer = motr_writer_factory->mock_motr_writer;
+  action_under_test->tried_count = 1;
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), create_object(_, _, _))
+      .Times(AtLeast(1));
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), set_oid(_)).Times(1);
+  action_under_test->collision_occured();
+  EXPECT_EQ(2, action_under_test->tried_count);
+
+  action_under_test->tried_count = MAX_COLLISION_RETRY_COUNT + 1;
+  EXPECT_CALL(*ptr_mock_request, set_out_header_value(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(*ptr_mock_request, send_response(500, _)).Times(1);
+  action_under_test->collision_occured();
+  EXPECT_STREQ("InternalError", action_under_test->get_s3_error_code().c_str());
+}
+
+TEST_F(S3PostMultipartObjectTest, CreateNewOid) {
+  struct m0_uint128 new_oid, old_oid;
+  S3Option::get_instance()->enable_murmurhash_oid();
+  old_oid = {0xffff, 0xffff};
+  action_under_test->set_oid(old_oid);
+  action_under_test->create_new_oid(old_oid);
+  new_oid = action_under_test->get_oid();
+  EXPECT_OID_NE(old_oid, new_oid);
+  S3Option::get_instance()->disable_murmurhash_oid();
+}
+
+TEST_F(S3PostMultipartObjectTest, RollbackCreate) {
+  action_under_test->motr_writer = motr_writer_factory->mock_motr_writer;
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), delete_object(_, _, _))
+      .Times(1);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), set_oid(_)).Times(1);
+  action_under_test->rollback_create();
+}
+
+TEST_F(S3PostMultipartObjectTest, RollbackCreateFailedMetadataMissing) {
+  action_under_test->motr_writer = motr_writer_factory->mock_motr_writer;
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), get_state())
+      .WillRepeatedly(Return(S3MotrWiterOpState::missing));
+  action_under_test->add_task_rollback(
+      std::bind(&S3PostMultipartObjectTest::func_callback_one, this));
+  action_under_test->rollback_create_failed();
+  EXPECT_EQ(1, call_count_one);
+}
+
+TEST_F(S3PostMultipartObjectTest, RollbackCreateFailedMetadataFailed) {
+  action_under_test->motr_writer = motr_writer_factory->mock_motr_writer;
+  action_under_test->add_task_rollback(
+      std::bind(&S3PostMultipartObjectTest::func_callback_one, this));
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), get_state())
+      .WillRepeatedly(Return(S3MotrWiterOpState::failed));
+
+  action_under_test->rollback_create_failed();
+  EXPECT_EQ(1, call_count_one);
+}
+
+TEST_F(S3PostMultipartObjectTest, RollbackCreateFailedMetadataFailed1) {
+  action_under_test->motr_writer = motr_writer_factory->mock_motr_writer;
+  action_under_test->add_task_rollback(
+      std::bind(&S3PostMultipartObjectTest::func_callback_one, this));
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), get_state())
+      .WillRepeatedly(Return(S3MotrWiterOpState::failed_to_launch));
+
+  action_under_test->rollback_create_failed();
+  EXPECT_EQ(1, call_count_one);
 }
 
 TEST_F(S3PostMultipartObjectTest, RollbackPartMetadataIndex) {
@@ -222,6 +444,7 @@ TEST_F(S3PostMultipartObjectTest, Send200ResponseToClient) {
   action_under_test->object_multipart_metadata =
       object_mp_meta_factory->mock_object_mp_metadata;
   action_under_test->part_metadata = part_meta_factory->mock_part_metadata;
+  action_under_test->motr_writer = motr_writer_factory->mock_motr_writer;
   EXPECT_CALL(*(object_mp_meta_factory->mock_object_mp_metadata), get_state())
       .WillRepeatedly(Return(S3ObjectMetadataState::saved));
   EXPECT_CALL(*(part_meta_factory->mock_part_metadata), get_state())


### PR DESCRIPTION
After re-basing 'br/DG/EOS-19183' with 'main' (locally in my dev workspace), all STs have passed.
So, this change is ready to be merged in 'FaultTolerence' branch.

Note: 'FaultTolerence' branch has to be re-based with 'main' in a separate commit.

Signed-off-by: Dattaprasad <dattaprasad.govekar@seagate.com>