### PR TITLE
github833: S3 logger robustness, performance improvement and reorg proposal

### DIFF
--- a/server/s3_iem.h
+++ b/server/s3_iem.h
@@ -42,7 +42,7 @@ extern S3Option* g_option_instance;
       s3_syslog(LOG_ERR, "IEC:ES" event_code ":" event_desc);                 \
     }                                                                         \
     std::string timestamp = s3_get_timestamp();                               \
-    s3_log(S3_ ## s3_loglevel, "",                                            \
+    s3_log(S3_##s3_loglevel, "",                                              \
            "IEC: " event_code ": " event_desc                                 \
            ": { \"time\": \"%s\", \"node\": \"%s\", \"pid\": "                \
            "%d, \"file\": \"%s\", \"line\": %d" json_fmt " }",                \

--- a/server/s3_log.cc
+++ b/server/s3_log.cc
@@ -21,11 +21,9 @@
 #include "s3_log.h"
 #include "s3_option.h"
 
-enum {
-  KB = 1 << 10,
-};
+#define ONE_KB (1 << 10)
 
-static thread_local char log_buffer[10 * KB];
+static thread_local char log_buffer[10 * ONE_KB];
 char *__log_buff() { return log_buffer; }
 size_t __log_buff_sz() { return sizeof(log_buffer); }
 

--- a/server/s3_log.cc
+++ b/server/s3_log.cc
@@ -25,13 +25,9 @@ enum {
   KB = 1 << 10,
 };
 
-static thread_local char log_buffer[10*KB];
-char *__log_buff() {
-  return log_buffer;
-}
-size_t __log_buff_sz() {
-  return 10*KB - 1;
-}
+static thread_local char log_buffer[10 * KB];
+char *__log_buff() { return log_buffer; }
+size_t __log_buff_sz() { return 10 * KB - 1; }
 
 int s3log_level = S3_LOG_INFO;
 s3_fatal_log_handler s3_fatal_handler;

--- a/server/s3_log.cc
+++ b/server/s3_log.cc
@@ -21,6 +21,18 @@
 #include "s3_log.h"
 #include "s3_option.h"
 
+enum {
+  KB = 1 << 10,
+};
+
+static thread_local char log_buffer[10*KB];
+char *__log_buff() {
+  return log_buffer;
+}
+size_t __log_buff_sz() {
+  return 10*KB - 1;
+}
+
 int s3log_level = S3_LOG_INFO;
 s3_fatal_log_handler s3_fatal_handler;
 

--- a/server/s3_log.cc
+++ b/server/s3_log.cc
@@ -27,7 +27,7 @@ enum {
 
 static thread_local char log_buffer[10 * KB];
 char *__log_buff() { return log_buffer; }
-size_t __log_buff_sz() { return 10 * KB - 1; }
+size_t __log_buff_sz() { return sizeof(log_buffer); }
 
 int s3log_level = S3_LOG_INFO;
 s3_fatal_log_handler s3_fatal_handler;

--- a/server/s3_log.h
+++ b/server/s3_log.h
@@ -51,15 +51,46 @@ inline const char* s3_log_get_req_id(const std::string& requestid) {
   return requestid.empty() ? S3_DEFAULT_REQID : requestid.c_str();
 }
 
-template<int VERBOSITY> struct s3_logger_get {};
-template<> struct s3_logger_get<S3_LOG_DEBUG> { template<typename T> static inline void log(T const& p) { LOG(INFO)    << (p); } };
-template<> struct s3_logger_get<S3_LOG_INFO>  { template<typename T> static inline void log(T const& p) { LOG(INFO)    << (p); } };
-template<> struct s3_logger_get<S3_LOG_WARN>  { template<typename T> static inline void log(T const& p) { LOG(WARNING) << (p); } };
-template<> struct s3_logger_get<S3_LOG_ERROR> { template<typename T> static inline void log(T const& p) { LOG(ERROR)   << (p); } };
-template<> struct s3_logger_get<S3_LOG_FATAL> { template<typename T> static inline void log(T const& p) { LOG(ERROR)   << (p); } };
+template <int VERBOSITY>
+struct s3_logger_get {};
+template <>
+struct s3_logger_get<S3_LOG_DEBUG> {
+  template <typename T>
+  static inline void log(T const& p) {
+    LOG(INFO) << (p);
+  }
+};
+template <>
+struct s3_logger_get<S3_LOG_INFO> {
+  template <typename T>
+  static inline void log(T const& p) {
+    LOG(INFO) << (p);
+  }
+};
+template <>
+struct s3_logger_get<S3_LOG_WARN> {
+  template <typename T>
+  static inline void log(T const& p) {
+    LOG(WARNING) << (p);
+  }
+};
+template <>
+struct s3_logger_get<S3_LOG_ERROR> {
+  template <typename T>
+  static inline void log(T const& p) {
+    LOG(ERROR) << (p);
+  }
+};
+template <>
+struct s3_logger_get<S3_LOG_FATAL> {
+  template <typename T>
+  static inline void log(T const& p) {
+    LOG(ERROR) << (p);
+  }
+};
 
-char   *__log_buff();
-size_t  __log_buff_sz();
+char* __log_buff();
+size_t __log_buff_sz();
 
 // Note:
 // 1. Google glog doesn't have a separate severity level for DEBUG logs.
@@ -67,17 +98,16 @@ size_t  __log_buff_sz();
 //    only if S3 log level is set to DEBUG.
 // 2. Logging a FATAL message terminates the program (after the message is
 //    logged).so demote it to ERROR
-#define s3_log(loglevel, requestid, fmt, ...)                    \
-  do {                                                           \
-    if (loglevel >= s3log_level) {                               \
-      snprintf(__log_buff(), __log_buff_sz(),			 \
-	       "[%s] [ReqID: %s] " fmt "\n", __func__,		 \
-	       s3_log_get_req_id(requestid), ##__VA_ARGS__);     \
-      s3_logger_get<loglevel>::log(__log_buff());                \
-    }                                                            \
-    if (loglevel >= S3_LOG_FATAL) {                              \
-      s3_fatal_handler(1);                                       \
-    }                                                            \
+#define s3_log(loglevel, requestid, fmt, ...)                               \
+  do {                                                                      \
+    if (loglevel >= s3log_level) {                                          \
+      snprintf(__log_buff(), __log_buff_sz(), "[%s] [ReqID: %s] " fmt "\n", \
+               __func__, s3_log_get_req_id(requestid), ##__VA_ARGS__);      \
+      s3_logger_get<loglevel>::log(__log_buff());                           \
+    }                                                                       \
+    if (loglevel >= S3_LOG_FATAL) {                                         \
+      s3_fatal_handler(1);                                                  \
+    }                                                                       \
   } while (0)
 
 // Note:


### PR DESCRIPTION
- removed ASPRINTF! and unneeded allocations for EVERY! log write!!!
- uses tls-approach.
- change the semantics of s3_iem() so that it becomes similar to s3 log.
- use templated verbosity select method to be able to handle const-expressions inside s3_log macro
- example: s3_log(cond ? S3_LOG_DEBUG : S3_LOG_ERROR, ...).