### PR TITLE
EOS-19428: 's3_setup reset' fails in miniprovisioner setup.

### DIFF
--- a/scripts/provisioning/templates/s3.reset.tmpl.1-node
+++ b/scripts/provisioning/templates/s3.reset.tmpl.1-node
@@ -19,6 +19,9 @@
 cortx:
   software:
     openldap:
+      root:
+        user: "admin"
+        secret: "TMPL_ROOT_SECRET_KEY"
       sgiam:
         user: "sgiamadmin"
         secret: "TMPL_SGIAM_SECRET_KEY"

--- a/scripts/provisioning/templates/s3.reset.tmpl.1-node.sample
+++ b/scripts/provisioning/templates/s3.reset.tmpl.1-node.sample
@@ -19,6 +19,9 @@
 cortx:
   software:
     openldap:
+      root:
+        user: "admin"
+        secret: "gAAAAABgWFRxlYPfMDe3j03DlE1gDxsr8d7MJ5upQ2k8UC2fCU-kSWlf0tb5M3aBXOxNDnT8Rb_M2b0w9UOgw9CQH-fSKzn6sA=="
       sgiam:
         user: "sgiamadmin"
         secret: "gAAAAABgWFPz2w_t6IBVictZmgTCgBXn5V-oy2JUVtvZkJvHM5KaaZKXRwtz4YKYieIy8mVKF8PUaZ6WYJEttcsi2KDpLOk9Vg=="


### PR DESCRIPTION
Signed-off-by: Saumitra Kulkarni <saumitra.kulkarni@seagate.com>