### PR TITLE
EOS-19192: Extended metadata added to different index table

### DIFF
--- a/server/s3_object_action_base.cc
+++ b/server/s3_object_action_base.cc
@@ -113,11 +113,12 @@ void S3ObjectAction::fetch_object_info_success() {
   // If object is extended, create S3ObjectExtendedMetadata and load extended
   // entries.
   if (object_metadata->is_object_extended()) {
-    // Read the extended parts of the object
+    // Read the extended parts of the object from extended index table
     std::shared_ptr<S3ObjectExtendedMetadata> extended_obj_metadata =
         object_metadata_factory->create_object_ext_metadata_obj(
             request, request->get_bucket_name(), request->get_object_name(),
-            object_metadata->get_obj_version_key(), object_list_oid,
+            object_metadata->get_obj_version_key(),
+            bucket_metadata->get_extended_metadata_index_oid(),
             object_metadata->get_number_of_parts(),
             object_metadata->get_number_of_fragments());
     object_metadata->set_extended_object_metadata(extended_obj_metadata);

--- a/server/s3_object_metadata.cc
+++ b/server/s3_object_metadata.cc
@@ -909,7 +909,7 @@ S3ObjectExtendedMetadata::S3ObjectExtendedMetadata(
   } else {
     mote_kv_writer_factory = std::make_shared<S3MotrKVSWriterFactory>();
   }
-  last_object = EXTENDED_METADATA_OBJECT_PREFIX + objectname;
+  last_object = objectname;
 }
 
 void S3ObjectExtendedMetadata::load(std::function<void(void)> on_success,
@@ -959,7 +959,7 @@ void S3ObjectExtendedMetadata::get_obj_ext_entries_successful() {
            kv.second.second.c_str());
     last_object = kv.first;
     // Check if fetched key starts with object prefix
-    std::string object_prefix = EXTENDED_METADATA_OBJECT_PREFIX + object_name;
+    std::string object_prefix = object_name;
     bool prefix_match = (kv.first.find(object_prefix) == 0) ? true : false;
     if (!prefix_match) {
       end_of_enumeration = true;
@@ -1118,7 +1118,7 @@ std::string S3ObjectExtendedMetadata::to_json() {
       std::vector<s3_part_frag_context> fragments;
       fragments = ext_objects[0];
       std::ostringstream buffer;
-      buffer << EXTENDED_METADATA_OBJECT_PREFIX << object_name
+      buffer << object_name
              << EXTENDED_METADATA_OBJECT_SEP << << frag_counter;
 
       root[buffer.str()] = ext_objects;
@@ -1127,7 +1127,7 @@ std::string S3ObjectExtendedMetadata::to_json() {
   } else {
     // This is multipart object
     for (const auto& ext_obj : ext_objects) {
-      std::string key = EXTENDED_METADATA_OBJECT_PREFIX + object_name +
+      std::string key = object_name +
                         EXTENDED_METADATA_OBJECT_SEP root[key] = ;
     }
   }
@@ -1156,8 +1156,7 @@ S3ObjectExtendedMetadata::get_kv_list_of_extended_entries() {
       std::string frag_field = "F" + std::to_string(frag_index);
       sskey.str("");
       sskey.clear();
-      sskey << EXTENDED_METADATA_OBJECT_PREFIX << object_name
-            << EXTENDED_METADATA_OBJECT_SEP << version_id;
+      sskey << object_name << EXTENDED_METADATA_OBJECT_SEP << version_id;
 
       if (part_field.empty()) {
         sskey << EXTENDED_METADATA_OBJECT_SEP << frag_field;

--- a/server/s3_object_metadata.h
+++ b/server/s3_object_metadata.h
@@ -35,13 +35,6 @@
 #include "s3_request_object.h"
 #include "s3_timer.h"
 
-// Object list index table is divided into objects and their extended parts, if
-// any.
-// All extended object entries start/prefix with special character "~",
-// to make them at the bottom of object list index table.
-// This special character is chosen, as it is not allowed in S3 object name and
-// also higher in the lexographical order.
-#define EXTENDED_METADATA_OBJECT_PREFIX "~"
 #define EXTENDED_METADATA_OBJECT_SEP "|"
 
 enum class S3ObjectMetadataState {

--- a/server/s3_put_object_action.cc
+++ b/server/s3_put_object_action.cc
@@ -353,7 +353,8 @@ void S3PutObjectAction::create_object_successful() {
       std::shared_ptr<S3ObjectExtendedMetadata> new_ext_object_metadata =
           object_metadata_factory->create_object_ext_metadata_obj(
               request, request->get_bucket_name(), request->get_object_name(),
-              new_object_metadata->get_obj_version_key(), object_list_oid);
+              new_object_metadata->get_obj_version_key(),
+              bucket_metadata->get_extended_metadata_index_oid());
       new_object_metadata->set_extended_object_metadata(
           new_ext_object_metadata);
       s3_log(S3_LOG_DEBUG, stripped_request_id,

--- a/st/clitests/fault_tolerence_spec.py
+++ b/st/clitests/fault_tolerence_spec.py
@@ -81,11 +81,11 @@ upload_MD5_hash = aws_test.fileMD5
 S3fiTest('s3cmd disable Fault injection').disable_fi("motr_obj_write_fail").execute_test().command_is_successful()
 
 # ********** Validate uploaded object using S3 metadata information **********
-# Validate FNo=5 and size of each fragment (except the last fragment) is 1MB
+# Validate FNo=4 and size of each fragment (except the last fragment) is 1MB
 obj_md, frag_info = s3kvs.fetch_object_info("s3faultbucket", "4_7MB")
 assert obj_md is None or not hasattr(obj_md, 'FNo'), "Error! Object metadata or FNo in metadata is missing"
 assert obj_md["FNo"] == 4, "Error! Fragment count (FNo) should be 4"
-assert frag_info is None or len(frag_info) == 4, "Error! No fragments found or count does not match 4"
+assert frag_info is not None and len(frag_info) == 4, "Error! No fragments found or count does not match 4"
 
 # Validate object by downloading it and comparing it's MD5 with the uploaded object
 aws_test = AwsTest('Aws can download fragmented object').get_object("s3faultbucket", "4_7MB")\

--- a/st/clitests/s3kvs.py
+++ b/st/clitests/s3kvs.py
@@ -151,6 +151,20 @@ def _extract_oid(json_keyval, bucket=True):
     oid_val.set_oid(hex(int_oid_hi), hex(int_oid_lo))
     return oid_val
 
+# Extract oid of extended metadata index from bucket record
+def _extract_extended_md_oid(json_keyval):
+    keyval = json.loads(json_keyval)
+    sbyteorder = sys.byteorder
+    oid_val = S3OID()
+    string_oid = keyval['extended_metadata_index_oid']
+    oid_list = string_oid.split("-")
+    dec_string_oid_hi = base64.b64decode(oid_list[0])
+    dec_string_oid_lo = base64.b64decode(oid_list[1])
+
+    int_oid_hi = int.from_bytes(dec_string_oid_hi,byteorder=sbyteorder)
+    int_oid_lo = int.from_bytes(dec_string_oid_lo,byteorder=sbyteorder)
+    oid_val.set_oid(hex(int_oid_hi), hex(int_oid_lo))
+    return oid_val
 
 # Fetch leak record from probable delete index corresponding to key 'rec_key'
 def _fetch_leak_record(rec_key):
@@ -225,15 +239,15 @@ def fetch_object_info(bucket_name, key, deep_frag_check = False):
     if (bucket_record is None or (len(bucket_record) == 0)):
         return (None, None)
     file_record = _fetch_object_info(key, bucket_record)
-    print ("Object record:\n" + str(file_record))
     if file_record is None or str(file_record) == "":
         if not deep_frag_check:
             return (None, None)
         else:
-            # Though main object md is not available, attempt to check fragments
+            # Though main object md is not available, attempt to check if
+            # there is any stale fragment, indicating inconsistency.
             frag_key = "~" + key
             bucket_json_keyval = _find_keyval_json(bucket_record)
-            oli_oid_decoded = _extract_oid(bucket_json_keyval, bucket=False)
+            oli_oid_decoded = _extract_extended_md_oid(bucket_json_keyval)
             frag_list = fetch_fragment_info(frag_key, oli_oid_decoded, 1)
             frag_kv_mp = extract_keys_values(frag_list)
             return (None, frag_kv_mp)
@@ -243,9 +257,9 @@ def fetch_object_info(bucket_name, key, deep_frag_check = False):
     # Check if any fragments on main object
     if "FNo" in file_keyval:
         # Read fragments
-        frag_key = "~" + key
+        frag_key = key
         bucket_json_keyval = _find_keyval_json(bucket_record)
-        oli_oid_decoded = _extract_oid(bucket_json_keyval, bucket=False)
+        oli_oid_decoded = _extract_extended_md_oid(bucket_json_keyval)
         frag_list = fetch_fragment_info(frag_key, oli_oid_decoded, file_keyval['FNo'])
         frag_kv_mp = extract_keys_values(frag_list)
         obj_info = (file_keyval, frag_kv_mp)


### PR DESCRIPTION
- Removed prefix delimiter '~' from extended/fragmented entry key names
- Extended metadata goes in extended metadata index.
- Updated fault tolerance spec file

Signed-off-by: Dattaprasad <dattaprasad.govekar@seagate.com>