### PR TITLE
EOS-17974: use pool version Id in read/write of objects

### DIFF
--- a/docs/design/pool-version-id.md
+++ b/docs/design/pool-version-id.md
@@ -1,0 +1,43 @@
+# Pool version Id
+
+Contents
+
+- [Pool version Id](#pool-version-id)
+  - [License](#license)
+  - [Proposed Design Change](#proposed-design-change)
+
+
+## License
+
+Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   <http://www.apache.org/licenses/LICENSE-2.0>
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+For any questions about this software or licensing,
+please email opensource@seagate.com or cortx-questions@seagate.com.
+
+
+## Proposed Design Change
+
+This document briefly describes proposed change - pool version id usage.
+
+Pool version is an object in configuration DB of Motr, which describes a subset of cluster.
+It contains disks, controllers of disks and racks for controllers.
+Cluster can be displayed as a tree with physical disks as leafs.
+A pool version is a subtree of that tree.
+Any Motr objects and indices are created and stored in a single pool version which is selected when an entity is created.
+Pool version Id is the identifier of a pool version.
+
+An entity (object or index) is identified by an unique identifier. This identifier is represented as 16 bytes with almost arbitrary content. Hence, an identifier doesn't contain any hints about physical location of entity's data.
+Motr implementation have to make lookup for the pool version the entity is stored in.
+This lookup can be omitted if s3server reads and saves pool version id after an entity is created and then fills appropriate field(s) in control structures for futher operations with the entity.

--- a/docs/design/pool-version-id.md
+++ b/docs/design/pool-version-id.md
@@ -3,28 +3,7 @@
 Contents
 
 - [Pool version Id](#pool-version-id)
-  - [License](#license)
   - [Proposed Design Change](#proposed-design-change)
-
-
-## License
-
-Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   <http://www.apache.org/licenses/LICENSE-2.0>
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-For any questions about this software or licensing,
-please email opensource@seagate.com or cortx-questions@seagate.com.
 
 
 ## Proposed Design Change
@@ -41,3 +20,17 @@ Pool version Id is the identifier of a pool version.
 An entity (object or index) is identified by an unique identifier. This identifier is represented as 16 bytes with almost arbitrary content. Hence, an identifier doesn't contain any hints about physical location of entity's data.
 Motr implementation have to make lookup for the pool version the entity is stored in.
 This lookup can be omitted if s3server reads and saves pool version id after an entity is created and then fills appropriate field(s) in control structures for futher operations with the entity.
+
+* * *
+
+So, every object operation done through libclovis, takes OID (object ID) as an argument.  (Except for create.)  Every operation needs to know layout ID and pool version ID (PVID) to operate on the object.  Before the fix (May 2021), S3 would only pass OID to libmotr, and so what happened -- Motr will do internal KVS lookup to load the "missing" data, layout ID and PVID.  Each object operation was doing internal KVS lookup.
+
+But this data is "static" data (does not change ever since object is created).  More over, we already store layout ID in object metadata.
+
+So idea is -- if we also store PVID, and then always pass these to libmotr on object operations -- no KVS lookup will be needed.  This will significantly decrease amount of KVS operations we do, and consequently improve the performance.
+
+Notes:
+
+* This fix depends on certain changes in Motr (before this fix, Motr was not expecting that client can pre-populate layout ID and PVID, so even if S3 provides data, Motr would ignore it).
+  * But still the fix is "harmless", and can be delivered before Motr changes.  There is no "hard", or "API" dependency, all API and structures are in Motr `main` already.
+* The fix is only required for "happy path" scenarios.  We assume that errors/failures/wrong API usage are rare, and we don't have to optimize those.  We only need to optimize scenarios which are "mainstream" usage, a majority of scenarios (assumes that user has all access rights, there is no internal errors that require rollback, etc.)

--- a/server/motr_delete_object_action.cc
+++ b/server/motr_delete_object_action.cc
@@ -73,10 +73,11 @@ void MotrDeleteObjectAction::validate_request() {
 void MotrDeleteObjectAction::delete_object() {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
-  motr_writer = motr_writer_factory->create_motr_writer(request, oid);
+  motr_writer = motr_writer_factory->create_motr_writer(request);
+
   motr_writer->delete_object(
       std::bind(&MotrDeleteObjectAction::delete_object_successful, this),
-      std::bind(&MotrDeleteObjectAction::delete_object_failed, this),
+      std::bind(&MotrDeleteObjectAction::delete_object_failed, this), oid,
       layout_id);
 
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);

--- a/server/s3_abort_multipart_action.cc
+++ b/server/s3_abort_multipart_action.cc
@@ -403,13 +403,15 @@ void S3AbortMultipartAction::delete_object() {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // process to delete object
   if (!motr_writer) {
-    motr_writer = motr_writer_factory->create_motr_writer(
-        request, object_multipart_metadata->get_oid());
+    motr_writer = motr_writer_factory->create_motr_writer(request);
   }
   motr_writer->delete_object(
       std::bind(&S3AbortMultipartAction::remove_probable_record, this),
       std::bind(&S3AbortMultipartAction::next, this),
-      object_multipart_metadata->get_layout_id());
+      object_multipart_metadata->get_oid(),
+      object_multipart_metadata->get_layout_id(),
+      object_multipart_metadata->get_pvid());
+
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 

--- a/server/s3_copy_object_action.cc
+++ b/server/s3_copy_object_action.cc
@@ -307,6 +307,7 @@ void S3CopyObjectAction::copy_object() {
     object_data_copier->copy(
         source_object_metadata->get_oid(), total_data_to_stream,
         source_object_metadata->get_layout_id(),
+        source_object_metadata->get_pvid(),
         std::bind(&S3CopyObjectAction::copy_object_cb, this),
         std::bind(&S3CopyObjectAction::copy_object_success, this),
         std::bind(&S3CopyObjectAction::copy_object_failed, this));

--- a/server/s3_delete_bucket_action.cc
+++ b/server/s3_delete_bucket_action.cc
@@ -231,6 +231,7 @@ void S3DeleteBucketAction::fetch_multipart_objects_successful() {
       if (multipart_obj_oid.u_hi != 0ULL || multipart_obj_oid.u_lo != 0ULL) {
         multipart_object_oids.push_back(multipart_obj_oid);
         multipart_object_layoutids.push_back(object->get_layout_id());
+        multipart_object_pv_ids.push_back(object->get_pvid());
       }
     }
     return_list_size++;
@@ -263,6 +264,7 @@ void S3DeleteBucketAction::delete_multipart_objects() {
     motr_writer = motr_writer_factory->create_motr_writer(request);
     motr_writer->delete_objects(
         multipart_object_oids, multipart_object_layoutids,
+        multipart_object_pv_ids,
         std::bind(&S3DeleteBucketAction::delete_multipart_objects_successful,
                   this),
         std::bind(&S3DeleteBucketAction::delete_multipart_objects_failed,

--- a/server/s3_delete_bucket_action.h
+++ b/server/s3_delete_bucket_action.h
@@ -42,6 +42,7 @@ class S3DeleteBucketAction : public S3BucketAction {
   std::vector<struct m0_uint128> part_oids;
   std::vector<struct m0_uint128> multipart_object_oids;
   std::vector<int> multipart_object_layoutids;
+  std::vector<struct m0_fid> multipart_object_pv_ids;
   m0_uint128 object_list_index_oid;
   m0_uint128 objects_version_list_index_oid;
   m0_uint128 extended_metadata_index_oid;

--- a/server/s3_delete_multiple_objects_action.cc
+++ b/server/s3_delete_multiple_objects_action.cc
@@ -360,6 +360,7 @@ void S3DeleteMultipleObjectsAction::delete_objects_metadata_successful() {
     delete_objects_response.add_success(obj->get_object_name());
     oids_to_delete.push_back(obj->get_oid());
     layout_id_for_objs_to_delete.push_back(obj->get_layout_id());
+    pv_ids_to_delete.push_back(obj->get_pvid());
   }
 
   if (delete_index_in_req < delete_request.get_count()) {
@@ -451,7 +452,7 @@ void S3DeleteMultipleObjectsAction::cleanup() {
     } else {
       // Now trigger the delete.
       motr_writer->delete_objects(
-          oids_to_delete, layout_id_for_objs_to_delete,
+          oids_to_delete, layout_id_for_objs_to_delete, pv_ids_to_delete,
           std::bind(&S3DeleteMultipleObjectsAction::cleanup_successful, this),
           std::bind(&S3DeleteMultipleObjectsAction::cleanup_failed, this));
     }

--- a/server/s3_delete_multiple_objects_action.h
+++ b/server/s3_delete_multiple_objects_action.h
@@ -55,6 +55,7 @@ class S3DeleteMultipleObjectsAction : public S3BucketAction {
   int delete_index_in_req;
   std::vector<struct m0_uint128> oids_to_delete;
   std::vector<int> layout_id_for_objs_to_delete;
+  std::vector<struct m0_fid> pv_ids_to_delete;
   std::vector<std::string> keys_to_delete;
   bool at_least_one_delete_successful;
 

--- a/server/s3_delete_object_action.cc
+++ b/server/s3_delete_object_action.cc
@@ -275,13 +275,12 @@ void S3DeleteObjectAction::delete_object() {
   }
   // process to delete object
   if (!motr_writer) {
-    motr_writer = motr_writer_factory->create_motr_writer(
-        request, object_metadata->get_oid());
+    motr_writer = motr_writer_factory->create_motr_writer(request);
   }
   motr_writer->delete_object(
       std::bind(&S3DeleteObjectAction::remove_probable_record, this),
-      std::bind(&S3DeleteObjectAction::next, this),
-      object_metadata->get_layout_id());
+      std::bind(&S3DeleteObjectAction::next, this), obj_oid,
+      object_metadata->get_layout_id(), object_metadata->get_pvid());
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 

--- a/server/s3_factory.h
+++ b/server/s3_factory.h
@@ -122,23 +122,20 @@ class S3PartMetadataFactory {
 
 class S3MotrWriterFactory {
  public:
-  virtual ~S3MotrWriterFactory() {}
-  virtual std::shared_ptr<S3MotrWiter> create_motr_writer(
-      std::shared_ptr<RequestObject> req, m0_uint128 oid) {
-    s3_log(S3_LOG_DEBUG, "", "S3MotrWriterFactory::create_motr_writer\n");
-    return std::make_shared<S3MotrWiter>(req, oid);
-  }
+  virtual ~S3MotrWriterFactory() = default;
+
   virtual std::shared_ptr<S3MotrWiter> create_motr_writer(
       std::shared_ptr<RequestObject> req) {
     s3_log(S3_LOG_DEBUG, "",
            "S3MotrWriterFactory::create_motr_writer with zero offset\n");
-    return std::make_shared<S3MotrWiter>(req);
+    return std::make_shared<S3MotrWiter>(std::move(req));
   }
   virtual std::shared_ptr<S3MotrWiter> create_motr_writer(
-      std::shared_ptr<RequestObject> req, m0_uint128 oid, uint64_t offset) {
+      std::shared_ptr<RequestObject> req, struct m0_uint128 oid,
+      struct m0_fid pv_id, uint64_t offset) {
     s3_log(S3_LOG_DEBUG, "",
            "S3MotrWriterFactory::create_motr_writer with offset %zu\n", offset);
-    return std::make_shared<S3MotrWiter>(req, oid, offset);
+    return std::make_shared<S3MotrWiter>(std::move(req), oid, pv_id, offset);
   }
 };
 
@@ -148,9 +145,10 @@ class S3MotrReaderFactory {
 
   virtual std::shared_ptr<S3MotrReader> create_motr_reader(
       std::shared_ptr<RequestObject> req, struct m0_uint128 oid, int layout_id,
-      std::shared_ptr<MotrAPI> motr_api = nullptr) {
+      struct m0_fid pvid = {}, std::shared_ptr<MotrAPI> motr_api = {}) {
     s3_log(S3_LOG_DEBUG, "", "S3MotrReaderFactory::create_motr_reader\n");
-    return std::make_shared<S3MotrReader>(req, oid, layout_id, motr_api);
+    return std::make_shared<S3MotrReader>(std::move(req), oid, layout_id, pvid,
+                                          std::move(motr_api));
   }
 };
 

--- a/server/s3_get_object_action.cc
+++ b/server/s3_get_object_action.cc
@@ -326,7 +326,8 @@ void S3GetObjectAction::read_object() {
   // get total number of blocks to read from an object
   set_total_blocks_to_read_from_object();
   motr_reader = motr_reader_factory->create_motr_reader(
-      request, object_metadata->get_oid(), object_metadata->get_layout_id());
+      request, object_metadata->get_oid(), object_metadata->get_layout_id(),
+      object_metadata->get_pvid());
   // get the block,in which first_byte_offset_to_read is present
   // and initilaize the last index with starting offset the block
   size_t block_start_offset =

--- a/server/s3_m0_uint128_helper.cc
+++ b/server/s3_m0_uint128_helper.cc
@@ -18,8 +18,9 @@
  *
  */
 
-#include "s3_m0_uint128_helper.h"
 #include "base64.h"
+#include "s3_log.h"
+#include "s3_m0_uint128_helper.h"
 
 namespace S3M0Uint128Helper {
 
@@ -60,6 +61,24 @@ m0_uint128 to_m0_uint128(const std::string &id_str) {
     }
   }
   return id;
+}
+
+void to_string(const struct m0_fid &fid, std::string &s_res) {
+  s_res = base64_encode(reinterpret_cast<unsigned char const *>(&fid),
+                        sizeof(struct m0_fid));
+}
+
+bool to_m0_fid(const std::string &encoded, struct m0_fid &dst) {
+  std::string s_decoded = base64_decode(encoded);
+  const bool f_correct = (s_decoded.size() == sizeof(struct m0_fid));
+
+  if (f_correct) {
+    memcpy(&dst, s_decoded.c_str(), sizeof(struct m0_fid));
+  } else {
+    s3_log(S3_LOG_DEBUG, "", "Incorrect encoded m0_fid");
+    memset(&dst, 0, sizeof(struct m0_fid));
+  }
+  return f_correct;
 }
 
 }  // namespace S3M0Uint128Helper

--- a/server/s3_m0_uint128_helper.cc
+++ b/server/s3_m0_uint128_helper.cc
@@ -64,6 +64,8 @@ m0_uint128 to_m0_uint128(const std::string &id_str) {
 }
 
 void to_string(const struct m0_fid &fid, std::string &s_res) {
+  s3_log(S3_LOG_DEBUG, "", "Entering with fid %" SCNx64 " : %" SCNx64 "\n",
+         fid.f_container, fid.f_key);
   s_res = base64_encode(reinterpret_cast<unsigned char const *>(&fid),
                         sizeof(struct m0_fid));
 }

--- a/server/s3_m0_uint128_helper.h
+++ b/server/s3_m0_uint128_helper.h
@@ -29,6 +29,8 @@
 
 #include "motr_helpers.h"
 
+struct m0_fid;
+
 namespace S3M0Uint128Helper {
 
 std::pair<std::string, std::string> to_string_pair(const m0_uint128 &id);
@@ -36,6 +38,9 @@ std::string to_string(const m0_uint128 &id);
 m0_uint128 to_m0_uint128(const std::string &id_u_lo,
                          const std::string &id_u_hi);
 m0_uint128 to_m0_uint128(const std::string &id_str);
+
+void to_string(const struct m0_fid &fid, std::string &s_res);
+bool to_m0_fid(const std::string &encoded, struct m0_fid &dst);
 
 template <size_t IntSize>
 int non_zero_tmpl_hlpr(const m0_uint128 &id);

--- a/server/s3_motr_reader.h
+++ b/server/s3_motr_reader.h
@@ -166,21 +166,22 @@ class S3MotrReader {
   std::function<void()> handler_on_failed;
 
   struct m0_uint128 oid;
+  struct m0_fid pvid;
   int layout_id;
   size_t motr_unit_size;
 
-  S3MotrReaderOpState state;
+  S3MotrReaderOpState state = S3MotrReaderOpState::start;
 
   // Holds references to buffers after the read so it can be consumed.
-  struct s3_motr_rw_op_context* motr_rw_op_context;
-  size_t iteration_index;
+  struct s3_motr_rw_op_context* motr_rw_op_context = nullptr;
+  size_t iteration_index = 0;
   // to Help iteration.
-  size_t num_of_blocks_to_read;
+  size_t num_of_blocks_to_read = 0;
 
-  uint64_t last_index;
+  uint64_t last_index = 0;
 
-  bool is_object_opened;
-  struct s3_motr_obj_context* obj_ctx;
+  bool is_object_opened = false;
+  struct s3_motr_obj_context* obj_ctx = nullptr;
 
   // Internal open operation so motr can fetch required object metadata
   // for example object pool version
@@ -200,7 +201,8 @@ class S3MotrReader {
  public:
   // object id is generated at upper level and passed to this constructor
   S3MotrReader(std::shared_ptr<RequestObject> req, struct m0_uint128 id,
-               int layout_id, std::shared_ptr<MotrAPI> motr_api = nullptr);
+               int layout_id, struct m0_fid pvid = {},
+               std::shared_ptr<MotrAPI> motr_api = {});
   virtual ~S3MotrReader();
 
   virtual S3MotrReaderOpState get_state() { return state; }

--- a/server/s3_motr_writer.cc
+++ b/server/s3_motr_writer.cc
@@ -69,18 +69,13 @@ struct s3_motr_op_context *S3MotrWiterContext::get_motr_op_ctx() {
   return motr_op_context;
 }
 
-S3MotrWiter::S3MotrWiter(std::shared_ptr<RequestObject> req, uint64_t offset,
+S3MotrWiter::S3MotrWiter(std::shared_ptr<RequestObject> req,
                          std::shared_ptr<MotrAPI> motr_api)
-    : request(std::move(req)),
-      state(S3MotrWiterOpState::start),
-      last_index(offset),
-      size_in_current_write(0),
-      total_written(0),
-      is_object_opened(false),
-      obj_ctx(nullptr) {
+    : request(std::move(req)) {
 
   request_id = request->get_request_id();
   stripped_request_id = request->get_stripped_request_id();
+
   s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
   struct m0_uint128 oid = {0ULL, 0ULL};
@@ -90,35 +85,33 @@ S3MotrWiter::S3MotrWiter(std::shared_ptr<RequestObject> req, uint64_t offset,
   } else {
     s3_motr_api = std::make_shared<ConcreteMotrAPI>();
   }
-
   std::string uri_name;
+
   std::shared_ptr<S3RequestObject> s3_request =
       std::dynamic_pointer_cast<S3RequestObject>(request);
-  if (s3_request != nullptr) {
+
+  if (s3_request) {
     uri_name = s3_request->get_object_uri();
   } else {
     uri_name = request->c_get_full_path();
   }
   S3UriToMotrOID(s3_motr_api, uri_name.c_str(), request_id, &oid);
 
-  oid_list.clear();
   oid_list.push_back(oid);
-  layout_ids.clear();
-
-  place_holder_for_last_unit = NULL;
-  last_op_was_write = false;
-  unit_size_for_place_holder = -1;
 }
 
 S3MotrWiter::S3MotrWiter(std::shared_ptr<RequestObject> req,
-                         struct m0_uint128 object_id, uint64_t offset,
-                         std::shared_ptr<MotrAPI> motr_api)
-    : S3MotrWiter(std::move(req), offset, std::move(motr_api)) {
+                         struct m0_uint128 object_id, struct m0_fid pv_id,
+                         uint64_t offset, std::shared_ptr<MotrAPI> motr_api)
+    : S3MotrWiter(std::move(req), std::move(motr_api)) {
 
   s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
   oid_list.clear();
   oid_list.push_back(object_id);
+
+  pv_ids.push_back(pv_id);
+  last_index = offset;
 }
 
 S3MotrWiter::~S3MotrWiter() {
@@ -180,7 +173,10 @@ int S3MotrWiter::open_objects() {
   struct s3_motr_op_context *ctx = open_context->get_motr_op_ctx();
 
   std::ostringstream oid_list_stream;
-  size_t ops_count = oid_list.size();
+  const size_t ops_count = oid_list.size();
+
+  assert(layout_ids.size() == ops_count);
+  assert(pv_ids.size() == ops_count);
 
   for (size_t i = 0; i < ops_count; ++i) {
     struct s3_motr_context_obj *op_ctx = (struct s3_motr_context_obj *)calloc(
@@ -213,9 +209,11 @@ int S3MotrWiter::open_objects() {
       s3_motr_op_pre_launch_failure(op_ctx->application_context, rc);
       return rc;
     }
-
     ctx->ops[i]->op_datum = (void *)op_ctx;
     s3_motr_api->motr_op_setup(ctx->ops[i], &ctx->cbs[i], 0);
+
+    memcpy(&obj_ctx->objs[i].ob_attr.oa_pver, &pv_ids[i],
+           sizeof(struct m0_fid));
   }
   s3_log(S3_LOG_INFO, stripped_request_id, "Motr API: openobj(oid: %s)\n",
          oid_list_stream.str().c_str());
@@ -269,8 +267,20 @@ void S3MotrWiter::open_objects_failed() {
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
+void S3MotrWiter::set_oid(const struct m0_uint128 &id) {
+  is_object_opened = false;
+  oid_list.clear();
+  oid_list.push_back(id);
+}
+
+void S3MotrWiter::set_layout_id(int id) {
+  layout_ids.clear();
+  layout_ids.push_back(id);
+}
+
 void S3MotrWiter::create_object(std::function<void(void)> on_success,
                                 std::function<void(void)> on_failed,
+                                const struct m0_uint128 &object_id,
                                 int layoutid) {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry with layoutid = %d\n",
          __func__, layoutid);
@@ -282,11 +292,9 @@ void S3MotrWiter::create_object(std::function<void(void)> on_success,
     reset_buffers_if_any(unit_size_for_place_holder);
   }
   last_op_was_write = false;
-  layout_ids.clear();
-  layout_ids.push_back(layoutid);
-  is_object_opened = false;
 
-  assert(oid_list.size() == 1);
+  set_oid(object_id);
+  set_layout_id(layoutid);
 
   if (obj_ctx) {
     // clean up any old allocations
@@ -515,24 +523,26 @@ void S3MotrWiter::write_content_failed() {
 
 void S3MotrWiter::delete_object(std::function<void(void)> on_success,
                                 std::function<void(void)> on_failed,
-                                int layoutid) {
+                                const struct m0_uint128 &object_id,
+                                int layoutid, const struct m0_fid &pv_id) {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry with layoutid = %d\n",
          __func__, layoutid);
+
   handler_on_success = std::move(on_success);
   handler_on_failed = std::move(on_failed);
 
-  assert(oid_list.size() == 1);
   if (last_op_was_write && !layout_ids.empty()) {
     reset_buffers_if_any(unit_size_for_place_holder);
   }
   last_op_was_write = false;
-  layout_ids.clear();
-  layout_ids.push_back(layoutid);
+
+  set_oid(object_id);
+  set_layout_id(layoutid);
+
+  pv_ids.clear();
+  pv_ids.push_back(pv_id);
 
   state = S3MotrWiterOpState::deleting;
-
-  // We should already have an OID
-  assert(oid_list.size() == 1);
 
   if (is_object_opened) {
     delete_objects();
@@ -580,8 +590,10 @@ void S3MotrWiter::delete_objects() {
 
     ctx->ops[i]->op_datum = (void *)op_ctx;
     s3_motr_api->motr_op_setup(ctx->ops[i], &ctx->cbs[i], 0);
-    oid_list_stream << "(" << oid_list[i].u_hi << " " << oid_list[i].u_lo
+    oid_list_stream << '(' << oid_list[i].u_hi << ' ' << oid_list[i].u_lo
                     << ") ";
+    memcpy(&obj_ctx->objs[i].ob_attr.oa_pver, &pv_ids[i],
+           sizeof(struct m0_fid));
   }
 
   delete_context->start_timer_for("delete_objects_from_motr");
@@ -625,6 +637,7 @@ void S3MotrWiter::delete_objects_failed() {
 
 void S3MotrWiter::delete_objects(std::vector<struct m0_uint128> oids,
                                  std::vector<int> layoutids,
+                                 std::vector<struct m0_fid> pvids,
                                  std::function<void(void)> on_success,
                                  std::function<void(void)> on_failed) {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
@@ -634,6 +647,7 @@ void S3MotrWiter::delete_objects(std::vector<struct m0_uint128> oids,
 
   oid_list = std::move(oids);
   layout_ids = std::move(layoutids);
+  pv_ids = std::move(pvids);
 
   state = S3MotrWiterOpState::deleting;
 
@@ -733,4 +747,10 @@ void S3MotrWiter::set_up_motr_data_buffers(struct s3_motr_rw_op_context *rw_ctx,
          size_in_current_write);
 
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
+
+struct m0_fid *S3MotrWiter::get_ppvid() const {
+  return obj_ctx && obj_ctx->n_initialized_contexts && obj_ctx->objs
+             ? &obj_ctx->objs->ob_attr.oa_pver
+             : nullptr;
 }

--- a/server/s3_motr_writer.h
+++ b/server/s3_motr_writer.h
@@ -92,37 +92,41 @@ class S3MotrWiter {
 
   std::vector<struct m0_uint128> oid_list;
   std::vector<int> layout_ids;
+  std::vector<struct m0_fid> pv_ids;
 
-  S3MotrWiterOpState state;
+  S3MotrWiterOpState state = S3MotrWiterOpState::start;
 
   std::string content_md5;
-  uint64_t last_index;
+  uint64_t last_index = 0;
   std::string request_id;
   std::string stripped_request_id;
   // md5 for the content written to motr.
   MD5hash md5crypt;
 
   // maintain state for debugging.
-  size_t size_in_current_write;
-  size_t total_written;
+  size_t size_in_current_write = 0;
+  size_t total_written = 0;
 
-  bool is_object_opened;
-  struct s3_motr_obj_context* obj_ctx;
+  bool is_object_opened = false;
+  struct s3_motr_obj_context* obj_ctx = nullptr;
 
-  void* place_holder_for_last_unit;
+  void* place_holder_for_last_unit = nullptr;
   // layout_id for place_holder_for_last_unit can be changed if
   // the motr_writer object is reused after use for writing data.
   // create motr_writer and use for write data with layout id = 9
   // followed by reusing same object for deleting obj layout id =1
   // This causes buffer to be returned to pool with wrong id.
-  bool last_op_was_write;
-  int unit_size_for_place_holder;
+  bool last_op_was_write = false;
+  int unit_size_for_place_holder = -1;
 
   // buffer currently used to write, will be freed on completion
   S3BufferSequence buffer_sequence;
   size_t size_of_each_buf;
 
   // Write - single object, delete - multiple objects supported
+  void create_object_successful();
+  void create_object_failed();
+
   int open_objects();
   void open_objects_successful();
   void open_objects_failed();
@@ -140,10 +144,14 @@ class S3MotrWiter {
  public:
   // struct m0_uint128 id;
   S3MotrWiter(std::shared_ptr<RequestObject> req, struct m0_uint128 object_id,
-              uint64_t offset = 0, std::shared_ptr<MotrAPI> motr_api = nullptr);
-  S3MotrWiter(std::shared_ptr<RequestObject> req, uint64_t offset = 0,
-              std::shared_ptr<MotrAPI> motr_api = nullptr);
+              struct m0_fid pv_id, uint64_t offset = 0,
+              std::shared_ptr<MotrAPI> motr_api = {});
+
+  S3MotrWiter(std::shared_ptr<RequestObject> req,
+              std::shared_ptr<MotrAPI> motr_api = {});
+
   virtual ~S3MotrWiter();
+
   void reset_buffers_if_any(int buf_unit_sz);
 
   virtual S3MotrWiterOpState get_state() { return state; }
@@ -158,16 +166,8 @@ class S3MotrWiter {
     return layout_ids[0];
   }
 
-  virtual void set_oid(struct m0_uint128 id) {
-    is_object_opened = false;
-    oid_list.clear();
-    oid_list.push_back(id);
-  }
-
-  virtual void set_layout_id(int id) {
-    layout_ids.clear();
-    layout_ids.push_back(id);
-  }
+  virtual void set_oid(const struct m0_uint128& id);
+  virtual void set_layout_id(int id);
 
   // This concludes the md5 calculation
   virtual std::string get_content_md5() {
@@ -190,10 +190,8 @@ class S3MotrWiter {
 
   // async create
   virtual void create_object(std::function<void(void)> on_success,
-                             std::function<void(void)> on_failed, int layoutid);
-  void create_object_successful();
-  void create_object_failed();
-
+                             std::function<void(void)> on_failed,
+                             const struct m0_uint128& object_id, int layoutid);
   // Async save operation.
   virtual void write_content(std::function<void(void)> on_success,
                              std::function<void(void)> on_failed,
@@ -201,11 +199,15 @@ class S3MotrWiter {
                              size_t size_of_each_buf);
 
   // Async delete operation.
+  // TODO: add pool version id into BackgroundDelete memo
   virtual void delete_object(std::function<void(void)> on_success,
-                             std::function<void(void)> on_failed, int layoutid);
+                             std::function<void(void)> on_failed,
+                             const struct m0_uint128& object_id, int layoutid,
+                             const struct m0_fid& pv_id = {});  // BG delete
 
   virtual void delete_objects(std::vector<struct m0_uint128> oids,
                               std::vector<int> layoutids,
+                              std::vector<struct m0_fid> pv_ids,
                               std::function<void(void)> on_success,
                               std::function<void(void)> on_failed);
 
@@ -215,6 +217,7 @@ class S3MotrWiter {
   void set_up_motr_data_buffers(struct s3_motr_rw_op_context* rw_ctx,
                                 S3BufferSequence buffer_sequence,
                                 size_t motr_buf_count);
+  struct m0_fid* get_ppvid() const;
 
   // For Testing purpose
   FRIEND_TEST(S3MotrWiterTest, Constructor);

--- a/server/s3_object_data_copier.cc
+++ b/server/s3_object_data_copier.cc
@@ -306,7 +306,7 @@ void S3ObjectDataCopier::write_data_block_failed() {
 
 void S3ObjectDataCopier::copy(
     struct m0_uint128 src_obj_id, size_t object_size, int layout_id,
-    std::function<bool(void)> check_shutdown_and_rollback,
+    struct m0_fid pvid, std::function<bool(void)> check_shutdown_and_rollback,
     std::function<void(void)> on_success,
     std::function<void(void)> on_failure) {
   s3_log(S3_LOG_INFO, request_id, "%s Entry\n", __func__);
@@ -326,7 +326,7 @@ void S3ObjectDataCopier::copy(
       S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(layout_id);
 
   motr_reader = motr_reader_factory->create_motr_reader(
-      request_object, src_obj_id, layout_id, motr_api);
+      request_object, src_obj_id, layout_id, pvid, motr_api);
   motr_reader->set_last_index(0);
 
   bytes_left_to_read = object_size;

--- a/server/s3_object_data_copier.h
+++ b/server/s3_object_data_copier.h
@@ -27,6 +27,7 @@
 #include <gtest/gtest_prod.h>
 
 #include "lib/types.h"  // struct m0_uint128
+#include "fid/fid.h"    // struct m0_fid
 #include "s3_buffer_sequence.h"
 
 class RequestObject;
@@ -79,6 +80,7 @@ class S3ObjectDataCopier {
   ~S3ObjectDataCopier();
 
   void copy(struct m0_uint128 src_obj_id, size_t object_size, int layout_id,
+            struct m0_fid pvid,
             std::function<bool(void)> check_shutdown_and_rollback,
             std::function<void(void)> on_success,
             std::function<void(void)> on_failure);

--- a/server/s3_object_metadata.cc
+++ b/server/s3_object_metadata.cc
@@ -790,5 +790,6 @@ void S3ObjectMetadata::set_pvid(const struct m0_fid* p_pvid) {
     S3M0Uint128Helper::to_string(*p_pvid, pvid_str);
   } else {
     s3_log(S3_LOG_DEBUG, request_id, "%s - NULL pointer", __func__);
+    pvid_str.clear();
   }
 }

--- a/server/s3_object_metadata.cc
+++ b/server/s3_object_metadata.cc
@@ -582,6 +582,7 @@ std::string S3ObjectMetadata::to_json() {
   }
 
   root["motr_oid"] = motr_oid_str;
+  root["PVID"] = this->pvid_str;
 
   for (auto sit : system_defined_attribute) {
     root["System-Defined"][sit.first] = sit.second;
@@ -672,7 +673,7 @@ int S3ObjectMetadata::from_json(std::string content) {
 
   motr_oid_str = newroot["motr_oid"].asString();
   layout_id = newroot["layout_id"].asInt();
-
+  pvid_str = newroot["PVID"].asString();
   oid = S3M0Uint128Helper::to_m0_uint128(motr_oid_str);
 
   //
@@ -778,3 +779,16 @@ bool S3ObjectMetadata::check_object_tags_exists() {
 
 int S3ObjectMetadata::object_tags_count() { return object_tags.size(); }
 
+struct m0_fid S3ObjectMetadata::get_pvid() const {
+  struct m0_fid pvid;
+  S3M0Uint128Helper::to_m0_fid(pvid_str, pvid);
+  return pvid;
+}
+
+void S3ObjectMetadata::set_pvid(const struct m0_fid* p_pvid) {
+  if (p_pvid) {
+    S3M0Uint128Helper::to_string(*p_pvid, pvid_str);
+  } else {
+    s3_log(S3_LOG_DEBUG, request_id, "%s - NULL pointer", __func__);
+  }
+}

--- a/server/s3_object_metadata.h
+++ b/server/s3_object_metadata.h
@@ -136,6 +136,7 @@ class S3ObjectMetadata : private S3ObjectMetadataCopyable {
   // Any validations we want to do on metadata.
   void validate();
   std::string index_name;
+  std::string pvid_str;
 
   // TODO Eventually move these to s3_common as duplicated in s3_bucket_metadata
   // This index has keys as "object_name"
@@ -233,6 +234,12 @@ class S3ObjectMetadata : private S3ObjectMetadataCopyable {
   std::string& get_encoded_object_acl();
   std::string get_acl_as_xml();
 
+  struct m0_fid get_pvid() const;
+  void set_pvid(const struct m0_fid* p_pvid);
+
+  const std::string& get_pvid_str() const { return pvid_str; }
+  void set_pvid_str(const std::string& val) { pvid_str = val; }
+
   // Load attributes.
   std::string get_system_attribute(std::string key);
   void add_system_attribute(std::string key, std::string val);
@@ -281,7 +288,7 @@ class S3ObjectMetadata : private S3ObjectMetadataCopyable {
   virtual int object_tags_count();
 
   // Virtual Destructor
-  virtual ~S3ObjectMetadata(){};
+  virtual ~S3ObjectMetadata() {};
 
  private:
   // Methods used internally within
@@ -348,4 +355,3 @@ class S3ObjectMetadata : private S3ObjectMetadataCopyable {
 };
 
 #endif
-

--- a/server/s3_post_complete_action.cc
+++ b/server/s3_post_complete_action.cc
@@ -922,7 +922,7 @@ void S3PostCompleteAction::delete_old_object() {
       std::bind(&S3PostCompleteAction::remove_old_object_version_metadata,
                 this),
       std::bind(&S3PostCompleteAction::next, this), old_object_oid,
-      old_layout_id);
+      old_layout_id, multipart_metadata->get_pvid());
 
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_post_complete_action.cc
+++ b/server/s3_post_complete_action.cc
@@ -610,6 +610,7 @@ void S3PostCompleteAction::save_metadata() {
     new_object_metadata->set_content_type(
         multipart_metadata->get_content_type());
     new_object_metadata->set_md5(etag);
+    new_object_metadata->set_pvid_str(multipart_metadata->get_pvid_str());
 
     new_object_metadata->save(
         std::bind(&S3PostCompleteAction::save_object_metadata_succesful, this),
@@ -902,8 +903,7 @@ void S3PostCompleteAction::mark_old_oid_for_deletion() {
 
 void S3PostCompleteAction::delete_old_object() {
   if (!motr_writer) {
-    motr_writer =
-        motr_writer_factory->create_motr_writer(request, old_object_oid);
+    motr_writer = motr_writer_factory->create_motr_writer(request);
   }
   // process to delete old object
   assert(old_object_oid.u_hi || old_object_oid.u_lo);
@@ -918,11 +918,12 @@ void S3PostCompleteAction::delete_old_object() {
     next();
     return;
   }
-  motr_writer->set_oid(old_object_oid);
   motr_writer->delete_object(
       std::bind(&S3PostCompleteAction::remove_old_object_version_metadata,
                 this),
-      std::bind(&S3PostCompleteAction::next, this), old_layout_id);
+      std::bind(&S3PostCompleteAction::next, this), old_object_oid,
+      old_layout_id);
+
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
@@ -989,14 +990,11 @@ void S3PostCompleteAction::delete_new_object() {
   assert(is_abort_multipart());
 
   if (!motr_writer) {
-    motr_writer =
-        motr_writer_factory->create_motr_writer(request, new_object_oid);
-  } else {
-    motr_writer->set_oid(new_object_oid);
+    motr_writer = motr_writer_factory->create_motr_writer(request);
   }
   motr_writer->delete_object(
       std::bind(&S3PostCompleteAction::remove_new_oid_probable_record, this),
-      std::bind(&S3PostCompleteAction::next, this), layout_id);
+      std::bind(&S3PostCompleteAction::next, this), new_object_oid, layout_id);
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 

--- a/server/s3_put_chunk_upload_object_action.cc
+++ b/server/s3_put_chunk_upload_object_action.cc
@@ -995,7 +995,7 @@ void S3PutChunkUploadObjectAction::delete_old_object() {
             &S3PutChunkUploadObjectAction::remove_old_object_version_metadata,
             this),
         std::bind(&S3PutChunkUploadObjectAction::next, this), old_object_oid,
-        old_layout_id);
+        old_layout_id, object_metadata->get_pvid());
   }
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_put_chunk_upload_object_action.cc
+++ b/server/s3_put_chunk_upload_object_action.cc
@@ -330,11 +330,9 @@ void S3PutChunkUploadObjectAction::_set_layout_id(int layout_id) {
 void S3PutChunkUploadObjectAction::create_object() {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   create_object_timer.start();
+
   if (tried_count == 0) {
-    motr_writer =
-        motr_writer_factory->create_motr_writer(request, new_object_oid);
-  } else {
-    motr_writer->set_oid(new_object_oid);
+    motr_writer = motr_writer_factory->create_motr_writer(request);
   }
   _set_layout_id(S3MotrLayoutMap::get_instance()->get_layout_for_object_size(
       request->get_data_length()));
@@ -342,7 +340,7 @@ void S3PutChunkUploadObjectAction::create_object() {
   motr_writer->create_object(
       std::bind(&S3PutChunkUploadObjectAction::create_object_successful, this),
       std::bind(&S3PutChunkUploadObjectAction::create_object_failed, this),
-      layout_id);
+      new_object_oid, layout_id);
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
@@ -662,6 +660,7 @@ void S3PutChunkUploadObjectAction::save_metadata() {
   new_object_metadata->set_content_type(request->get_content_type());
   new_object_metadata->set_md5(motr_writer->get_content_md5());
   new_object_metadata->set_tags(new_object_tags_map);
+  new_object_metadata->set_pvid(motr_writer->get_ppvid());
 
   for (auto it : request->get_in_headers_copy()) {
     if (it.first.find("x-amz-meta-") != std::string::npos) {
@@ -990,15 +989,14 @@ void S3PutChunkUploadObjectAction::delete_old_object() {
            "BD.\n");
     // Call next task in the pipeline
     next();
-    return;
+  } else {
+    motr_writer->delete_object(
+        std::bind(
+            &S3PutChunkUploadObjectAction::remove_old_object_version_metadata,
+            this),
+        std::bind(&S3PutChunkUploadObjectAction::next, this), old_object_oid,
+        old_layout_id);
   }
-
-  motr_writer->set_oid(old_object_oid);
-  motr_writer->delete_object(
-      std::bind(
-          &S3PutChunkUploadObjectAction::remove_old_object_version_metadata,
-          this),
-      std::bind(&S3PutChunkUploadObjectAction::next, this), old_layout_id);
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
@@ -1019,11 +1017,12 @@ void S3PutChunkUploadObjectAction::delete_new_object() {
          S3PutChunkUploadObjectActionState::completed);
   assert(new_object_oid.u_hi != 0ULL || new_object_oid.u_lo != 0ULL);
 
-  motr_writer->set_oid(new_object_oid);
   motr_writer->delete_object(
       std::bind(&S3PutChunkUploadObjectAction::remove_new_oid_probable_record,
                 this),
-      std::bind(&S3PutChunkUploadObjectAction::next, this), layout_id);
+      std::bind(&S3PutChunkUploadObjectAction::next, this), new_object_oid,
+      layout_id);
+
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 

--- a/server/s3_put_multiobject_action.cc
+++ b/server/s3_put_multiobject_action.cc
@@ -353,7 +353,8 @@ void S3PutMultiObjectAction::compute_part_offset() {
   }
   // Create writer to write from given offset as per the partnumber
   motr_writer = motr_writer_factory->create_motr_writer(
-      request, object_multipart_metadata->get_oid(), offset);
+      request, object_multipart_metadata->get_oid(),
+      object_multipart_metadata->get_pvid(), offset);
 
   _set_layout_id(object_multipart_metadata->get_layout_id());
   motr_writer->set_layout_id(layout_id);

--- a/server/s3_put_object_action_base.cc
+++ b/server/s3_put_object_action_base.cc
@@ -469,7 +469,7 @@ void S3PutObjectActionBase::delete_old_object() {
       std::bind(&S3PutObjectActionBase::remove_old_object_version_metadata,
                 this),
       std::bind(&S3PutObjectActionBase::next, this), old_object_oid,
-      old_layout_id);
+      old_layout_id, object_metadata->get_pvid());
 
   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
 }

--- a/server/s3_put_object_action_base.cc
+++ b/server/s3_put_object_action_base.cc
@@ -158,17 +158,15 @@ void S3PutObjectActionBase::create_object() {
   s3_log(S3_LOG_INFO, request_id, "Entering\n");
 
   if (!tried_count) {
-    motr_writer =
-        motr_writer_factory->create_motr_writer(request, new_object_oid);
-  } else {
-    motr_writer->set_oid(new_object_oid);
+    motr_writer = motr_writer_factory->create_motr_writer(request);
   }
   _set_layout_id(S3MotrLayoutMap::get_instance()->get_layout_for_object_size(
       total_data_to_stream));
 
   motr_writer->create_object(
       std::bind(&S3PutObjectActionBase::create_object_successful, this),
-      std::bind(&S3PutObjectActionBase::create_object_failed, this), layout_id);
+      std::bind(&S3PutObjectActionBase::create_object_failed, this),
+      new_object_oid, layout_id);
 
   // for shutdown testcases, check FI and set shutdown signal
   S3_CHECK_FI_AND_SET_SHUTDOWN_SIGNAL(
@@ -467,11 +465,12 @@ void S3PutObjectActionBase::delete_old_object() {
   // If PUT is success, we delete old object if present
   assert(old_object_oid.u_hi != 0ULL || old_object_oid.u_lo != 0ULL);
 
-  motr_writer->set_oid(old_object_oid);
   motr_writer->delete_object(
       std::bind(&S3PutObjectActionBase::remove_old_object_version_metadata,
                 this),
-      std::bind(&S3PutObjectActionBase::next, this), old_layout_id);
+      std::bind(&S3PutObjectActionBase::next, this), old_object_oid,
+      old_layout_id);
+
   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
 }
 
@@ -490,10 +489,10 @@ void S3PutObjectActionBase::delete_new_object() {
   assert(s3_put_action_state != S3PutObjectActionState::completed);
   assert(new_object_oid.u_hi != 0ULL || new_object_oid.u_lo != 0ULL);
 
-  motr_writer->set_oid(new_object_oid);
   motr_writer->delete_object(
       std::bind(&S3PutObjectActionBase::remove_new_oid_probable_record, this),
-      std::bind(&S3PutObjectActionBase::next, this), layout_id);
+      std::bind(&S3PutObjectActionBase::next, this), new_object_oid, layout_id);
+
   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
 }
 

--- a/ut/mock_s3_factory.h
+++ b/ut/mock_s3_factory.h
@@ -144,10 +144,9 @@ class MockS3ObjectMultipartMetadataFactory
 
 class MockS3MotrWriterFactory : public S3MotrWriterFactory {
  public:
-  MockS3MotrWriterFactory(std::shared_ptr<RequestObject> req, m0_uint128 oid,
-                          std::shared_ptr<MockS3Motr> ptr_mock_s3_motr_api =
-                              nullptr)
-      : S3MotrWriterFactory() {
+  MockS3MotrWriterFactory(
+      std::shared_ptr<RequestObject> req, m0_uint128 oid,
+      std::shared_ptr<MockS3Motr> ptr_mock_s3_motr_api = {}) {
     mock_motr_writer =
         std::make_shared<MockS3MotrWiter>(req, oid, ptr_mock_s3_motr_api);
   }
@@ -160,18 +159,13 @@ class MockS3MotrWriterFactory : public S3MotrWriterFactory {
   }
 
   std::shared_ptr<S3MotrWiter> create_motr_writer(
-      std::shared_ptr<RequestObject> req, struct m0_uint128 oid) override {
-    return mock_motr_writer;
-  }
-
-  std::shared_ptr<S3MotrWiter> create_motr_writer(
       std::shared_ptr<RequestObject> req) override {
     return mock_motr_writer;
   }
 
   std::shared_ptr<S3MotrWiter> create_motr_writer(
       std::shared_ptr<RequestObject> req, struct m0_uint128 oid,
-      uint64_t offset) override {
+      struct m0_fid pv_id, uint64_t offset) override {
     return mock_motr_writer;
   }
 
@@ -182,16 +176,15 @@ class MockS3MotrReaderFactory : public S3MotrReaderFactory {
  public:
   MockS3MotrReaderFactory(std::shared_ptr<RequestObject> req, m0_uint128 oid,
                           int layout_id,
-                          std::shared_ptr<MockS3Motr> s3_motr_mock_apis =
-                              nullptr)
-      : S3MotrReaderFactory() {
+                          std::shared_ptr<MockS3Motr> s3_motr_mock_apis = {}) {
     mock_motr_reader = std::make_shared<MockS3MotrReader>(req, oid, layout_id,
                                                           s3_motr_mock_apis);
   }
 
   std::shared_ptr<S3MotrReader> create_motr_reader(
       std::shared_ptr<RequestObject> req, struct m0_uint128 oid, int layout_id,
-      std::shared_ptr<MotrAPI> motr_api = nullptr) override {
+      struct m0_fid pvid = {},
+      std::shared_ptr<MotrAPI> motr_api = {}) override {
     return mock_motr_reader;
   }
 
@@ -325,4 +318,3 @@ class MockS3GlobalBucketIndexMetadataFactory
 };
 
 #endif
-

--- a/ut/mock_s3_motr_reader.h
+++ b/ut/mock_s3_motr_reader.h
@@ -34,11 +34,11 @@ using ::testing::Return;
 class MockS3MotrReader : public S3MotrReader {
  public:
   MockS3MotrReader(std::shared_ptr<RequestObject> req, struct m0_uint128 oid,
-                   int layout_id, std::shared_ptr<MotrAPI> motr_api = nullptr)
-      : S3MotrReader(req, oid, layout_id, motr_api) {}
+                   int layout_id, std::shared_ptr<MotrAPI> motr_api = {})
+      : S3MotrReader(req, oid, layout_id, {}, motr_api) {}
+
   MOCK_METHOD0(get_state, S3MotrReaderOpState());
   MOCK_METHOD0(get_oid, struct m0_uint128());
-  MOCK_METHOD0(get_value, std::string());
   MOCK_METHOD1(set_oid, void(struct m0_uint128 oid));
   MOCK_METHOD3(read_object_data,
                bool(size_t num_of_blocks, std::function<void(void)> on_success,

--- a/ut/mock_s3_motr_writer.h
+++ b/ut/mock_s3_motr_writer.h
@@ -37,29 +37,28 @@ class MockS3MotrWiter : public S3MotrWiter {
  public:
   MockS3MotrWiter(std::shared_ptr<RequestObject> req, struct m0_uint128 oid,
                   std::shared_ptr<MockS3Motr> s3_motr_mock_ptr)
-      : S3MotrWiter(req, oid, 0, s3_motr_mock_ptr) {}
+      : S3MotrWiter(req, oid, {}, 0, s3_motr_mock_ptr) {}
   MockS3MotrWiter(std::shared_ptr<RequestObject> req,
                   std::shared_ptr<MockS3Motr> s3_motr_mock_ptr)
-      : S3MotrWiter(req, 0, s3_motr_mock_ptr) {}
+      : S3MotrWiter(req, s3_motr_mock_ptr) {}
 
   MOCK_METHOD0(get_state, S3MotrWiterOpState());
   MOCK_METHOD0(get_oid, struct m0_uint128());
   MOCK_METHOD0(get_content_md5, std::string());
   MOCK_METHOD1(get_op_ret_code_for, int(int));
   MOCK_METHOD1(get_op_ret_code_for_delete_op, int(int));
-  MOCK_METHOD3(create_object,
-               void(std::function<void(void)> on_success,
-                    std::function<void(void)> on_failed, int layout_id));
-  MOCK_METHOD3(delete_object,
-               void(std::function<void(void)> on_success,
-                    std::function<void(void)> on_failed, int layout_id));
-  MOCK_METHOD3(delete_index,
-               void(struct m0_uint128 oid, std::function<void(void)> on_success,
+  MOCK_METHOD4(create_object, void(std::function<void(void)> on_success,
+                                   std::function<void(void)> on_failed,
+                                   const struct m0_uint128&, int layout_id));
+  MOCK_METHOD5(delete_object, void(std::function<void(void)> on_success,
+                                   std::function<void(void)> on_failed,
+                                   const struct m0_uint128&, int layout_id,
+                                   const struct m0_fid&));
+  MOCK_METHOD5(delete_objects,
+               void(std::vector<struct m0_uint128> oids,
+                    std::vector<int> layoutids, std::vector<struct m0_fid>,
+                    std::function<void(void)> on_success,
                     std::function<void(void)> on_failed));
-  MOCK_METHOD4(delete_objects, void(std::vector<struct m0_uint128> oids,
-                                    std::vector<int> layoutids,
-                                    std::function<void(void)> on_success,
-                                    std::function<void(void)> on_failed));
   MOCK_METHOD1(set_oid, void(struct m0_uint128 oid));
   MOCK_METHOD4(write_content, void(std::function<void(void)> on_success,
                                    std::function<void(void)> on_failed,

--- a/ut/s3_copy_object_action_test.cc
+++ b/ut/s3_copy_object_action_test.cc
@@ -559,7 +559,7 @@ TEST_F(S3CopyObjectActionTest, CreateObjectFirstAttempt) {
   action_under_test->total_data_to_stream = 1024;
 
   EXPECT_CALL(*ptr_mock_motr_writer_factory->mock_motr_writer,
-              create_object(_, _, _)).Times(1);
+              create_object(_, _, _, _)).Times(1);
 
   action_under_test->create_object();
 
@@ -574,10 +574,8 @@ TEST_F(S3CopyObjectActionTest, CreateObjectSecondAttempt) {
 
   action_under_test->tried_count = 1;
 
-  EXPECT_CALL(*ptr_mock_motr_writer_factory->mock_motr_writer, set_oid(_))
-      .Times(1);
   EXPECT_CALL(*ptr_mock_motr_writer_factory->mock_motr_writer,
-              create_object(_, _, _)).Times(1);
+              create_object(_, _, _, _)).Times(1);
 
   action_under_test->create_object();
 }
@@ -618,10 +616,8 @@ TEST_F(S3CopyObjectActionTest, CreateObjectFailedWithCollisionRetry) {
   EXPECT_CALL(*ptr_mock_motr_writer_factory->mock_motr_writer, get_state())
       .Times(1)
       .WillOnce(Return(S3MotrWiterOpState::exists));
-  EXPECT_CALL(*ptr_mock_motr_writer_factory->mock_motr_writer, set_oid(_))
-      .Times(1);
   EXPECT_CALL(*ptr_mock_motr_writer_factory->mock_motr_writer,
-              create_object(_, _, _)).Times(1);
+              create_object(_, _, _, _)).Times(1);
 
   action_under_test->create_object_failed();
 }
@@ -629,7 +625,7 @@ TEST_F(S3CopyObjectActionTest, CreateObjectFailedWithCollisionRetry) {
 TEST_F(S3CopyObjectActionTest, CreateObjectFailedTest) {
   action_under_test->total_data_to_stream = 1024;
   EXPECT_CALL(*ptr_mock_motr_writer_factory->mock_motr_writer,
-              create_object(_, _, _)).Times(1);
+              create_object(_, _, _, _)).Times(1);
   action_under_test->create_object();
 
   EXPECT_CALL(*ptr_mock_motr_writer_factory->mock_motr_writer, get_state())
@@ -646,7 +642,7 @@ TEST_F(S3CopyObjectActionTest, CreateObjectFailedTest) {
 TEST_F(S3CopyObjectActionTest, CreateObjectFailedToLaunchTest) {
   action_under_test->total_data_to_stream = 1024;
   EXPECT_CALL(*ptr_mock_motr_writer_factory->mock_motr_writer,
-              create_object(_, _, _)).Times(1);
+              create_object(_, _, _, _)).Times(1);
   action_under_test->create_object();
 
   EXPECT_CALL(*ptr_mock_motr_writer_factory->mock_motr_writer, get_state())

--- a/ut/s3_delete_bucket_action_test.cc
+++ b/ut/s3_delete_bucket_action_test.cc
@@ -410,7 +410,7 @@ TEST_F(S3DeleteBucketActionTest,
        DeleteMultipartObjectsMultipartObjectsPresent) {
   action_under_test->multipart_object_oids.push_back(oid);
   EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
-              delete_objects(_, _, _, _)).Times(1);
+              delete_objects(_, _, _, _, _)).Times(1);
   action_under_test->delete_multipart_objects();
 }
 

--- a/ut/s3_delete_multiple_objects_action_test.cc
+++ b/ut/s3_delete_multiple_objects_action_test.cc
@@ -759,7 +759,7 @@ TEST_F(S3DeleteMultipleObjectsActionTest, CleanupOnMetadataSavedDelayedDel) {
   action_under_test->motr_writer = motr_writer_factory->mock_motr_writer;
 
   EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
-              delete_objects(_, _, _, _)).Times(AtLeast(0));
+              delete_objects(_, _, _, _, _)).Times(AtLeast(0));
 
   action_under_test->cleanup();
 }
@@ -775,7 +775,7 @@ TEST_F(S3DeleteMultipleObjectsActionTest, CleanupOnMetadataSavedTest1) {
   action_under_test->motr_writer = motr_writer_factory->mock_motr_writer;
 
   EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
-              delete_objects(_, _, _, _)).Times(AtLeast(1));
+              delete_objects(_, _, _, _, _)).Times(AtLeast(1));
 
   action_under_test->cleanup();
 }
@@ -786,8 +786,8 @@ TEST_F(S3DeleteMultipleObjectsActionTest, CleanupOnMetadataSavedTest2) {
       motr_kvs_writer_factory->mock_motr_kvs_writer;
   action_under_test->motr_writer = motr_writer_factory->mock_motr_writer;
 
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), delete_object(_, _, _))
-      .Times(0);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
+              delete_object(_, _, _, _, _)).Times(0);
 
   action_under_test->cleanup();
 }
@@ -865,7 +865,7 @@ TEST_F(S3DeleteMultipleObjectsActionTest, DelayedDeleteMultipleObjects) {
   action_under_test->motr_writer = motr_writer_factory->mock_motr_writer;
 
   EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
-              delete_objects(_, _, _, _)).Times(0);
+              delete_objects(_, _, _, _, _)).Times(0);
 
   action_under_test->cleanup();
 }

--- a/ut/s3_delete_object_action_test.cc
+++ b/ut/s3_delete_object_action_test.cc
@@ -310,9 +310,8 @@ TEST_F(S3DeleteObjectActionTest, DeleteObject) {
       .WillRepeatedly(Return(obj_oid));
   EXPECT_CALL(*(object_meta_factory->mock_object_metadata), get_layout_id())
       .Times(AtLeast(1));
-
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), delete_object(_, _, _))
-      .Times(1);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
+              delete_object(_, _, _, _, _)).Times(1);
 
   action_under_test->delete_object();
 }
@@ -328,8 +327,8 @@ TEST_F(S3DeleteObjectActionTest, DelayedDeleteObject) {
       .WillRepeatedly(Return(obj_oid));
   EXPECT_CALL(*(object_meta_factory->mock_object_metadata), get_layout_id())
       .Times(0);
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), delete_object(_, _, _))
-      .Times(0);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
+              delete_object(_, _, _, _, _)).Times(0);
   action_under_test->delete_object();
 }
 

--- a/ut/s3_motr_reader_test.cc
+++ b/ut/s3_motr_reader_test.cc
@@ -88,12 +88,13 @@ class S3MotrReaderTest : public testing::Test {
     request_mock = std::make_shared<MockS3RequestObject>(req, evhtp_obj_ptr);
     s3_motr_api_mock = std::make_shared<MockS3Motr>();
     motr_reader_ptr = std::make_shared<S3MotrReader>(
-        request_mock, oid, layout_id, s3_motr_api_mock);
+        request_mock, oid, layout_id, pv_id, s3_motr_api_mock);
   }
 
   ~S3MotrReaderTest() { event_base_free(evbase); }
 
   struct m0_uint128 oid;
+  struct m0_fid pv_id = {};
   int layout_id;
   evbase_t *evbase;
   evhtp_request_t *req;
@@ -302,8 +303,8 @@ TEST_F(S3MotrReaderTest, OpenObjectTest) {
 TEST_F(S3MotrReaderTest, OpenObjectFailedTest) {
   S3CallBack S3MotrWiter_callbackobj;
 
-  motr_reader_ptr =
-      std::make_shared<S3MotrReader>(request_mock, oid, 1, s3_motr_api_mock);
+  motr_reader_ptr = std::make_shared<S3MotrReader>(request_mock, oid, 1, pv_id,
+                                                   s3_motr_api_mock);
 
   EXPECT_CALL(*s3_motr_api_mock, motr_obj_init(_, _, _, _)).Times(1);
   EXPECT_CALL(*s3_motr_api_mock, motr_entity_open(_, _))

--- a/ut/s3_motr_writer_test.cc
+++ b/ut/s3_motr_writer_test.cc
@@ -135,6 +135,7 @@ class S3MotrWiterTest : public testing::Test {
   evbase_t *evbase;
   evhtp_request_t *req;
   struct m0_uint128 obj_oid;
+  struct m0_fid pv_id = {};
   int layout_id;
   std::shared_ptr<MockS3RequestObject> request_mock;
   std::shared_ptr<MockS3Motr> s3_motr_api_mock;
@@ -145,8 +146,8 @@ class S3MotrWiterTest : public testing::Test {
 };
 
 TEST_F(S3MotrWiterTest, Constructor) {
-  motr_writer_ptr =
-      std::make_shared<S3MotrWiter>(request_mock, obj_oid, 0, s3_motr_api_mock);
+  motr_writer_ptr = std::make_shared<S3MotrWiter>(request_mock, obj_oid, pv_id,
+                                                  0, s3_motr_api_mock);
   EXPECT_EQ(S3MotrWiterOpState::start, motr_writer_ptr->get_state());
   EXPECT_EQ(request_mock, motr_writer_ptr->request);
   EXPECT_EQ(0, motr_writer_ptr->size_in_current_write);
@@ -158,7 +159,7 @@ TEST_F(S3MotrWiterTest, Constructor) {
 
 TEST_F(S3MotrWiterTest, Constructor2) {
   motr_writer_ptr =
-      std::make_shared<S3MotrWiter>(request_mock, 0, s3_motr_api_mock);
+      std::make_shared<S3MotrWiter>(request_mock, s3_motr_api_mock);
   EXPECT_EQ(S3MotrWiterOpState::start, motr_writer_ptr->get_state());
   EXPECT_EQ(request_mock, motr_writer_ptr->request);
   EXPECT_EQ(0, motr_writer_ptr->size_in_current_write);
@@ -169,8 +170,8 @@ TEST_F(S3MotrWiterTest, Constructor2) {
 TEST_F(S3MotrWiterTest, CreateObjectTest) {
   S3CallBack S3MotrWiter_callbackobj;
 
-  motr_writer_ptr =
-      std::make_shared<S3MotrWiter>(request_mock, obj_oid, 0, s3_motr_api_mock);
+  motr_writer_ptr = std::make_shared<S3MotrWiter>(request_mock, obj_oid, pv_id,
+                                                  0, s3_motr_api_mock);
 
   EXPECT_CALL(*s3_motr_api_mock, motr_obj_init(_, _, _, _));
   EXPECT_CALL(*s3_motr_api_mock, motr_entity_create(_, _))
@@ -184,7 +185,8 @@ TEST_F(S3MotrWiterTest, CreateObjectTest) {
 
   motr_writer_ptr->create_object(
       std::bind(&S3CallBack::on_success, &S3MotrWiter_callbackobj),
-      std::bind(&S3CallBack::on_failed, &S3MotrWiter_callbackobj), layout_id);
+      std::bind(&S3CallBack::on_failed, &S3MotrWiter_callbackobj), obj_oid,
+      layout_id);
 
   EXPECT_TRUE(S3MotrWiter_callbackobj.success_called);
   EXPECT_FALSE(S3MotrWiter_callbackobj.fail_called);
@@ -193,8 +195,8 @@ TEST_F(S3MotrWiterTest, CreateObjectTest) {
 TEST_F(S3MotrWiterTest, CreateObjectEntityCreateFailTest) {
   S3CallBack S3MotrWiter_callbackobj;
 
-  motr_writer_ptr =
-      std::make_shared<S3MotrWiter>(request_mock, obj_oid, 0, s3_motr_api_mock);
+  motr_writer_ptr = std::make_shared<S3MotrWiter>(request_mock, obj_oid, pv_id,
+                                                  0, s3_motr_api_mock);
 
   EXPECT_CALL(*s3_motr_api_mock, motr_obj_init(_, _, _, _));
   EXPECT_CALL(*s3_motr_api_mock, motr_entity_create(_, _)).WillOnce(Return(-1));
@@ -204,7 +206,8 @@ TEST_F(S3MotrWiterTest, CreateObjectEntityCreateFailTest) {
 
   motr_writer_ptr->create_object(
       std::bind(&S3CallBack::on_success, &S3MotrWiter_callbackobj),
-      std::bind(&S3CallBack::on_failed, &S3MotrWiter_callbackobj), layout_id);
+      std::bind(&S3CallBack::on_failed, &S3MotrWiter_callbackobj), obj_oid,
+      layout_id);
 
   EXPECT_FALSE(S3MotrWiter_callbackobj.success_called);
   EXPECT_TRUE(S3MotrWiter_callbackobj.fail_called);
@@ -213,8 +216,8 @@ TEST_F(S3MotrWiterTest, CreateObjectEntityCreateFailTest) {
 TEST_F(S3MotrWiterTest, CreateObjectSuccessfulTest) {
   S3CallBack S3MotrWiter_callbackobj;
 
-  motr_writer_ptr =
-      std::make_shared<S3MotrWiter>(request_mock, obj_oid, 0, s3_motr_api_mock);
+  motr_writer_ptr = std::make_shared<S3MotrWiter>(request_mock, obj_oid, pv_id,
+                                                  0, s3_motr_api_mock);
 
   EXPECT_CALL(*s3_motr_api_mock, motr_obj_init(_, _, _, _));
   EXPECT_CALL(*s3_motr_api_mock, motr_entity_create(_, _))
@@ -228,7 +231,8 @@ TEST_F(S3MotrWiterTest, CreateObjectSuccessfulTest) {
 
   motr_writer_ptr->create_object(
       std::bind(&S3CallBack::on_success, &S3MotrWiter_callbackobj),
-      std::bind(&S3CallBack::on_failed, &S3MotrWiter_callbackobj), layout_id);
+      std::bind(&S3CallBack::on_failed, &S3MotrWiter_callbackobj), obj_oid,
+      layout_id);
 
   EXPECT_TRUE(S3MotrWiter_callbackobj.success_called);
   EXPECT_FALSE(S3MotrWiter_callbackobj.fail_called);
@@ -237,8 +241,8 @@ TEST_F(S3MotrWiterTest, CreateObjectSuccessfulTest) {
 TEST_F(S3MotrWiterTest, DeleteObjectSuccessfulTest) {
   S3CallBack S3MotrWiter_callbackobj;
 
-  motr_writer_ptr =
-      std::make_shared<S3MotrWiter>(request_mock, obj_oid, 0, s3_motr_api_mock);
+  motr_writer_ptr = std::make_shared<S3MotrWiter>(request_mock, obj_oid, pv_id,
+                                                  0, s3_motr_api_mock);
 
   EXPECT_CALL(*s3_motr_api_mock, motr_obj_init(_, _, _, _));
   EXPECT_CALL(*s3_motr_api_mock, motr_entity_open(_, _))
@@ -254,7 +258,8 @@ TEST_F(S3MotrWiterTest, DeleteObjectSuccessfulTest) {
 
   motr_writer_ptr->delete_object(
       std::bind(&S3CallBack::on_success, &S3MotrWiter_callbackobj),
-      std::bind(&S3CallBack::on_failed, &S3MotrWiter_callbackobj), layout_id);
+      std::bind(&S3CallBack::on_failed, &S3MotrWiter_callbackobj), obj_oid,
+      layout_id);
 
   EXPECT_TRUE(S3MotrWiter_callbackobj.success_called);
   EXPECT_FALSE(S3MotrWiter_callbackobj.fail_called);
@@ -263,8 +268,8 @@ TEST_F(S3MotrWiterTest, DeleteObjectSuccessfulTest) {
 TEST_F(S3MotrWiterTest, DeleteObjectFailedTest) {
   S3CallBack S3MotrWiter_callbackobj;
 
-  motr_writer_ptr =
-      std::make_shared<S3MotrWiter>(request_mock, obj_oid, 0, s3_motr_api_mock);
+  motr_writer_ptr = std::make_shared<S3MotrWiter>(request_mock, obj_oid, pv_id,
+                                                  0, s3_motr_api_mock);
 
   EXPECT_CALL(*s3_motr_api_mock, motr_obj_init(_, _, _, _));
   EXPECT_CALL(*s3_motr_api_mock, motr_entity_open(_, _))
@@ -279,7 +284,8 @@ TEST_F(S3MotrWiterTest, DeleteObjectFailedTest) {
 
   motr_writer_ptr->delete_object(
       std::bind(&S3CallBack::on_success, &S3MotrWiter_callbackobj),
-      std::bind(&S3CallBack::on_failed, &S3MotrWiter_callbackobj), layout_id);
+      std::bind(&S3CallBack::on_failed, &S3MotrWiter_callbackobj), obj_oid,
+      layout_id);
 
   EXPECT_FALSE(S3MotrWiter_callbackobj.success_called);
   EXPECT_TRUE(S3MotrWiter_callbackobj.fail_called);
@@ -294,9 +300,10 @@ TEST_F(S3MotrWiterTest, DeleteObjectmotrEntityDeleteFailedTest) {
     oids.push_back(obj_oid);
     layoutids.push_back(layout_id);
   }
+  std::vector<struct m0_fid> pv_ids(3, pv_id);
 
-  motr_writer_ptr =
-      std::make_shared<S3MotrWiter>(request_mock, obj_oid, 0, s3_motr_api_mock);
+  motr_writer_ptr = std::make_shared<S3MotrWiter>(request_mock, obj_oid, pv_id,
+                                                  0, s3_motr_api_mock);
 
   EXPECT_CALL(*s3_motr_api_mock, motr_obj_init(_, _, _, _)).Times(oids.size());
   EXPECT_CALL(*s3_motr_api_mock, motr_entity_open(_, _))
@@ -314,7 +321,7 @@ TEST_F(S3MotrWiterTest, DeleteObjectmotrEntityDeleteFailedTest) {
   S3Option::get_instance()->set_eventbase(evbase);
 
   motr_writer_ptr->delete_objects(
-      oids, layoutids,
+      oids, layoutids, pv_ids,
       std::bind(&S3CallBack::on_success, &S3MotrWiter_callbackobj),
       std::bind(&S3CallBack::on_failed, &S3MotrWiter_callbackobj));
 
@@ -331,9 +338,10 @@ TEST_F(S3MotrWiterTest, DeleteObjectsSuccessfulTest) {
     oids.push_back(obj_oid);
     layoutids.push_back(layout_id);
   }
+  std::vector<struct m0_fid> pv_ids(3, pv_id);
 
-  motr_writer_ptr =
-      std::make_shared<S3MotrWiter>(request_mock, obj_oid, 0, s3_motr_api_mock);
+  motr_writer_ptr = std::make_shared<S3MotrWiter>(request_mock, obj_oid, pv_id,
+                                                  0, s3_motr_api_mock);
 
   EXPECT_CALL(*s3_motr_api_mock, motr_obj_init(_, _, _, _)).Times(oids.size());
   EXPECT_CALL(*s3_motr_api_mock, motr_entity_open(_, _))
@@ -351,7 +359,7 @@ TEST_F(S3MotrWiterTest, DeleteObjectsSuccessfulTest) {
   S3Option::get_instance()->set_eventbase(evbase);
 
   motr_writer_ptr->delete_objects(
-      oids, layoutids,
+      oids, layoutids, pv_ids,
       std::bind(&S3CallBack::on_success, &S3MotrWiter_callbackobj),
       std::bind(&S3CallBack::on_failed, &S3MotrWiter_callbackobj));
 
@@ -368,9 +376,10 @@ TEST_F(S3MotrWiterTest, DeleteObjectsFailedTest) {
     oids.push_back(obj_oid);
     layoutids.push_back(layout_id);
   }
+  std::vector<struct m0_fid> pv_ids(3, pv_id);
 
-  motr_writer_ptr =
-      std::make_shared<S3MotrWiter>(request_mock, obj_oid, 0, s3_motr_api_mock);
+  motr_writer_ptr = std::make_shared<S3MotrWiter>(request_mock, obj_oid, pv_id,
+                                                  0, s3_motr_api_mock);
 
   EXPECT_CALL(*s3_motr_api_mock, motr_obj_init(_, _, _, _)).Times(oids.size());
   EXPECT_CALL(*s3_motr_api_mock, motr_entity_open(_, _))
@@ -384,7 +393,7 @@ TEST_F(S3MotrWiterTest, DeleteObjectsFailedTest) {
   S3Option::get_instance()->set_eventbase(evbase);
 
   motr_writer_ptr->delete_objects(
-      oids, layoutids,
+      oids, layoutids, pv_ids,
       std::bind(&S3CallBack::on_success, &S3MotrWiter_callbackobj),
       std::bind(&S3CallBack::on_failed, &S3MotrWiter_callbackobj));
 
@@ -393,8 +402,8 @@ TEST_F(S3MotrWiterTest, DeleteObjectsFailedTest) {
 }
 
 TEST_F(S3MotrWiterTest, OpenObjectsTest) {
-  motr_writer_ptr =
-      std::make_shared<S3MotrWiter>(request_mock, obj_oid, 0, s3_motr_api_mock);
+  motr_writer_ptr = std::make_shared<S3MotrWiter>(request_mock, obj_oid, pv_id,
+                                                  0, s3_motr_api_mock);
   motr_writer_ptr->set_layout_id(layout_id);
 
   EXPECT_CALL(*s3_motr_api_mock, motr_obj_init(_, _, _, _)).Times(1);
@@ -413,8 +422,8 @@ TEST_F(S3MotrWiterTest, OpenObjectsTest) {
 TEST_F(S3MotrWiterTest, OpenObjectsEntityOpenFailedTest) {
   S3CallBack S3MotrWiter_callbackobj;
   int rc;
-  motr_writer_ptr =
-      std::make_shared<S3MotrWiter>(request_mock, obj_oid, 0, s3_motr_api_mock);
+  motr_writer_ptr = std::make_shared<S3MotrWiter>(request_mock, obj_oid, pv_id,
+                                                  0, s3_motr_api_mock);
   motr_writer_ptr->set_layout_id(layout_id);
 
   EXPECT_CALL(*s3_motr_api_mock, motr_obj_init(_, _, _, _)).Times(1);
@@ -434,8 +443,8 @@ TEST_F(S3MotrWiterTest, OpenObjectsEntityOpenFailedTest) {
 TEST_F(S3MotrWiterTest, OpenObjectsFailedTest) {
   S3CallBack S3MotrWiter_callbackobj;
 
-  motr_writer_ptr =
-      std::make_shared<S3MotrWiter>(request_mock, obj_oid, 0, s3_motr_api_mock);
+  motr_writer_ptr = std::make_shared<S3MotrWiter>(request_mock, obj_oid, pv_id,
+                                                  0, s3_motr_api_mock);
   motr_writer_ptr->set_layout_id(layout_id);
 
   EXPECT_CALL(*s3_motr_api_mock, motr_obj_init(_, _, _, _)).Times(1);
@@ -460,8 +469,8 @@ TEST_F(S3MotrWiterTest, OpenObjectsFailedTest) {
 TEST_F(S3MotrWiterTest, OpenObjectsFailedMissingTest) {
   S3CallBack S3MotrWiter_callbackobj;
 
-  motr_writer_ptr =
-      std::make_shared<S3MotrWiter>(request_mock, obj_oid, 0, s3_motr_api_mock);
+  motr_writer_ptr = std::make_shared<S3MotrWiter>(request_mock, obj_oid, pv_id,
+                                                  0, s3_motr_api_mock);
   motr_writer_ptr->set_layout_id(layout_id);
 
   EXPECT_CALL(*s3_motr_api_mock, motr_obj_init(_, _, _, _)).Times(1);
@@ -489,8 +498,8 @@ TEST_F(S3MotrWiterTest, WriteContentSuccessfulTest) {
   bool is_last_buf = true;
   std::string sdata("Hello.World");
 
-  motr_writer_ptr =
-      std::make_shared<S3MotrWiter>(request_mock, obj_oid, 0, s3_motr_api_mock);
+  motr_writer_ptr = std::make_shared<S3MotrWiter>(request_mock, obj_oid, pv_id,
+                                                  0, s3_motr_api_mock);
   motr_writer_ptr->set_layout_id(layout_id);
 
   EXPECT_CALL(*s3_motr_api_mock, motr_obj_init(_, _, _, _));
@@ -526,8 +535,8 @@ TEST_F(S3MotrWiterTest, WriteContentFailedTest) {
   S3CallBack S3MotrWiter_callbackobj;
   bool is_last_buf = true;
 
-  motr_writer_ptr =
-      std::make_shared<S3MotrWiter>(request_mock, obj_oid, 0, s3_motr_api_mock);
+  motr_writer_ptr = std::make_shared<S3MotrWiter>(request_mock, obj_oid, pv_id,
+                                                  0, s3_motr_api_mock);
   motr_writer_ptr->set_layout_id(layout_id);
 
   EXPECT_CALL(*s3_motr_api_mock, motr_obj_init(_, _, _, _));
@@ -558,8 +567,8 @@ TEST_F(S3MotrWiterTest, WriteEntityFailedTest) {
   S3CallBack S3MotrWiter_callbackobj;
   bool is_last_buf = true;
 
-  motr_writer_ptr =
-      std::make_shared<S3MotrWiter>(request_mock, obj_oid, 0, s3_motr_api_mock);
+  motr_writer_ptr = std::make_shared<S3MotrWiter>(request_mock, obj_oid, pv_id,
+                                                  0, s3_motr_api_mock);
   motr_writer_ptr->set_layout_id(layout_id);
 
   EXPECT_CALL(*s3_motr_api_mock, motr_obj_init(_, _, _, _));

--- a/ut/s3_post_complete_action_test.cc
+++ b/ut/s3_post_complete_action_test.cc
@@ -79,7 +79,7 @@ using ::testing::_;
   do {                                                                  \
     action_under_test_ptr->motr_writer =                                \
         action_under_test_ptr->motr_writer_factory->create_motr_writer( \
-            request_mock, oid);                                         \
+            request_mock);                                              \
   } while (0)
 
 #define CREATE_KVS_WRITER_OBJ                                                  \
@@ -108,8 +108,8 @@ class S3PostCompleteActionTest : public testing::Test {
  protected:  // You should make the members protected s.t. they can be
              // accessed from sub-classes.
   S3PostCompleteActionTest() {
-    evhtp_request_t *req = NULL;
-    EvhtpInterface *evhtp_obj_ptr = new EvhtpWrapper();
+    evhtp_request_t* req = NULL;
+    EvhtpInterface* evhtp_obj_ptr = new EvhtpWrapper();
     upload_id = "upload_id";
     mp_indx_oid = {0xffff, 0xffff};
     oid = {0xfff, 0xfff};
@@ -183,7 +183,9 @@ class S3PostCompleteActionTest : public testing::Test {
     action_under_test_ptr->next();
   }
   void dummy_delete_object(std::function<void(void)> on_success,
-                           std::function<void(void)> on_failed, int layoutid) {
+                           std::function<void(void)> on_failed,
+                           const struct m0_uint128& object_id, int layoutid,
+                           const struct m0_fid& pv_id) {
     action_under_test_ptr->next();
   }
 };
@@ -663,7 +665,7 @@ TEST_F(S3PostCompleteActionTest, DeleteNewObject) {
   action_under_test_ptr->set_abort_multipart(true);
 
   EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
-              delete_object(_, _, layout_id)).Times(1);
+              delete_object(_, _, _, layout_id, _)).Times(1);
 
   action_under_test_ptr->delete_new_object();
 }
@@ -680,10 +682,8 @@ TEST_F(S3PostCompleteActionTest, DeleteOldObject) {
   action_under_test_ptr->old_layout_id = old_layout_id;
   action_under_test_ptr->set_abort_multipart(true);
 
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), set_oid(_))
-      .Times(AtLeast(1));
   EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
-              delete_object(_, _, old_layout_id)).Times(AtLeast(1));
+              delete_object(_, _, _, old_layout_id, _)).Times(AtLeast(1));
 
   action_under_test_ptr->delete_old_object();
 }
@@ -700,9 +700,8 @@ TEST_F(S3PostCompleteActionTest, DelayedDeleteOldObject) {
   action_under_test_ptr->old_layout_id = old_layout_id;
   action_under_test_ptr->set_abort_multipart(true);
 
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), set_oid(_)).Times(0);
   EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
-              delete_object(_, _, old_layout_id)).Times(0);
+              delete_object(_, _, _, old_layout_id, _)).Times(0);
 
   action_under_test_ptr->clear_tasks();
   ACTION_TASK_ADD_OBJPTR(action_under_test_ptr,
@@ -760,7 +759,8 @@ TEST_F(S3PostCompleteActionTest, StartCleanupAbortedSinceValidationFailed) {
       .WillRepeatedly(
            Invoke(this, &S3PostCompleteActionTest::dummy_put_keyval));
 
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), delete_object(_, _, _))
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
+              delete_object(_, _, _, _, _))
       .Times(1)
       .WillRepeatedly(
            Invoke(this, &S3PostCompleteActionTest::dummy_delete_object));

--- a/ut/s3_post_multipartobject_action_test.cc
+++ b/ut/s3_post_multipartobject_action_test.cc
@@ -235,14 +235,13 @@ TEST_F(S3PostMultipartObjectTest, CreateObject) {
       object_mp_meta_factory->mock_object_mp_metadata;
 
   action_under_test->tried_count = 0;
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), create_object(_, _, _))
-      .Times(1);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
+              create_object(_, _, _, _)).Times(1);
   action_under_test->create_object();
 
   action_under_test->tried_count = 1;
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), create_object(_, _, _))
-      .Times(1);
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), set_oid(_)).Times(1);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
+              create_object(_, _, _, _)).Times(1);
   action_under_test->create_object();
 }
 
@@ -294,9 +293,8 @@ TEST_F(S3PostMultipartObjectTest, CreateObjectFailedDueToCollision) {
   EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), get_state())
       .Times(AtLeast(1))
       .WillRepeatedly(Return(S3MotrWiterOpState::exists));
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), set_oid(_)).Times(1);
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), create_object(_, _, _))
-      .Times(1);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
+              create_object(_, _, _, _)).Times(1);
   action_under_test->tried_count = 1;
   action_under_test->create_object_failed();
   EXPECT_EQ(2, action_under_test->tried_count);
@@ -306,9 +304,8 @@ TEST_F(S3PostMultipartObjectTest, CollisionOccured) {
   S3Option::get_instance()->set_is_s3_shutting_down(false);
   action_under_test->motr_writer = motr_writer_factory->mock_motr_writer;
   action_under_test->tried_count = 1;
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), create_object(_, _, _))
-      .Times(AtLeast(1));
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), set_oid(_)).Times(1);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
+              create_object(_, _, _, _)).Times(AtLeast(1));
   action_under_test->collision_occured();
   EXPECT_EQ(2, action_under_test->tried_count);
 
@@ -332,9 +329,8 @@ TEST_F(S3PostMultipartObjectTest, CreateNewOid) {
 
 TEST_F(S3PostMultipartObjectTest, RollbackCreate) {
   action_under_test->motr_writer = motr_writer_factory->mock_motr_writer;
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), delete_object(_, _, _))
-      .Times(1);
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), set_oid(_)).Times(1);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
+              delete_object(_, _, _, _, _)).Times(1);
   action_under_test->rollback_create();
 }
 
@@ -454,4 +450,3 @@ TEST_F(S3PostMultipartObjectTest, Send200ResponseToClient) {
   EXPECT_CALL(*ptr_mock_request, send_response(200, _)).Times(AtLeast(1));
   action_under_test->send_response_to_s3_client();
 }
-

--- a/ut/s3_put_chunk_upload_object_action_test.cc
+++ b/ut/s3_put_chunk_upload_object_action_test.cc
@@ -407,8 +407,8 @@ TEST_F(S3PutChunkUploadObjectActionTestNoAuth,
 }
 
 TEST_F(S3PutChunkUploadObjectActionTestNoAuth, CreateObjectFirstAttempt) {
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), create_object(_, _, _))
-      .Times(1);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
+              create_object(_, _, _, _)).Times(1);
   EXPECT_CALL(*mock_request, get_data_length()).Times(1).WillOnce(Return(0));
 
   action_under_test->create_object();
@@ -416,14 +416,13 @@ TEST_F(S3PutChunkUploadObjectActionTestNoAuth, CreateObjectFirstAttempt) {
 }
 
 TEST_F(S3PutChunkUploadObjectActionTestNoAuth, CreateObjectSecondAttempt) {
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), create_object(_, _, _))
-      .Times(2);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
+              create_object(_, _, _, _)).Times(2);
   EXPECT_CALL(*mock_request, get_data_length()).Times(2).WillRepeatedly(
       Return(0));
 
   action_under_test->create_object();
   action_under_test->tried_count = 1;
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), set_oid(_)).Times(1);
   action_under_test->create_object();
   EXPECT_TRUE(action_under_test->motr_writer != nullptr);
 }
@@ -467,16 +466,15 @@ TEST_F(S3PutChunkUploadObjectActionTestNoAuth,
   EXPECT_CALL(*mock_request, get_data_length()).Times(1).WillOnce(Return(0));
 
   action_under_test->tried_count = MAX_COLLISION_RETRY_COUNT - 1;
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), set_oid(_)).Times(1);
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), create_object(_, _, _))
-      .Times(1);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
+              create_object(_, _, _, _)).Times(1);
 
   action_under_test->create_object_failed();
 }
 
 TEST_F(S3PutChunkUploadObjectActionTestNoAuth, CreateObjectFailedTest) {
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), create_object(_, _, _))
-      .Times(1);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
+              create_object(_, _, _, _)).Times(1);
   EXPECT_CALL(*mock_request, get_data_length()).Times(1).WillOnce(Return(0));
 
   action_under_test->create_object();
@@ -494,8 +492,8 @@ TEST_F(S3PutChunkUploadObjectActionTestNoAuth, CreateObjectFailedTest) {
 }
 
 TEST_F(S3PutChunkUploadObjectActionTestNoAuth, CreateObjectFailedToLaunchTest) {
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), create_object(_, _, _))
-      .Times(1);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
+              create_object(_, _, _, _)).Times(1);
   EXPECT_CALL(*mock_request, get_data_length()).Times(1).WillOnce(Return(0));
 
   action_under_test->create_object();
@@ -703,9 +701,8 @@ TEST_F(S3PutChunkUploadObjectActionTestNoAuth, DelayedDeleteOldObject) {
   action_under_test->old_object_oid = old_object_oid;
   action_under_test->old_layout_id = old_layout_id;
 
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), set_oid(_)).Times(0);
   EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
-              delete_object(_, _, old_layout_id)).Times(0);
+              delete_object(_, _, _, old_layout_id, _)).Times(0);
 
   action_under_test->clear_tasks();
   ACTION_TASK_ADD_OBJPTR(
@@ -953,7 +950,6 @@ TEST_F(S3PutChunkUploadObjectActionTestNoAuth, SaveMetadata) {
   EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), get_oid())
       .Times(AtLeast(1))
       .WillOnce(Return(oid));
-  EXPECT_CALL(*(object_meta_factory->mock_object_metadata), set_oid(_))
       .Times(AtLeast(1));
 
   std::map<std::string, std::string> input_headers;

--- a/ut/s3_put_chunk_upload_object_action_test.cc
+++ b/ut/s3_put_chunk_upload_object_action_test.cc
@@ -950,7 +950,6 @@ TEST_F(S3PutChunkUploadObjectActionTestNoAuth, SaveMetadata) {
   EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), get_oid())
       .Times(AtLeast(1))
       .WillOnce(Return(oid));
-      .Times(AtLeast(1));
 
   std::map<std::string, std::string> input_headers;
   input_headers["x-amz-meta-item-1"] = "1024";

--- a/ut/s3_put_object_action_test.cc
+++ b/ut/s3_put_object_action_test.cc
@@ -507,8 +507,8 @@ TEST_F(S3PutObjectActionTest, FetchObjectInfoReturnedInvalidStateReportsError) {
 TEST_F(S3PutObjectActionTest, CreateObjectFirstAttempt) {
   EXPECT_CALL(*ptr_mock_request, get_content_length()).Times(1).WillOnce(
       Return(1024));
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), create_object(_, _, _))
-      .Times(1);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
+              create_object(_, _, _, _)).Times(1);
   action_under_test->create_object();
   EXPECT_TRUE(action_under_test->motr_writer != nullptr);
 }
@@ -517,11 +517,10 @@ TEST_F(S3PutObjectActionTest, CreateObjectSecondAttempt) {
   EXPECT_CALL(*ptr_mock_request, get_content_length()).Times(2).WillRepeatedly(
       Return(1024));
 
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), create_object(_, _, _))
-      .Times(2);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
+              create_object(_, _, _, _)).Times(2);
   action_under_test->create_object();
   action_under_test->tried_count = 1;
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), set_oid(_)).Times(1);
   action_under_test->create_object();
   EXPECT_TRUE(action_under_test->motr_writer != nullptr);
 }
