### PR TITLE
[EOS-19178] S3Test rpm integration with CI-CD Miniprovisioning Job

### DIFF
--- a/rpms/s3test/s3test.spec
+++ b/rpms/s3test/s3test.spec
@@ -35,7 +35,6 @@ Prefix:     %{_prefix}
 BuildArch:  noarch
 Vendor:     Seagate
 
-Requires:  cortx-s3server
 Requires:  cortx-s3iamcli
 Requires:  s3cmd
 

--- a/scripts/provisioning/s3setup_prereqs.json
+++ b/scripts/provisioning/s3setup_prereqs.json
@@ -54,7 +54,7 @@
   },
   "test" :
   {
-    "rpms": ["openldap-servers", "openldap-clients", "haproxy", "cortx-motr", "python36-ldap"],
+    "rpms": ["openldap-servers", "openldap-clients", "s3cmd", "s3iamcli"],
     "pip3s": ["s3confstore", "cryptography", "s3cipher"]
   }
 }

--- a/scripts/provisioning/testcmd.py
+++ b/scripts/provisioning/testcmd.py
@@ -44,7 +44,6 @@ class TestCmd(SetupCmd):
   def process(self):
     """Main processing function."""
     #TODO: remove the return in next sprint
-    return
     sys.stdout.write(f"Processing {self.name} {self.url}\n")
     self.phase_prereqs_validate(self.name)
 

--- a/scripts/s3-sanity/s3-sanity-test.sh
+++ b/scripts/s3-sanity/s3-sanity-test.sh
@@ -211,7 +211,7 @@ fi
 echo "*** S3 Sanity tests start ***"
 
 echo "ldapsearch test starts ***"
