### PR TITLE
EOS-19564:Auth:Fix for Authserver LogLevel values

### DIFF
--- a/auth/resources/keystore.properties.sample
+++ b/auth/resources/keystore.properties.sample
@@ -24,14 +24,3 @@ s3KeyStorePassword=seagate
 s3KeyPassword=seagate
 s3AuthCertAlias=s3auth_pass
 s3CipherUtil=s3cipher generate_key --const_key cortx
-
-# Uncomment this to override logging config file.
-#
-# logConfigFile=<PATH TO CONFIG FILE>
-
-# Uncomment this to override log level.
-# Note - setting this will override the logging level of root logger.
-# If this option is set along with logConfigFile, the log level set in the
-# config file will be overridden.
-#
-logLevel=INFO


### PR DESCRIPTION
kesytore.properties does not required logger config which was causing conflicts for "logLevel" properteis with authserver.properties 
hence debug mode value was updated as INFO while loading authserver 
 Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>