@@ -563,9 +562,8 @@ TEST_F(S3PutObjectActionTest, CreateObjectFailedWithCollisionRetry) {
       Return(1024));
 
   action_under_test->tried_count = MAX_COLLISION_RETRY_COUNT - 1;
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), set_oid(_)).Times(1);
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), create_object(_, _, _))
-      .Times(1);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
+              create_object(_, _, _, _)).Times(1);
 
   action_under_test->create_object_failed();
 }
@@ -573,8 +571,8 @@ TEST_F(S3PutObjectActionTest, CreateObjectFailedWithCollisionRetry) {
 TEST_F(S3PutObjectActionTest, CreateObjectFailedTest) {
   EXPECT_CALL(*ptr_mock_request, get_content_length()).Times(1).WillOnce(
       Return(1024));
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), create_object(_, _, _))
-      .Times(1);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
+              create_object(_, _, _, _)).Times(1);
   action_under_test->create_object();
 
   EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), get_state())
@@ -592,8 +590,8 @@ TEST_F(S3PutObjectActionTest, CreateObjectFailedTest) {
 TEST_F(S3PutObjectActionTest, CreateObjectFailedToLaunchTest) {
   EXPECT_CALL(*ptr_mock_request, get_content_length()).Times(1).WillOnce(
       Return(1024));
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), create_object(_, _, _))
-      .Times(1);
+  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
+              create_object(_, _, _, _)).Times(1);
   action_under_test->create_object();
 
   EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), get_state())
@@ -783,9 +781,8 @@ TEST_F(S3PutObjectActionTest, DelayedDeleteOldObject) {
   action_under_test->old_object_oid = old_object_oid;
   action_under_test->old_layout_id = old_layout_id;
 
-  EXPECT_CALL(*(motr_writer_factory->mock_motr_writer), set_oid(_)).Times(0);
   EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
-              delete_object(_, _, old_layout_id)).Times(0);
+              delete_object(_, _, _, old_layout_id, _)).Times(0);
 
   action_under_test->clear_tasks();
   ACTION_TASK_ADD_OBJPTR(action_under_test,


### PR DESCRIPTION
Signed-off-by: evgeniy-brazhnikov <evgeniy.brazhnikov@seagate.com>

-----
[View rendered docs/design/pool-version-id.md](https://github.com/Seagate/cortx-s3server/blob/br/eb/eos-17974/docs/design/pool-version-id.md)