-cmd_out=$(ldapsearch -b "o=s3-background-delete-svc,ou=accounts,dc=s3,dc=seagate,dc=com" -x -w $ldappasswd -D "cn=sgiamadmin,dc=seagate,dc=com" -H ldap://) || echo ""
+cmd_out=$(ldapsearch -b "o=s3-background-delete-svc,ou=accounts,dc=s3,dc=seagate,dc=com" -x -w $ldappasswd -D "cn=sgiamadmin,dc=seagate,dc=com" -H ldap://"$end_point") || echo ""
 if [[ $cmd_out == *"No such object"* ]];then
   die_with_error "***** S3: SANITY ldapsearch TESTS COMPLETED WITH FAILURE, failed to find s3background delete account!*****"
 fi


### PR DESCRIPTION
# Change Summary
## Problem Statement/Description
_[EOS-19178](https://jts.seagate.com/browse/EOS-19178):_
_Integrate S3TestRpm with Miniprovisioning Job such that sanity is successfully executed._

## Solution Overview

1. Removed dependency on cortx-s3server of cortx-s3-test rpm.
2. Removed unnecessary rpms from prerequisites json for test phase.
3. ldapsearch in sanity script now needs an endpoint parameter, so that it can work from another machine.
4. Removed return statement from testcmd.py file, and now it invokes sanity script.

## Unit Test Cases

### Case 1:
**Miniprovisioning job should install cortx-s3-test rpm, set appropriate parameter in template file and invoke s3_setup.
s3_setup inturn invokes sanity script. Sanity script should return success.**

<details>
  <summary>Output of Case 1</summary>

[Full Log](http://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/Mini-Provisioning/job/cortx-s3server/831)


> 15:37:55  TASK [s3server : [ Validate ] : Install s3iamcli RPM] **************************
> 15:38:08  changed: [srvnode-1] => changed=true 
> 15:38:08    cmd: |-
> 15:38:08      if [[  "$(yum list available | grep cortx-s3iamcli)" ]]; then
> 15:38:08        echo "Installing cortx-s3iamcli cortx-s3-test rpm from build repo"
> 15:38:08        yum install -y --nogpgcheck cortx-s3iamcli cortx-s3-test
> 15:38:08      else
> 15:38:08        echo "Installing cortx-s3iamcli rpm from last successful main repo"
> 15:38:08        yum install -y --nogpgcheck http://cortx-storage.colo.seagate.com/releases/cortx/github/main/centos-7.8.2003/last_successful//$(curl -s http://cortx-storage.colo.seagate.com/releases/cortx/github/main/centos-7.8.2003/last_successful/ | grep cortx-s3iamcli | grep -v cortx-s3iamcli-devel | cut -d'"' -f2)
> 15:38:08        yum install -y --nogpgcheck http://cortx-storage.colo.seagate.com/releases/cortx/github/main/centos-7.8.2003/last_successful//$(curl -s http://cortx-storage.colo.seagate.com/releases/cortx/github/main/centos-7.8.2003/last_successful/ | grep cortx-s3-test | cut -d'"' -f2)
> 15:38:08      fi
> 15:38:08    delta: '0:00:11.663753'
> 15:38:08    end: '2021-04-16 04:08:07.935764'
> 15:38:08    rc: 0
> 15:38:08    start: '2021-04-16 04:07:56.272011'
> 15:38:08    stderr: ''
> 15:38:08    stderr_lines: <omitted>
> 15:38:08    stdout: |-
> 15:38:08      Installing cortx-s3iamcli cortx-s3-test rpm from build repo
> 15:38:08      Loaded plugins: fastestmirror, product-id, search-disabled-repos, subscription-
> 15:38:08                    : manager
> 15:38:08      Loading mirror speeds from cached hostfile
> 15:38:08      Resolving Dependencies
> 15:38:08      --> Running transaction check
> 15:38:08      ---> Package cortx-s3-test.noarch 0:2.0.0-831_git4f8a20b will be installed
> 15:38:08      --> Processing Dependency: s3cmd for package: cortx-s3-test-2.0.0-831_git4f8a20b.noarch
> 15:38:08      ---> Package cortx-s3iamcli.noarch 0:2.0.0-831_git4f8a20b will be installed
> 15:38:08      --> Processing Dependency: python36-xmltodict >= 0.9.0 for package: cortx-s3iamcli-2.0.0-831_git4f8a20b.noarch
> 15:38:08      --> Processing Dependency: python36-s3transfer >= 0.1.10 for package: cortx-s3iamcli-2.0.0-831_git4f8a20b.noarch
> 15:38:08      --> Processing Dependency: python36-jmespath >= 0.7.1 for package: cortx-s3iamcli-2.0.0-831_git4f8a20b.noarch
> 15:38:08      --> Processing Dependency: python36-botocore >= 1.5.0 for package: cortx-s3iamcli-2.0.0-831_git4f8a20b.noarch
> 15:38:08      --> Processing Dependency: python36-boto3 >= 1.4.6 for package: cortx-s3iamcli-2.0.0-831_git4f8a20b.noarch
> 15:38:08      --> Running transaction check
> 15:38:08      ---> Package python36-boto3.noarch 0:1.4.6-1.el7 will be installed
> 15:38:08      ---> Package python36-botocore.noarch 0:1.6.0-1.el7 will be installed
> 15:38:08      --> Processing Dependency: python36-docutils >= 0.10 for package: python36-botocore-1.6.0-1.el7.noarch
> 15:38:08      --> Processing Dependency: python36-dateutil >= 2.1 for package: python36-botocore-1.6.0-1.el7.noarch
> 15:38:08      ---> Package python36-jmespath.noarch 0:0.9.4-2.el7 will be installed
> 15:38:08      ---> Package python36-s3transfer.noarch 0:0.1.10-1.el7 will be installed
> 15:38:08      ---> Package python36-xmltodict.noarch 0:0.9.0-2.el7 will be installed
> 15:38:08      ---> Package s3cmd.noarch 0:2.1.0-1.el7 will be installed
> 15:38:08      --> Running transaction check
> 15:38:08      ---> Package python36-dateutil.noarch 1:2.4.2-5.el7 will be installed
> 15:38:08      ---> Package python36-docutils.noarch 0:0.14-1.el7 will be installed
> 15:38:08      --> Finished Dependency Resolution
> 15:38:08    
> 15:38:08      Dependencies Resolved
> 15:38:08    
> 15:38:08      ================================================================================
> 15:38:08       Package              Arch    Version                  Repository          Size
> 15:38:08      ================================================================================
> 15:38:08      Installing:
> 15:38:08       cortx-s3-test        noarch  2.0.0-831_git4f8a20b     cortx-rpm          8.7 k
> 15:38:08       cortx-s3iamcli       noarch  2.0.0-831_git4f8a20b     cortx-rpm           26 k
> 15:38:08      Installing for dependencies:
> 15:38:08       python36-boto3       noarch  1.4.6-1.el7              3rd-party          133 k
> 15:38:08       python36-botocore    noarch  1.6.0-1.el7              3rd-party          2.5 M
> 15:38:08       python36-dateutil    noarch  1:2.4.2-5.el7            3rd-party           81 k
> 15:38:08       python36-docutils    noarch  0.14-1.el7               3rd-party          880 k
> 15:38:08       python36-jmespath    noarch  0.9.4-2.el7              EOS_EPEL-7_EPEL-7   42 k
> 15:38:08       python36-s3transfer  noarch  0.1.10-1.el7             3rd-party           82 k
> 15:38:08       python36-xmltodict   noarch  0.9.0-2.el7              EOS_EPEL-7_EPEL-7   16 k
> 15:38:08       s3cmd                noarch  2.1.0-1.el7              EOS_EPEL-7_EPEL-7  194 k
> 15:38:08    
> 15:38:08      Transaction Summary
> 15:38:08      ================================================================================
> 15:38:08      Install  2 Packages (+8 Dependent packages)
> 15:38:08    
> 15:38:08      Total download size: 3.9 M
> 15:38:08      Installed size: 33 M
> 15:38:08      Downloading packages:
> 15:38:08      --------------------------------------------------------------------------------
> 15:38:08      Total                                              9.3 MB/s | 3.9 MB  00:00
> 15:38:08      Running transaction check
> 15:38:08      Running transaction test
> 15:38:08      Transaction test succeeded
> 15:38:08      Running transaction
> 15:38:08        Installing : python36-jmespath-0.9.4-2.el7.noarch                        1/10
> 15:38:08        Installing : s3cmd-2.1.0-1.el7.noarch                                    2/10
> 15:38:08        Installing : 1:python36-dateutil-2.4.2-5.el7.noarch                      3/10
> 15:38:08        Installing : python36-xmltodict-0.9.0-2.el7.noarch                       4/10
> 15:38:08        Installing : python36-docutils-0.14-1.el7.noarch                         5/10
> 15:38:08        Installing : python36-botocore-1.6.0-1.el7.noarch                        6/10
> 15:38:08        Installing : python36-s3transfer-0.1.10-1.el7.noarch                     7/10
> 15:38:08        Installing : python36-boto3-1.4.6-1.el7.noarch                           8/10
> 15:38:08        Installing : cortx-s3iamcli-2.0.0-831_git4f8a20b.noarch                  9/10
> 15:38:08        Installing : cortx-s3-test-2.0.0-831_git4f8a20b.noarch                  10/10
> 15:38:08      Loaded plugins: fastestmirror, product-id, subscription-manager
> 15:38:08        Verifying  : python36-docutils-0.14-1.el7.noarch                         1/10
> 15:38:08        Verifying  : python36-jmespath-0.9.4-2.el7.noarch                        2/10
> 15:38:08        Verifying  : python36-s3transfer-0.1.10-1.el7.noarch                     3/10
> 15:38:08        Verifying  : python36-boto3-1.4.6-1.el7.noarch                           4/10
> 15:38:08        Verifying  : cortx-s3-test-2.0.0-831_git4f8a20b.noarch                   5/10
> 15:38:08        Verifying  : python36-xmltodict-0.9.0-2.el7.noarch                       6/10
> 15:38:08        Verifying  : 1:python36-dateutil-2.4.2-5.el7.noarch                      7/10
> 15:38:08        Verifying  : python36-botocore-1.6.0-1.el7.noarch                        8/10
> 15:38:08        Verifying  : s3cmd-2.1.0-1.el7.noarch                                    9/10
> 15:38:08        Verifying  : cortx-s3iamcli-2.0.0-831_git4f8a20b.noarch                 10/10
> 15:38:08    
> 15:38:08      Installed:
> 15:38:08        cortx-s3-test.noarch 0:2.0.0-831_git4f8a20b
> 15:38:08        cortx-s3iamcli.noarch 0:2.0.0-831_git4f8a20b
> 15:38:08    
> 15:38:08      Dependency Installed:
> 15:38:08        python36-boto3.noarch 0:1.4.6-1.el7
> 15:38:08        python36-botocore.noarch 0:1.6.0-1.el7
> 15:38:08        python36-dateutil.noarch 1:2.4.2-5.el7
> 15:38:08        python36-docutils.noarch 0:0.14-1.el7
> 15:38:08        python36-jmespath.noarch 0:0.9.4-2.el7
> 15:38:08        python36-s3transfer.noarch 0:0.1.10-1.el7
> 15:38:08        python36-xmltodict.noarch 0:0.9.0-2.el7
> 15:38:08        s3cmd.noarch 0:2.1.0-1.el7
> 15:38:08    
> 15:38:08      Complete!
> 15:38:08    stdout_lines: <omitted>
> 15:38:08  
> 15:38:08  TASK [s3server : [ Validate ] : S3 Sanity Test] ********************************
> 15:38:16  changed: [srvnode-1] => changed=true 
> 15:38:16    cmd: /opt/seagate/cortx/s3/bin/s3_setup test --config "yaml:///opt/seagate/cortx/s3/conf/s3.test.tmpl.1-node"
> 15:38:16    delta: '0:00:08.532194'
> 15:38:16    end: '2021-04-16 04:08:16.865268'
> 15:38:16    failed_when_result: false
> 15:38:16    rc: 0
> 15:38:16    start: '2021-04-16 04:08:08.333074'
> 15:38:16    stderr: |-
> 15:38:16      /usr/local/lib64/python3.6/site-packages/cryptography/hazmat/backends/openssl/hmac.py:59: UserWarning: implicit cast from 'char *' to a different pointer type: will be forbidden in the future (check that the types are as you expect; use an explicit ffi.cast() if they are correct)
> 15:38:16        res = self._backend._lib.HMAC_Update(self._ctx, data_ptr, len(data))
> 15:38:16      /usr/local/lib64/python3.6/site-packages/cryptography/hazmat/backends/openssl/ciphers.py:114: UserWarning: implicit cast from 'char *' to a different pointer type: will be forbidden in the future (check that the types are as you expect; use an explicit ffi.cast() if they are correct)
> 15:38:16        operation
> 15:38:16      /usr/local/lib64/python3.6/site-packages/cryptography/hazmat/backends/openssl/ciphers.py:140: UserWarning: implicit cast from 'char *' to a different pointer type: will be forbidden in the future (check that the types are as you expect; use an explicit ffi.cast() if they are correct)
> 15:38:16        self._backend._ffi.from_buffer(data), len(data)
> 15:38:16    stderr_lines: <omitted>
> 15:38:16    stdout: |-
> 15:38:16      Processing test yaml:///opt/seagate/cortx/s3/conf/s3.test.tmpl.1-node
> 15:38:16      Validations running from /opt/seagate/cortx/s3/mini-prov/s3setup_prereqs.json
> 15:38:16      Endpoint fqdn s3.seagate.com
> 15:38:16      ['/opt/seagate/cortx/s3/scripts/s3-sanity-test.sh', '-p', 'seagate2', '-e', 's3.seagate.com']:b"Check s3iamcli...OK, S3IAMCLI tests are enabled.\nCheck S3CMD...OK, S3CMD data path tests are enabled.\nusing s3endpoint s3.seagate.com\n/****/.sgs3iamcli/config.yaml\n\nSanity Account doesn't exist for cleanup\n*** S3 Sanity tests start ***\nldapsearch test starts ***\nldapsearch TESTS SUCCESSFULLY COMPLETED\nS3IAMCLI tests start\nCreate Account\nUserId = AIDA7BFE520768F1478FB, ARN = arn:aws:iam::994255163361:user/SanityUserToDeleteAfterUse, Path = /\nS3CMD tests start\nCreate bucket - 'sanitybucket': \nBucket 's3://sanitybucket/' created\nUpload '/tmp/SanityObjectToDeleteAfterUse.input35895' to 'sanitybucket': \nupload: '/tmp/SanityObjectToDeleteAfterUse.input35895' -> 's3://sanitybucket/SanityObjectToDeleteAfterUse' (5000000 bytes in 0.2 seconds, 25.47 MB/s) [1 of 1]\nList uploaded SanityObjectToDeleteAfterUse in 'sanitybucket': \n2021-04-16 10:08      5000000  s3://sanitybucket/SanityObjectToDeleteAfterUse\nDownload 'SanityObjectToDeleteAfterUse' from 'sanitybucket': \ndownload: 's3://sanitybucket/SanityObjectToDeleteAfterUse' -> '/tmp/SanityObjectToDeleteAfterUse.out35895' (5000000 bytes in 0.1 seconds, 73.39 MB/s)\nData integrity check: \nPassed.\nDelete 'SanityObjectToDeleteAfterUse' from 'sanitybucket': \ndelete: 's3://sanitybucket/SanityObjectToDeleteAfterUse'\nDelete bucket - 'sanitybucket': \nBucket 's3://sanitybucket/' removed\nS3: S3CMD SANITY DATA TESTS SUCCESSFULLY COMPLETED\nDelete User - 'SanityUserToDeleteAfterUse': \nUser deleted.\nDelete Account - 'SanityAccountToDeleteAfterUse': \nAccount deleted successfully.\nS3: SANITY IAMCLI TESTS SUCCESSFULLY COMPLETED\n/****/.sgs3iamcli/config.yaml\n/tmp/.s3cfg\n/tmp/SanityObjectToDeleteAfterUse.input35895\n/tmp/SanityObjectToDeleteAfterUse.out35895\n*** S3: SANITY ALL TESTS SUCCESSFULLY COMPLETED ***\n":b"1+0 records in\n1+0 records out\n5000000 bytes (5.0 MB) copied, 0.041663 s, 120 MB/s\nINFO: No cache file found, creating it.\nINFO: Compiling list of local files...\nINFO: Running stat() and reading/calculating MD5 values on 1 files, this may take some time...\nINFO: Summary: 1 local files to upload\nINFO: Sending file '/tmp/SanityObjectToDeleteAfterUse.input35895', please wait...\nINFO: Summary: 1 remote files to download\nINFO: Receiving file '/tmp/SanityObjectToDeleteAfterUse.out35895', please wait...\nINFO: Summary: 1 remote files to delete\n":0
> 15:38:16      PASS: S3-Sanity test passed.
> 15:38:16    stdout_lines: <omitted>

</details>