### PR TITLE
EOS-19181: Implementation of BD changes for S3 fault tolerenace feature

### DIFF
--- a/s3backgrounddelete/s3backgrounddelete/object_recovery_validator.py
+++ b/s3backgrounddelete/s3backgrounddelete/object_recovery_validator.py
@@ -31,6 +31,7 @@ import math
 
 #zero/null object oid in base64 encoded format
 NULL_OBJ_OID = "AAAAAAAAAAA=-AAAAAAAAAAA="
+EXTENDED_METADATA_SEPERATOR = "|"
 
 class ObjectRecoveryValidator:
     """This class is implementation of Validator for object recovery."""
@@ -170,6 +171,18 @@ class ObjectRecoveryValidator:
                                       " from version list")
             else:
                 return status
+
+        # Delete any stale entry in fragment index for this object
+        if ("fno" in self.object_leak_info and self.object_leak_info["fno"] != 0):
+            fragment_idx = self.object_leak_info["extended_md_idx_oid"]
+            if (fragment_idx is not None):
+                fragment = "F" + str(self.object_leak_info["fno"])
+                # Fetch version_id from version key string "<object_key>/<version_id>"
+                key_len = len(self.object_leak_info["object_key_in_index"]) + 1
+                version_id = (self.object_leak_info["version_key_in_index"])[key_len:]
+                fragment_key = self.object_leak_info["object_key_in_index"] + EXTENDED_METADATA_SEPERATOR + \
+                    version_id + EXTENDED_METADATA_SEPERATOR + fragment
+                self.delete_key_from_index(fragment_idx, fragment_key, "Extended MD Entry DEL")
 
         leak_rec_key = self.probable_delete_records["Key"]
         # If 'delete_entry =True', then delete record from probable delete index

--- a/server/s3_probable_delete_record.h
+++ b/server/s3_probable_delete_record.h
@@ -48,6 +48,9 @@ class S3ProbableDeleteRecord {
                       // delete object
   bool is_multipart;
   struct m0_uint128 part_list_idx_oid;  // present in case of multipart
+  unsigned int fragment;
+  unsigned int part;
+  struct m0_uint128 extended_md_idx_oid;
 
  public:
   S3ProbableDeleteRecord(std::string rec_key, struct m0_uint128 old_oid,
@@ -57,7 +60,9 @@ class S3ProbableDeleteRecord {
                          struct m0_uint128 objs_version_list_idx_oid,
                          std::string ver_key_in_index, bool force_del = false,
                          bool is_multipart = false,
-                         struct m0_uint128 part_list_oid = {0ULL, 0ULL});
+                         struct m0_uint128 part_list_oid = {0ULL, 0ULL},
+                         unsigned int frg = 0, unsigned int prt = 0,
+                         struct m0_uint128 extended_idx = {0ULL, 0ULL});
   virtual ~S3ProbableDeleteRecord() {}
 
   virtual const std::string& get_key() const { return record_key; }

--- a/server/s3_put_object_action.cc
+++ b/server/s3_put_object_action.cc
@@ -822,7 +822,9 @@ void S3PutObjectAction::add_extended_object_oid_to_probable_dead_oid_list(
       extended_obj_oid_str, null_oid, object_metadata->get_object_name(),
       extended_oid, layout_id, bucket_metadata->get_object_list_index_oid(),
       bucket_metadata->get_objects_version_list_index_oid(),
-      object_metadata->get_version_key_in_index(), false /* force_delete */));
+      object_metadata->get_version_key_in_index(), false /* force_delete */,
+      false, {0ULL, 0ULL}, current_fault_iteration, 0,
+      bucket_metadata->get_extended_metadata_index_oid()));
 
   if (!motr_kv_writer) {
     motr_kv_writer =
@@ -1404,9 +1406,43 @@ void S3PutObjectAction::delete_new_object_success() {
   if (new_obj_oids.size() > 0) {
     delete_new_object();
   } else {
+    // All created objects have been deleted. Try to delete fragments, if any
+    remove_new_fragments();
+  }
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
+
+// Remove fragments of new object, if any, when PUT operation fails
+void S3PutObjectAction::remove_new_fragments() {
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
+  if (new_object_metadata && new_object_metadata->is_object_extended()) {
+    const std::shared_ptr<S3ObjectExtendedMetadata>& ext_metadata =
+        new_object_metadata->get_extended_object_metadata();
+    if (ext_metadata->has_entries()) {
+      // Delete fragments, if any
+      ext_metadata->remove(
+          std::bind(&S3PutObjectAction::remove_new_ext_metadata_successful,
+                    this),
+          std::bind(&S3PutObjectAction::remove_new_ext_metadata_successful,
+                    this));
+    } else {
+      // Extended object exist, but no fragments, delete probbale index entries
+      remove_new_oid_probable_record();
+    }
+  } else {
+    // If this is not extended object, delete entries from probable index
     remove_new_oid_probable_record();
   }
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
+
+void S3PutObjectAction::remove_new_ext_metadata_successful() {
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
+  s3_log(S3_LOG_DEBUG, request_id,
+         "Removed extended metadata for Object [%s].\n",
+         (new_object_metadata->get_object_name()).c_str());
+  remove_new_oid_probable_record();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }
 
 void S3PutObjectAction::set_authorization_meta() {

--- a/server/s3_put_object_action.h
+++ b/server/s3_put_object_action.h
@@ -169,6 +169,10 @@ class S3PutObjectAction : public S3ObjectAction {
   void remove_old_object_version_metadata();
   void delete_new_object();
   void delete_new_object_success();
+  // During PUT failure due to md failure, delete fragments,
+  // if existed any, from the fragment index
+  void remove_new_fragments();
+  void remove_new_ext_metadata_successful();
 
   FRIEND_TEST(S3PutObjectActionTest, ConstructorTest);
   FRIEND_TEST(S3PutObjectActionTest, ValidateRequestTags);


### PR DESCRIPTION
Object leak scenarios:
1. When nth extended object creation fails
2. When saving to meta data fails and S3 cleanup fails

Signed-off-by: Dattaprasad <dattaprasad.govekar@seagate.com>