### PR TITLE
EOS-19636:  Uploading object with 2KB metadata size fails

### DIFF
--- a/resources/s3_error_messages.json
+++ b/resources/s3_error_messages.json
@@ -115,6 +115,10 @@
     "Description": "The request could not be understood by the server due to malformed syntax. The client should not repeat the request without modifications.",
     "httpcode": 400
   },
+  "MetadataTooLarge": {
+    "Description": "Your metadata headers exceed the maximum allowed metadata size",
+    "httpcode": 400
+  },
   "RequestTimeout": {
     "Description": "The client did not produce a request within the time that the server was prepared to wait.",
     "httpcode": 400

--- a/server/request_object.cc
+++ b/server/request_object.cc
@@ -46,7 +46,10 @@ extern "C" int consume_header(evhtp_kv_t* kvobj, void* arg) {
   if (kvobj->key != NULL) {
     request->header_size += strlen(kvobj->key);
     if (strncasecmp(kvobj->key, "x-amz-meta-", strlen("x-amz-meta-")) == 0) {
-      request->user_metadata_size += strlen(kvobj->key);
+      // subtracting the lenght of key 'x-amz-meta-' from the metadata size
+      // as this is added by S3server as an identifier for metadata
+      request->user_metadata_size +=
+          (strlen(kvobj->key) - strlen("x-amz-meta-"));
     }
   }
   if (kvobj->val != NULL) {

--- a/server/request_object.cc
+++ b/server/request_object.cc
@@ -50,8 +50,7 @@ extern "C" int consume_header(evhtp_kv_t* kvobj, void* arg) {
       // subtracting the length of key 'x-amz-meta-' from the metadata size
       // as this is added by S3server as an identifier for metadata
       request->user_metadata_size +=
-          (strnlen(kvobj->key, MAX_OBJECT_KEY_LENGTH) -
-           strnlen("x-amz-meta-", MAX_OBJECT_KEY_LENGTH));
+          (strlen(kvobj->key) - strlen("x-amz-meta-"));
     }
   }
   if (kvobj->val != NULL) {

--- a/server/request_object.cc
+++ b/server/request_object.cc
@@ -33,6 +33,7 @@
 #include "s3_stats.h"
 #include "s3_addb.h"
 #include "base64.h"
+#include "s3_action_base.h"
 
 extern S3Option* g_option_instance;
 
@@ -49,7 +50,8 @@ extern "C" int consume_header(evhtp_kv_t* kvobj, void* arg) {
       // subtracting the length of key 'x-amz-meta-' from the metadata size
       // as this is added by S3server as an identifier for metadata
       request->user_metadata_size +=
-          (strlen(kvobj->key) - strlen("x-amz-meta-"));
+          (strnlen(kvobj->key, MAX_OBJECT_KEY_LENGTH) -
+           strnlen("x-amz-meta-", MAX_OBJECT_KEY_LENGTH));
     }
   }
   if (kvobj->val != NULL) {

--- a/server/request_object.cc
+++ b/server/request_object.cc
@@ -46,7 +46,7 @@ extern "C" int consume_header(evhtp_kv_t* kvobj, void* arg) {
   if (kvobj->key != NULL) {
     request->header_size += strlen(kvobj->key);
     if (strncasecmp(kvobj->key, "x-amz-meta-", strlen("x-amz-meta-")) == 0) {
-      // subtracting the lenght of key 'x-amz-meta-' from the metadata size
+      // subtracting the length of key 'x-amz-meta-' from the metadata size
       // as this is added by S3server as an identifier for metadata
       request->user_metadata_size +=
           (strlen(kvobj->key) - strlen("x-amz-meta-"));

--- a/server/s3_put_chunk_upload_object_action.cc
+++ b/server/s3_put_chunk_upload_object_action.cc
@@ -311,7 +311,7 @@ void S3PutChunkUploadObjectAction::validate_put_chunk_request() {
              request->get_user_metadata_size() > MAX_USER_METADATA_SIZE) {
     s3_put_chunk_action_state =
         S3PutChunkUploadObjectActionState::validationFailed;
-    set_s3_error("BadRequest");
+    set_s3_error("MetadataTooLarge");
     send_response_to_s3_client();
   } else {
     next();

--- a/server/s3_put_multiobject_action.cc
+++ b/server/s3_put_multiobject_action.cc
@@ -129,7 +129,7 @@ void S3PutMultiObjectAction::check_part_details() {
     send_response_to_s3_client();
   } else if (request->get_header_size() > MAX_HEADER_SIZE ||
              request->get_user_metadata_size() > MAX_USER_METADATA_SIZE) {
-    set_s3_error("BadRequest");
+    set_s3_error("MetadataTooLarge");
     send_response_to_s3_client();
   } else if ((request->get_object_name()).length() > MAX_OBJECT_KEY_LENGTH) {
     set_s3_error("KeyTooLongError");

--- a/server/s3_put_multiobject_action.h
+++ b/server/s3_put_multiobject_action.h
@@ -204,6 +204,10 @@ class S3PutMultiObjectAction : public S3ObjectAction {
   FRIEND_TEST(S3PutMultipartObjectActionTestNoMockAuth,
               ValidateUserMetadataLengthNegativeCase);
   FRIEND_TEST(S3PutMultipartObjectActionTestNoMockAuth,
+              ValidateMetadataLengthBeyond8KNegativeCase);
+  FRIEND_TEST(S3PutMultipartObjectActionTestNoMockAuth,
+              ValidateUserMetadataLengthBeyond2KNegativeCase);
+  FRIEND_TEST(S3PutMultipartObjectActionTestNoMockAuth,
               ValidateMissingContentLength);
 };
 

--- a/server/s3_put_multiobject_action.h
+++ b/server/s3_put_multiobject_action.h
@@ -204,10 +204,6 @@ class S3PutMultiObjectAction : public S3ObjectAction {
   FRIEND_TEST(S3PutMultipartObjectActionTestNoMockAuth,
               ValidateUserMetadataLengthNegativeCase);
   FRIEND_TEST(S3PutMultipartObjectActionTestNoMockAuth,
-              ValidateMetadataLength8K);
-  FRIEND_TEST(S3PutMultipartObjectActionTestNoMockAuth,
-              ValidateUserMetadataLength2K);
-  FRIEND_TEST(S3PutMultipartObjectActionTestNoMockAuth,
               ValidateMissingContentLength);
 };
 

--- a/server/s3_put_multiobject_action.h
+++ b/server/s3_put_multiobject_action.h
@@ -204,9 +204,9 @@ class S3PutMultiObjectAction : public S3ObjectAction {
   FRIEND_TEST(S3PutMultipartObjectActionTestNoMockAuth,
               ValidateUserMetadataLengthNegativeCase);
   FRIEND_TEST(S3PutMultipartObjectActionTestNoMockAuth,
-              ValidateMetadataLengthBeyond8KNegativeCase);
+              ValidateMetadataLength8K);
   FRIEND_TEST(S3PutMultipartObjectActionTestNoMockAuth,
-              ValidateUserMetadataLengthBeyond2KNegativeCase);
+              ValidateUserMetadataLength2K);
   FRIEND_TEST(S3PutMultipartObjectActionTestNoMockAuth,
               ValidateMissingContentLength);
 };

--- a/server/s3_put_object_action.cc
+++ b/server/s3_put_object_action.cc
@@ -152,7 +152,7 @@ void S3PutObjectAction::validate_put_request() {
              request->get_user_metadata_size() > MAX_USER_METADATA_SIZE) {
 
     s3_put_action_state = S3PutObjectActionState::validationFailed;
-    set_s3_error("BadRequest");
+    set_s3_error("MetadataTooLarge");
     send_response_to_s3_client();
   } else if (!request->is_header_present("Content-Length")) {
     // 'Content-Length' header is required and missing

--- a/ut/s3_put_multiobject_action_test.cc
+++ b/ut/s3_put_multiobject_action_test.cc
@@ -338,7 +338,16 @@ TEST_F(S3PutMultipartObjectActionTestNoMockAuth,
        ValidateMetadataLengthNegativeCase) {
   EXPECT_CALL(*ptr_mock_request, get_header_size()).WillOnce(Return(9000));
   action_under_test->check_part_details();
-  EXPECT_STREQ("BadRequest", action_under_test->get_s3_error_code().c_str());
+  EXPECT_STREQ("MetadataTooLarge",
+               action_under_test->get_s3_error_code().c_str());
+}
+
+TEST_F(S3PutMultipartObjectActionTestNoMockAuth,
+       ValidateMetadataLengthBeyond8KNegativeCase) {
+  EXPECT_CALL(*ptr_mock_request, get_header_size()).WillOnce(Return(8193));
+  action_under_test->check_part_details();
+  EXPECT_STREQ("MetadataTooLarge",
+               action_under_test->get_s3_error_code().c_str());
 }
 
 TEST_F(S3PutMultipartObjectActionTestNoMockAuth,
@@ -346,7 +355,17 @@ TEST_F(S3PutMultipartObjectActionTestNoMockAuth,
   EXPECT_CALL(*ptr_mock_request, get_user_metadata_size())
       .WillOnce(Return(3000));
   action_under_test->check_part_details();
-  EXPECT_STREQ("BadRequest", action_under_test->get_s3_error_code().c_str());
+  EXPECT_STREQ("MetadataTooLarge",
+               action_under_test->get_s3_error_code().c_str());
+}
+
+TEST_F(S3PutMultipartObjectActionTestNoMockAuth,
+       ValidateUserMetadataLengthBeyond2KNegativeCase) {
+  EXPECT_CALL(*ptr_mock_request, get_user_metadata_size())
+      .WillOnce(Return(2049));
+  action_under_test->check_part_details();
+  EXPECT_STREQ("MetadataTooLarge",
+               action_under_test->get_s3_error_code().c_str());
 }
 
 TEST_F(S3PutMultipartObjectActionTestNoMockAuth,

--- a/ut/s3_put_multiobject_action_test.cc
+++ b/ut/s3_put_multiobject_action_test.cc
@@ -342,11 +342,10 @@ TEST_F(S3PutMultipartObjectActionTestNoMockAuth,
                action_under_test->get_s3_error_code().c_str());
 }
 
-TEST_F(S3PutMultipartObjectActionTestNoMockAuth,
-       ValidateMetadataLengthBeyond8KNegativeCase) {
-  EXPECT_CALL(*ptr_mock_request, get_header_size()).WillOnce(Return(8193));
+TEST_F(S3PutMultipartObjectActionTestNoMockAuth, ValidateMetadataLength8K) {
+  EXPECT_CALL(*ptr_mock_request, get_header_size()).WillOnce(Return(8192));
   action_under_test->check_part_details();
-  EXPECT_STREQ("MetadataTooLarge",
+  EXPECT_STRNE("MetadataTooLarge",
                action_under_test->get_s3_error_code().c_str());
 }
 
@@ -359,12 +358,11 @@ TEST_F(S3PutMultipartObjectActionTestNoMockAuth,
                action_under_test->get_s3_error_code().c_str());
 }
 
-TEST_F(S3PutMultipartObjectActionTestNoMockAuth,
-       ValidateUserMetadataLengthBeyond2KNegativeCase) {
+TEST_F(S3PutMultipartObjectActionTestNoMockAuth, ValidateUserMetadataLength2K) {
   EXPECT_CALL(*ptr_mock_request, get_user_metadata_size())
-      .WillOnce(Return(2049));
+      .WillOnce(Return(2048));
   action_under_test->check_part_details();
-  EXPECT_STREQ("MetadataTooLarge",
+  EXPECT_STRNE("MetadataTooLarge",
                action_under_test->get_s3_error_code().c_str());
 }
 

--- a/ut/s3_put_multiobject_action_test.cc
+++ b/ut/s3_put_multiobject_action_test.cc
@@ -342,27 +342,12 @@ TEST_F(S3PutMultipartObjectActionTestNoMockAuth,
                action_under_test->get_s3_error_code().c_str());
 }
 
-TEST_F(S3PutMultipartObjectActionTestNoMockAuth, ValidateMetadataLength8K) {
-  EXPECT_CALL(*ptr_mock_request, get_header_size()).WillOnce(Return(8192));
-  action_under_test->check_part_details();
-  EXPECT_STRNE("MetadataTooLarge",
-               action_under_test->get_s3_error_code().c_str());
-}
-
 TEST_F(S3PutMultipartObjectActionTestNoMockAuth,
        ValidateUserMetadataLengthNegativeCase) {
   EXPECT_CALL(*ptr_mock_request, get_user_metadata_size())
       .WillOnce(Return(3000));
   action_under_test->check_part_details();
   EXPECT_STREQ("MetadataTooLarge",
-               action_under_test->get_s3_error_code().c_str());
-}
-
-TEST_F(S3PutMultipartObjectActionTestNoMockAuth, ValidateUserMetadataLength2K) {
-  EXPECT_CALL(*ptr_mock_request, get_user_metadata_size())
-      .WillOnce(Return(2048));
-  action_under_test->check_part_details();
-  EXPECT_STRNE("MetadataTooLarge",
                action_under_test->get_s3_error_code().c_str());
 }
 

--- a/ut/s3_put_object_action_test.cc
+++ b/ut/s3_put_object_action_test.cc
@@ -214,15 +214,6 @@ TEST_F(S3PutObjectActionTest, ValidateMetadataLengthNegativeCase) {
                action_under_test->get_s3_error_code().c_str());
 }
 
-TEST_F(S3PutObjectActionTest, ValidateMetadataLength8K) {
-  EXPECT_CALL(*ptr_mock_request, get_object_name()).Times(AtLeast(1)).WillOnce(
-      ReturnRef(object_name));
-  EXPECT_CALL(*ptr_mock_request, get_header_size()).WillOnce(Return(8192));
-  action_under_test->validate_put_request();
-  EXPECT_STRNE("MetadataTooLarge",
-               action_under_test->get_s3_error_code().c_str());
-}
-
 TEST_F(S3PutObjectActionTest, ValidateUserMetadataLengthNegativeCase) {
   EXPECT_CALL(*ptr_mock_request, get_object_name()).Times(AtLeast(1)).WillOnce(
       ReturnRef(object_name));
@@ -230,16 +221,6 @@ TEST_F(S3PutObjectActionTest, ValidateUserMetadataLengthNegativeCase) {
       .WillOnce(Return(3000));
   action_under_test->validate_put_request();
   EXPECT_STREQ("MetadataTooLarge",
-               action_under_test->get_s3_error_code().c_str());
-}
-
-TEST_F(S3PutObjectActionTest, ValidateUserMetadataLength2K) {
-  EXPECT_CALL(*ptr_mock_request, get_object_name()).Times(AtLeast(1)).WillOnce(
-      ReturnRef(object_name));
-  EXPECT_CALL(*ptr_mock_request, get_user_metadata_size())
-      .WillOnce(Return(2048));
-  action_under_test->validate_put_request();
-  EXPECT_STRNE("MetadataTooLarge",
                action_under_test->get_s3_error_code().c_str());
 }
 

--- a/ut/s3_put_object_action_test.cc
+++ b/ut/s3_put_object_action_test.cc
@@ -214,12 +214,12 @@ TEST_F(S3PutObjectActionTest, ValidateMetadataLengthNegativeCase) {
                action_under_test->get_s3_error_code().c_str());
 }
 
-TEST_F(S3PutObjectActionTest, ValidateMetadataLengthBeyond8KNegativeCase) {
+TEST_F(S3PutObjectActionTest, ValidateMetadataLength8K) {
   EXPECT_CALL(*ptr_mock_request, get_object_name()).Times(AtLeast(1)).WillOnce(
       ReturnRef(object_name));
-  EXPECT_CALL(*ptr_mock_request, get_header_size()).WillOnce(Return(8193));
+  EXPECT_CALL(*ptr_mock_request, get_header_size()).WillOnce(Return(8192));
   action_under_test->validate_put_request();
-  EXPECT_STREQ("MetadataTooLarge",
+  EXPECT_STRNE("MetadataTooLarge",
                action_under_test->get_s3_error_code().c_str());
 }
 
@@ -233,13 +233,13 @@ TEST_F(S3PutObjectActionTest, ValidateUserMetadataLengthNegativeCase) {
                action_under_test->get_s3_error_code().c_str());
 }
 
-TEST_F(S3PutObjectActionTest, ValidateUserMetadataLengthBeyond2KNegativeCase) {
+TEST_F(S3PutObjectActionTest, ValidateUserMetadataLength2K) {
   EXPECT_CALL(*ptr_mock_request, get_object_name()).Times(AtLeast(1)).WillOnce(
       ReturnRef(object_name));
   EXPECT_CALL(*ptr_mock_request, get_user_metadata_size())
-      .WillOnce(Return(2049));
+      .WillOnce(Return(2048));
   action_under_test->validate_put_request();
-  EXPECT_STREQ("MetadataTooLarge",
+  EXPECT_STRNE("MetadataTooLarge",
                action_under_test->get_s3_error_code().c_str());
 }
 

--- a/ut/s3_put_object_action_test.cc
+++ b/ut/s3_put_object_action_test.cc
@@ -210,7 +210,17 @@ TEST_F(S3PutObjectActionTest, ValidateMetadataLengthNegativeCase) {
       ReturnRef(object_name));
   EXPECT_CALL(*ptr_mock_request, get_header_size()).WillOnce(Return(9000));
   action_under_test->validate_put_request();
-  EXPECT_STREQ("BadRequest", action_under_test->get_s3_error_code().c_str());
+  EXPECT_STREQ("MetadataTooLarge",
+               action_under_test->get_s3_error_code().c_str());
+}
+
+TEST_F(S3PutObjectActionTest, ValidateMetadataLengthBeyond8KNegativeCase) {
+  EXPECT_CALL(*ptr_mock_request, get_object_name()).Times(AtLeast(1)).WillOnce(
+      ReturnRef(object_name));
+  EXPECT_CALL(*ptr_mock_request, get_header_size()).WillOnce(Return(8193));
+  action_under_test->validate_put_request();
+  EXPECT_STREQ("MetadataTooLarge",
+               action_under_test->get_s3_error_code().c_str());
 }
 
 TEST_F(S3PutObjectActionTest, ValidateUserMetadataLengthNegativeCase) {
@@ -219,7 +229,18 @@ TEST_F(S3PutObjectActionTest, ValidateUserMetadataLengthNegativeCase) {
   EXPECT_CALL(*ptr_mock_request, get_user_metadata_size())
       .WillOnce(Return(3000));
   action_under_test->validate_put_request();
-  EXPECT_STREQ("BadRequest", action_under_test->get_s3_error_code().c_str());
+  EXPECT_STREQ("MetadataTooLarge",
+               action_under_test->get_s3_error_code().c_str());
+}
+
+TEST_F(S3PutObjectActionTest, ValidateUserMetadataLengthBeyond2KNegativeCase) {
+  EXPECT_CALL(*ptr_mock_request, get_object_name()).Times(AtLeast(1)).WillOnce(
+      ReturnRef(object_name));
+  EXPECT_CALL(*ptr_mock_request, get_user_metadata_size())
+      .WillOnce(Return(2049));
+  action_under_test->validate_put_request();
+  EXPECT_STREQ("MetadataTooLarge",
+               action_under_test->get_s3_error_code().c_str());
 }
 
 TEST_F(S3PutObjectActionTest, ValidateRequestTags) {


### PR DESCRIPTION
# Change Summary
## Problem Statement/Description
_[EOS-19636](https://jts.seagate.com/browse/EOS-19636):_
_Uploading object with 2KB metadata size fails_

## Solution Overview
root cause: 
S3 server adds identifier "x-amz-meta-" in to metatadata key in to header. When the metadata length gets calculated it was also considering the above additional length which was causing the upload object fail. 

Fix:
Subtracted the length of  "x-amz-meta-" from the metadata length.
Corrected the error message for the header or metadata exceed.   

## Unit Test Cases
Performed the object upload with metadata as 2048 on dev VM. Object uploaded successfully.
Performed the object upload with metadata as 2049 on dev VM. Object upload failed with proper error message.
 
<details>
  <summary>Output of UT</summary>
[root@ssc-vm-3160 cortx-s3server]# aws s3 cp LICENSE s3://mp-bkt-test1619002304 --endpoint-url http://s3.seagate.com --metadata "26NyodkBkH=7CNkGWnzzoWuWEPBzUcwNsA49LhPtBfsksTfEYrHmE8JaN9PqsR3RXPtFQk5r8moPDQfartJkUsvPbTyviXnFVWjkfKGfjdW3UaJAFD7BiGlvQxN6YJvpfBokHvKnfFWZWu17OHfKS8nQxC2eQliS05fSEwjZgW8I6vsX800ZTiVmw4eFNcwdNooG9bp5eVIQW4BMn5dxzLEAyd8IcNw8cXYhwXdYmRNa6sAgiX49Awm0K8fR3o25wgAuzs9NbkwQAzFcyQ0RXNZvrIpoe31dWbdVz3yLgXxuuz1vzx2Ntseyk9YSXd5m09HHefyHUpfUDF44u96wcnSqJ3xbxZZN5ngNB2Vzk70yJHyohELUAHj3hOngyvQnrKzAAf75dIugoTKFGljZkVQzEDyYYofBXKolWjxj1NsAxHnSO3L1b5rxqBPX7nBdhQpnJW5aY0gjfKzYCkFxSKGVWOZruPC8Xc9Cha9FiUTK1RnD4DDuXTY6VTtVfqiPnOVB31VvFzyUBBU0DUBFNpFQ2AQNLaRSdSx84o0tcuZT0OhTlol1yG5WBQTfiS96OcE53M1BaDdu53MYCiPdcEkfln84WN5KmHr123WvK8fB3LQsW1g2eXlrHf7rmrwEg4vhLVRvumZ1efQJqtfnrtJZuzjSRa9mNnN845spfJVftdpVugiH8eeEw9QGjQHnycWaM00AH5mLCGu2kJvwvNI72zvm9s5aCtJgjdzchJxOPoPlTYClsJNORg2dX27ODs2uMUIuJ40GGhZ3jcxmnqAS9wc2kAEtUiWTxzQFtdFXH22Rgd8ebTpa44AqpZHoCIxSZODPYsrPyKtOwnaPPwltBxSNwPOxBFVPNUpyVPkOLXlO9UdgcJ6JFY63RX6eSeeIFXzJEiJBeJFeaJzlFZ7DIRwYqrKIgxNk0xW6Mdrk1wMTgzwRhk7TFk6fZjS2d9kWCQLr3bnMwPbqNHKh7JOJe49T7tFc8jTVO8Bpb9wU3JbJBlzTdhBRMz9SY2JTQsSQdtBHho9NsKup67CF4VY1Cr9HgxJh4WnNnr99L18swljHHQOEV35L1jJLjhG5Ki7a5fM5mvHYGBvcuIIPeO28TyEVqPJMSTta7ZATdkTCIY5dSUhX6y80qN3iHWvnCO5kxRfUCEVLaJHQ01g8cIPUYoAEwB43K1XWYVY5eaaG86rIK3FQf7xIvQchJYPF1U5HaaqqSVFgk7zAqdywLs2q2SuIkb1Jm1I7YH5O94PBqNlQpIeu1mWZTVkMj8vX08JqXR8jQWHPMpCjOPAjPSFF60RUUwd2j76F0TWfIov9zOzvGISwSOWXUtMydMHk5rvGvzzgZ0xrp9IDPKz2DSvhRgcRb2jgPXht5YCqXwMfD9BElOomObIdGfSFib3YM0uhiIDkekfePMSr5nxO0bRUr7eeBFm3YvoS6f9wpjaiNK00PHtDS3Pql4VC7sOqh7Lczl6HJOEzwetlob25SLAQiDxiLFQHLHJsIex3Kpf51QVSaal0wr2KpS6arMdrlyUuEe8MHt5SBnCTJtikxCCSHT3XWWZvFRTQ4tjhHy3IZNq9ixkeT9kp9sj1yAFkzcaMM0s72tdKHOryiNGbSTwFymwGvEbVnhnJwDnQGsHzzut55sSOK7FBB4Znk6UO2Iyu4SDstgSLWTOGnTcfeQxtVg6jDYEFpG73OWgLt95aLFj2Cp7pBi8BTA6CKuN9i0hIEhmqmFroYiV2RcknDrNWkOr4lEhDtYgNiVajNsRNAzZ9MAeaZpr2q6FJ4kKBKRydS5MLKO2X5hUG5JkzFiCwKEPh8wrQFeqllrTkRUBka2dcQJnbQ0fjrkNlPgnD9h3S6VTDYvQgKICM7aRcOwmqAcUYZeGLmIhCvZq1o0YlgdEUY1LN76EbvOezh22zGZuX2YTJ5rZbRU7FMC2HINujlqPOyeYNkX8g11dBJg9OKWdjSd9UMB2vQby1yIZKmattDd5tOK9W0NTQfuGPQoX5nwTcADauf0w8G1fVtc37vnCsps1nfB612345678901"
upload failed: ./LICENSE to s3://mp-bkt-test1619002304/LICENSE An error occurred (MetadataTooLarge) when calling the PutObject operation: Your metadata headers exceed the maximum allowed metadata size
[root@ssc-vm-3160 cortx-s3server]# aws s3 cp LICENSE s3://mp-bkt-test1619002304 --endpoint-url http://s3.seagate.com --metadata "26NyodkBkH=7CNkGWnzzoWuWEPBzUcwNsA49LhPtBfsksTfEYrHmE8JaN9PqsR3RXPtFQk5r8moPDQfartJkUsvPbTyviXnFVWjkfKGfjdW3UaJAFD7BiGlvQxN6YJvpfBokHvKnfFWZWu17OHfKS8nQxC2eQliS05fSEwjZgW8I6vsX800ZTiVmw4eFNcwdNooG9bp5eVIQW4BMn5dxzLEAyd8IcNw8cXYhwXdYmRNa6sAgiX49Awm0K8fR3o25wgAuzs9NbkwQAzFcyQ0RXNZvrIpoe31dWbdVz3yLgXxuuz1vzx2Ntseyk9YSXd5m09HHefyHUpfUDF44u96wcnSqJ3xbxZZN5ngNB2Vzk70yJHyohELUAHj3hOngyvQnrKzAAf75dIugoTKFGljZkVQzEDyYYofBXKolWjxj1NsAxHnSO3L1b5rxqBPX7nBdhQpnJW5aY0gjfKzYCkFxSKGVWOZruPC8Xc9Cha9FiUTK1RnD4DDuXTY6VTtVfqiPnOVB31VvFzyUBBU0DUBFNpFQ2AQNLaRSdSx84o0tcuZT0OhTlol1yG5WBQTfiS96OcE53M1BaDdu53MYCiPdcEkfln84WN5KmHr123WvK8fB3LQsW1g2eXlrHf7rmrwEg4vhLVRvumZ1efQJqtfnrtJZuzjSRa9mNnN845spfJVftdpVugiH8eeEw9QGjQHnycWaM00AH5mLCGu2kJvwvNI72zvm9s5aCtJgjdzchJxOPoPlTYClsJNORg2dX27ODs2uMUIuJ40GGhZ3jcxmnqAS9wc2kAEtUiWTxzQFtdFXH22Rgd8ebTpa44AqpZHoCIxSZODPYsrPyKtOwnaPPwltBxSNwPOxBFVPNUpyVPkOLXlO9UdgcJ6JFY63RX6eSeeIFXzJEiJBeJFeaJzlFZ7DIRwYqrKIgxNk0xW6Mdrk1wMTgzwRhk7TFk6fZjS2d9kWCQLr3bnMwPbqNHKh7JOJe49T7tFc8jTVO8Bpb9wU3JbJBlzTdhBRMz9SY2JTQsSQdtBHho9NsKup67CF4VY1Cr9HgxJh4WnNnr99L18swljHHQOEV35L1jJLjhG5Ki7a5fM5mvHYGBvcuIIPeO28TyEVqPJMSTta7ZATdkTCIY5dSUhX6y80qN3iHWvnCO5kxRfUCEVLaJHQ01g8cIPUYoAEwB43K1XWYVY5eaaG86rIK3FQf7xIvQchJYPF1U5HaaqqSVFgk7zAqdywLs2q2SuIkb1Jm1I7YH5O94PBqNlQpIeu1mWZTVkMj8vX08JqXR8jQWHPMpCjOPAjPSFF60RUUwd2j76F0TWfIov9zOzvGISwSOWXUtMydMHk5rvGvzzgZ0xrp9IDPKz2DSvhRgcRb2jgPXht5YCqXwMfD9BElOomObIdGfSFib3YM0uhiIDkekfePMSr5nxO0bRUr7eeBFm3YvoS6f9wpjaiNK00PHtDS3Pql4VC7sOqh7Lczl6HJOEzwetlob25SLAQiDxiLFQHLHJsIex3Kpf51QVSaal0wr2KpS6arMdrlyUuEe8MHt5SBnCTJtikxCCSHT3XWWZvFRTQ4tjhHy3IZNq9ixkeT9kp9sj1yAFkzcaMM0s72tdKHOryiNGbSTwFymwGvEbVnhnJwDnQGsHzzut55sSOK7FBB4Znk6UO2Iyu4SDstgSLWTOGnTcfeQxtVg6jDYEFpG73OWgLt95aLFj2Cp7pBi8BTA6CKuN9i0hIEhmqmFroYiV2RcknDrNWkOr4lEhDtYgNiVajNsRNAzZ9MAeaZpr2q6FJ4kKBKRydS5MLKO2X5hUG5JkzFiCwKEPh8wrQFeqllrTkRUBka2dcQJnbQ0fjrkNlPgnD9h3S6VTDYvQgKICM7aRcOwmqAcUYZeGLmIhCvZq1o0YlgdEUY1LN76EbvOezh22zGZuX2YTJ5rZbRU7FMC2HINujlqPOyeYNkX8g11dBJg9OKWdjSd9UMB2vQby1yIZKmattDd5tOK9W0NTQfuGPQoX5nwTcADauf0w8G1fVtc37vnCsps1nfB61234567890"
upload: ./LICENSE to s3://mp-bkt-test1619002304/LICENSE
[root@ssc-vm-3160 cortx-s3server]#

</details>