### PR TITLE
EOS-20265:add missing path in PATH variable

### DIFF
--- a/jenkins-build.sh
+++ b/jenkins-build.sh
@@ -381,6 +381,10 @@ if [ $cleanup_only -eq 1 ]; then
   exit
 fi
 
+# add /usr/local/bin to PATH
+export PATH=$PATH:/usr/local/bin
+echo $PATH
+
 # Configuration setting for using HTTP connection
 if [ $use_http_client -eq 1 ]
 then


### PR DESCRIPTION
In case of dev vm we are observing the environment variable PATH which does not has "/usr/local/bin" entry hence python modules in s3server like s3iamcli, s3confstore, s3cipher seems to be broken.

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>