### PR TITLE
EOS-19572:Auth: account/iamuser creation limit config fixes

### DIFF
--- a/auth/server/src/main/java/com/seagates3/authserver/AuthServer.java
+++ b/auth/server/src/main/java/com/seagates3/authserver/AuthServer.java
@@ -138,6 +138,17 @@ class AuthServer {
             System.exit(1);
           }
 
+          int maxldapsearchlimit =
+              AuthServerConfig.getLdapSearchResultsSizeLimit();
+          if (maxldapsearchlimit < AuthServerConfig.getMaxAccountLimit() ||
+              maxldapsearchlimit < AuthServerConfig.getMaxIAMUserLimit()) {
+            logger.error(
+                "Invalid configuration found in authserver.properties file!!!" +
+                "\n" +
+                "ldapSearchResultSizeLimit value must be greater than or " +
+                "equals to maxAccountLimit & maxIAMUserLimit value");
+            System.exit(1);
+          }
           SSLContextProvider.init();
           IAMResourceMapper.init();
           DAODispatcher.init();

--- a/auth/server/src/main/java/com/seagates3/controller/AccountController.java
+++ b/auth/server/src/main/java/com/seagates3/controller/AccountController.java
@@ -108,7 +108,7 @@ public class AccountController extends AbstractController {
         int maxAllowedLdapResults = maxAccountLimit + internalAccountCount;
 
         try {
-          accountCount = accountDao.getTotalCountOfAccounts();
+          accountCount = getTotalCountOfAccounts();
 
           if (accountCount >= maxAllowedLdapResults) {
             LOGGER.error("Maximum allowed Account limit has exceeded (i.e." +
@@ -197,7 +197,7 @@ public class AccountController extends AbstractController {
         // if account limit creation exceeded due to multiple thread/multiple
         // node create() API calls.
         try {
-          accountCount = accountDao.getTotalCountOfAccounts();
+          accountCount = getTotalCountOfAccounts();
         }
         catch (DataAccessException ex) {
           LOGGER.error("failed to get total count of accounts from ldap :" +
@@ -223,9 +223,21 @@ public class AccountController extends AbstractController {
     }
 
     /**
-     * Generate canonical id and check if its unique in ldap
+     * Fetch total account count present in ldap
+     * @return count of accounts
      * @throws DataAccessException
      */
+   private
+    int getTotalCountOfAccounts() throws DataAccessException {
+      Account[] accounts;
+      accounts = accountDao.findAll();
+      return accounts.length;
+    }
+
+    /**
+ * Generate canonical id and check if its unique in ldap
+ * @throws DataAccessException
+ */
    private
     String generateUniqueCanonicalId() throws DataAccessException {
       Account account;

--- a/auth/server/src/main/java/com/seagates3/dao/AccountDAO.java
+++ b/auth/server/src/main/java/com/seagates3/dao/AccountDAO.java
@@ -68,13 +68,6 @@ public interface AccountDAO {
     public
      Account findByEmailAddress(String emailAddress) throws DataAccessException;
 
-     /* Get total count of accounts present in ldap
-      *  @return int - Total count of accounts
-      *  @throws DataAccessException
-      */
-    public
-     int getTotalCountOfAccounts() throws DataAccessException;
-
      /**
       * Delete account entry internally from account
       * @param account

--- a/auth/server/src/main/java/com/seagates3/dao/UserDAO.java
+++ b/auth/server/src/main/java/com/seagates3/dao/UserDAO.java
@@ -59,14 +59,6 @@ public interface UserDAO {
     public
      User findByArn(String arn) throws DataAccessException;
 
-     /* Get total count of users present in ldap
-     *  @return int - Total count of users
-     *  @throws DataAccessException
-     */
-    public
-     int getTotalCountOfUsers(String accountName,
-                              String pathPrefix) throws DataAccessException;
-
      /**
       * Delete user from LDAP silently.
       * @param user

--- a/auth/server/src/main/java/com/seagates3/dao/ldap/AccountImpl.java
+++ b/auth/server/src/main/java/com/seagates3/dao/ldap/AccountImpl.java
@@ -546,57 +546,6 @@ public class AccountImpl implements AccountDAO {
         return account;
     }
 
-    /* Get total count of accounts present in ldap
-    *  @return int - Total count of accounts
-    *  @throws DataAccessException
-    */
-   public
-    int getTotalCountOfAccounts() throws DataAccessException {
-      LDAPSearchResults ldapResults;
-      /*
-       * search base: the starting point for search example:
-       * 'ou=accounts,dc=s3,dc=seagate,dc=com'
-       */
-      String baseDn =
-          String.format("%s=%s,%s", LDAPUtils.ORGANIZATIONAL_UNIT_NAME,
-                        LDAPUtils.ACCOUNT_OU, LDAPUtils.BASE_DN);
-      /*
-       * search filter: '(objectClass=account)'
-       */
-      String accountFilter = String.format("(%s=%s)", LDAPUtils.OBJECT_CLASS,
-                                           LDAPUtils.ACCOUNT_OBJECT_CLASS);
-      String[] attr = {LDAPUtils.ACCOUNT_ID};
-
-      LOGGER.debug("Searching baseDn: " + baseDn + " account filter: " +
-                   accountFilter);
-
-      try {
-        ldapResults = LDAPUtils.search(baseDn, LDAPConnection.SCOPE_SUB,
-                                       accountFilter, attr);
-        try {
-          // Added delay so that ldap entry count gets populated properly from
-          // ldap.
-          Thread.sleep(500);
-        }
-        catch (InterruptedException e) {
-          LOGGER.error("Delay failing to fetch account count from ldap- " + e);
-          Thread.currentThread().interrupt();
-        }
-
-        if (ldapResults != null) {
-          return ldapResults.getCount();
-        } else {
-          LOGGER.error("Failed to fetch total count of accounts.");
-          throw new DataAccessException(
-              "Failed to fetch total count of accounts.\n");
-        }
-      }
-      catch (LDAPException ex) {
-        LOGGER.error("Failed to fetch total count of accounts." + ex);
-        throw new DataAccessException(
-            "Failed to fetch total count of accounts.\n" + ex);
-      }
-    }
 
     /**
      * Delete account entry silently from ldap.

--- a/auth/server/src/main/java/com/seagates3/dao/ldap/UserImpl.java
+++ b/auth/server/src/main/java/com/seagates3/dao/ldap/UserImpl.java
@@ -520,55 +520,6 @@ public class UserImpl implements UserDAO {
      return user;
    }
 
-   @Override public int getTotalCountOfUsers(
-       String accountName, String pathPrefix) throws DataAccessException {
-     String[] attrs = {LDAPUtils.USER_ID};
-     String userBaseDN = String.format(
-         "%s=%s,%s=%s,%s=%s,%s", LDAPUtils.ORGANIZATIONAL_UNIT_NAME,
-         LDAPUtils.USER_OU, LDAPUtils.ORGANIZATIONAL_NAME, accountName,
-         LDAPUtils.ORGANIZATIONAL_UNIT_NAME, LDAPUtils.ACCOUNT_OU,
-         LDAPUtils.BASE_DN);
-     String filter =
-         String.format("(&(%s=%s*)(%s=%s))", LDAPUtils.PATH, pathPrefix,
-                       LDAPUtils.OBJECT_CLASS, LDAPUtils.IAMUSER_OBJECT_CLASS,
-                       LDAPUtils.IAMUSER_OBJECT_CLASS);
-
-     LDAPSearchResults ldapResults;
-
-     LOGGER.debug("Searching user base dn: " + userBaseDN);
-
-     try {
-       ldapResults = LDAPUtils.search(userBaseDN, LDAPConnection.SCOPE_SUB,
-                                      filter, attrs);
-       try {
-         // Added delay so that ldap entry count gets populated properly from
-         // ldap.
-         Thread.sleep(500);
-       }
-       catch (InterruptedException e) {
-         LOGGER.error("Delay failing to fetch total user count from ldap- " +
-                      e);
-         Thread.currentThread().interrupt();
-       }
-       if (ldapResults != null) {
-         return ldapResults.getCount();
-       } else {
-         LOGGER.error("Failed to find total users count of path prefix: " +
-                      pathPrefix + " account: " + accountName);
-         throw new DataAccessException(
-             "Failed to find total users count in account." + accountName +
-             "\n");
-       }
-     }
-     catch (LDAPException ex) {
-       LOGGER.error("Failed to find total users count of path prefix: " +
-                    pathPrefix + " account: " + accountName);
-       throw new DataAccessException(
-           "Failed to find total users count in account." + accountName + "\n" +
-           ex);
-     }
-   }
-
    @Override public void ldap_delete_user(User user)
        throws DataAccessException {
      String dn = String.format("%s=%s,%s=%s,%s=%s,%s=%s,%s", LDAPUtils.USER_ID,

--- a/auth/server/src/test/java/com/seagates3/controller/AccountControllerTest.java
+++ b/auth/server/src/test/java/com/seagates3/controller/AccountControllerTest.java
@@ -204,6 +204,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
             throws Exception {
         Mockito.when(accountDAO.find("s3test")).thenThrow(
                 new DataAccessException("failed to search account.\n"));
+        Mockito.doReturn(new Account[0]).when(accountDAO).findAll();
         final String expectedResponseBody =
             "<?xml version=\"1.0\" " +
             "encoding=\"UTF-8\" standalone=\"no\"?>" + "<ErrorResponse " +
@@ -227,7 +228,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
         account.setName("s3test");
 
         Mockito.when(accountDAO.find("s3test")).thenReturn(account);
-
+        Mockito.doReturn(new Account[1]).when(accountDAO).findAll();
         final String expectedResponseBody =
             "<?xml version=\"1.0\" " +
             "encoding=\"UTF-8\" standalone=\"no\"?>" + "<ErrorResponse " +
@@ -251,6 +252,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 
       Mockito.when(accountDAO.find("s3test")).thenReturn(account);
       Mockito.doReturn(account).when(accountDAO).findByCanonicalID("can1234");
+      Mockito.doReturn(new Account[0]).when(accountDAO).findAll();
 
       final String expectedResponseBody =
           "<?xml version=\"1.0\" " + "encoding=\"UTF-8\" standalone=\"no\"?>" +
@@ -273,6 +275,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
         account.setName("s3test");
 
         Mockito.doReturn(account).when(accountDAO).find("s3test");
+        Mockito.doReturn(new Account[0]).when(accountDAO).findAll();
         Mockito.doThrow(new DataAccessException("failed to add new account.\n"))
             .when(accountDAO)
             .save(account);
@@ -301,6 +304,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
         account.setName("s3test");
 
         Mockito.doReturn(account).when(accountDAO).find("s3test");
+        Mockito.doReturn(new Account[0]).when(accountDAO).findAll();
         Mockito.doNothing().when(accountDAO).save(any(Account.class));
         Mockito.doThrow(new DataAccessException("failed to save new user.\n"))
                 .when(userDAO).save(any(User.class));
@@ -328,6 +332,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
         Account account = new Account();
         account.setName("s3test");
 
+        Mockito.doReturn(new Account[0]).when(accountDAO).findAll();
         Mockito.doReturn(account).when(accountDAO).find("s3test");
         Mockito.doNothing().when(accountDAO).save(any(Account.class));
         Mockito.doNothing().when(userDAO).save(any(User.class));
@@ -366,7 +371,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
         PowerMockito.doReturn("htuspscae/123")
             .when(KeyGenUtil.class, "generateSecretKey");
 
-        Mockito.doReturn(0).when(accountDAO).getTotalCountOfAccounts();
+        Mockito.doReturn(new Account[0]).when(accountDAO).findAll();
         Mockito.doReturn(account).when(accountDAO).find("s3test");
         Mockito.doNothing().when(accountDAO).save(any(Account.class));
         Mockito.doNothing().when(userDAO).save(any(User.class));

--- a/auth/server/src/test/java/com/seagates3/controller/UserControllerTest.java
+++ b/auth/server/src/test/java/com/seagates3/controller/UserControllerTest.java
@@ -215,6 +215,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 
         Mockito.when(userDAO.find("s3test", "s3testuser")).thenThrow(
                 new DataAccessException("failed to search user.\n"));
+        Mockito.doReturn(new User[0]).when(userDAO).findAll("s3test", "/");
 
         final String expectedResponseBody =
             "<?xml version=\"1.0\" " +
@@ -254,6 +255,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
         user.setId("AIDA5KZQJXPTROAIAKCKO");
 
         Mockito.when(userDAO.find("s3test", "s3testuser")).thenReturn(user);
+        Mockito.doReturn(new User[1]).when(userDAO).findAll("s3test", "/");
 
         final String expectedResponseBody =
             "<?xml version=\"1.0\" " +
@@ -291,6 +293,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
         user.setAccountName("s3test");
         user.setName("s3testuser");
 
+        Mockito.doReturn(new User[0]).when(userDAO).findAll("s3test", "/");
         Mockito.when(userDAO.find("s3test", "s3testuser")).thenReturn(user);
         Mockito.doThrow(new DataAccessException("failed to save new user.\n"))
                 .when(userDAO).save(user);
@@ -332,6 +335,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
         user.setName("s3testuser");
         user.setArn("arn:aws:iam::1:user/s3testuser");
 
+        Mockito.doReturn(new User[0]).when(userDAO).findAll("s3test", "/");
         Mockito.when(userDAO.find("s3test", "s3testuser")).thenReturn(user);
         Mockito.doNothing().when(userDAO).save(user);
 
@@ -391,6 +395,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
         userDAO = Mockito.mock(UserDAO.class);
         PowerMockito.doReturn(userDAO)
             .when(DAODispatcher.class, "getResourceDAO", DAOResource.USER);
+        Mockito.doReturn(new User[0]).when(userDAO).findAll("s3test", "/");
         userController = new UserController(requestor, requestBody);
         User user = new User();
         user.setAccountName("s3test");
@@ -427,6 +432,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
         user.setName("s3testuser");
         user.setArn("arn:aws:iam::1:user/s3testuser");
 
+        Mockito.doReturn(new User[0]).when(userDAO).findAll("s3test", "/test");
         Mockito.when(userDAO.find("s3test", "s3testuser")).thenReturn(user);
         Mockito.doNothing().when(userDAO).save(user);
 


### PR DESCRIPTION
1) In Authserver.properties file LdapSearchResultsSizeLimit value must be greater than or equals to maxAccountLimit & maxIAMUserLimit value 
2) for getTotalCount() api, use listall() method from DAO layer instead of calling from ldapUtils.java

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>