### PR TITLE
EOS-19622 : s3_setup needs to verify values of keys in argument file.

### DIFF
--- a/scripts/ldap/replication/setupReplicationScript.sh
+++ b/scripts/ldap/replication/setupReplicationScript.sh
@@ -54,7 +54,7 @@ checkHostValidity()
         if [ "$isValid" -le 1 ]
         then
             echo "ERROR: $host is either invalid or not reachable."
-            exit
+            exit 1
         else
             echo "INFO: $host is valid and reachable."
         fi

--- a/scripts/provisioning/setupcmd.py
+++ b/scripts/provisioning/setupcmd.py
@@ -176,6 +176,17 @@ class SetupCmd(object):
     except Exception as e:
       raise S3PROVError(f'ERROR: {phase_name} prereqs validations failed, exception: {e} \n')
 
+  def key_value_verify(self, key: str):
+    """Verify if there exists a corresponding value for given key."""
+    # Once a key from yardstick file has found a
+    # matching pair in argument file, the value
+    # of that key from argument file needs to be
+    # verified. It should be neither none, empty
+    # nor any undesirable value.
+    value = self.get_confvalue(key)
+    if not value:
+      raise Exception(f'Empty value for key : {key}')
+
   def extract_yardstick_list(self, phase_name: str):
     """Extract keylist to be used as yardstick for validating keys of each phase."""
     # The s3 prov config file has below pairs :
@@ -325,6 +336,8 @@ class SetupCmd(object):
                 elif key_x != key_y:
                   break
                 key_match_found = True
+              if key_match_found:
+                self.key_value_verify(key_arg)
         if key_match_found is False:
           list_match_found = False
           break

--- a/scripts/provisioning/setupcmd.py
+++ b/scripts/provisioning/setupcmd.py
@@ -28,6 +28,7 @@ from s3cipher.cortx_s3_cipher import CortxS3Cipher
 from cortx.utils.validator.v_pkg import PkgV
 from cortx.utils.validator.v_service import ServiceV
 from cortx.utils.validator.v_path import PathV
+from cortx.utils.validator.v_network import NetworkV
 from cortx.utils.process import SimpleProcess
 
 class S3PROVError(Exception):
@@ -186,6 +187,12 @@ class SetupCmd(object):
     value = self.get_confvalue(key)
     if not value:
       raise Exception(f'Empty value for key : {key}')
+    else:
+      address_token = ["hostname", "public_fqdn", "private_fqdn"]
+      for token in address_token:
+        if key.find(token) != -1:
+          NetworkV().validate('connectivity',[value])
+          break
 
   def extract_yardstick_list(self, phase_name: str):
     """Extract keylist to be used as yardstick for validating keys of each phase."""


### PR DESCRIPTION
New handler has been added with initial check for handling
None-type or Empty strings. This would be further enhanced.

Files modified:
   scripts/provisioning/setupcmd.py

Testing :
  `UT with no value and empty value keys in argument file is throwing error as expected.`

Signed-off-by: Mohammed Shahid <mohammed.shahid@seagate.com>