### PR TITLE
[EOS-19517] Handling storage set count parsing on server node list

### DIFF
--- a/scripts/provisioning/configcmd.py
+++ b/scripts/provisioning/configcmd.py
@@ -187,7 +187,8 @@ class ConfigCmd(SetupCmd):
       if type(server_nodes_list) is str:
         # list is stored as string in the confstore file
         server_nodes_list = literal_eval(server_nodes_list)
-        srv_count += len(server_nodes_list)
+
+      srv_count += len(server_nodes_list)
       index += 1
     sys.stdout.write(f"Server node count : {srv_count}\n")
     # Partition count should be ( number of hosts * 2 )


### PR DESCRIPTION
In single node deployment , we saw issue where server node count is not handled properly ..
hence added this logic to fix this issue .
verified on single node deployment by manually updating the config file.

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>