### PR TITLE
EOS-19814:Auth: increase LdapResult size from 500 -> 10000 for dev vm

### DIFF
--- a/ansible/openldap.yml
+++ b/ansible/openldap.yml
@@ -104,6 +104,11 @@
           src: files/ldap/s3slapdindex.ldif
           dest: /tmp/s3ldap/s3slapdindex.ldif
 
+      - name: Copy s3 ldap resultssizelimit file
+        template:
+          src: files/ldap/resultssizelimit.ldif
+          dest: /tmp/s3ldap/resultssizelimit.ldif
+
       - name: Copy ldap schema, data, replication-config files
         copy: src={{ item.src }} dest={{ item.dest }}
         with_items:
@@ -189,6 +194,10 @@
 
       - name: Configure OpenLDAP - Enable openldap indexing
         command: ldapmodify -Y EXTERNAL -H ldapi:/// -w {{ openldappasswd }} -f /tmp/s3ldap/s3slapdindex.ldif
+        no_log: true
+
+      - name: Configure OpenLDAP - Set ldap search Result size
+        command: ldapmodify -Y EXTERNAL -H ldapi:/// -w {{ openldappasswd }} -f /tmp/s3ldap/resultssizelimit.ldif
         no_log: true
 
       - name: Backup original slapd file


### PR DESCRIPTION
In case of dev vm we have max ldap search limit set as default value ie.e. 500 
hence if we have entries more than 500 then create/list API will be broken with "Size Limit Exceeded" error thrown by ldap.

In case of provisioned setup:
This case is already handled in setup_ldap.sh script hence no changes required in case of prod setup script.

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>