### PR TITLE
[EOS-20328] Tuning of mempool to avoid read mempool buffers

### DIFF
--- a/s3config-test.yaml
+++ b/s3config-test.yaml
@@ -98,9 +98,9 @@ S3_MOTR_CONFIG:                                     # Section for S3 Motr
    S3_MOTR_CASS_CLUSTER_EP: 10.10.1.3                 # Cassandra cluster end point
    S3_MOTR_CASS_KEYSPACE: "motr_index_keyspace"     # Cassandra keyspace
    S3_MOTR_CASS_MAX_COL_FAMILY_NUM: 1                 # Cassandra max column family number, default is 1
-   S3_UNIT_SIZES_FOR_MEMORY_POOL: [4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304]                          # Memory pool will be created for each of this unit_size with following properties
-   S3_MOTR_READ_POOL_INITIAL_BUFFER_COUNT: 10         # 10 blocks, the initial pool size, multiple of S3_MOTR_UNIT_SIZE
-   S3_MOTR_READ_POOL_EXPANDABLE_COUNT: 20             # 20 blocks, pool's expandable size, multiple of S3_MOTR_UNIT_SIZE
+   S3_UNIT_SIZES_FOR_MEMORY_POOL: [16384]              # Memory pool will be created for each of this unit_size with following properties
+   S3_MOTR_READ_POOL_INITIAL_BUFFER_COUNT: 3          # 10 blocks, the initial pool size, multiple of S3_MOTR_UNIT_SIZE
+   S3_MOTR_READ_POOL_EXPANDABLE_COUNT: 6             # 20 blocks, pool's expandable size, multiple of S3_MOTR_UNIT_SIZE
    S3_MOTR_READ_POOL_MAX_THRESHOLD: 104857600         # 100 MB, The maximum memory threshold for the pool, multiple of S3_MOTR_UNIT_SIZE
    S3_MOTR_READ_MEMPOOL_ZERO_BUFFER: false            # Enable Motr Mempool 'zeroing' after use (like secure erase) - disabled by default
    S3_MOTR_OPERATION_WAIT_PERIOD: 90                  # 90 s, Maximum wait duration for sync motr operations.

--- a/s3config-test.yaml
+++ b/s3config-test.yaml
@@ -99,8 +99,8 @@ S3_MOTR_CONFIG:                                     # Section for S3 Motr
    S3_MOTR_CASS_KEYSPACE: "motr_index_keyspace"     # Cassandra keyspace
    S3_MOTR_CASS_MAX_COL_FAMILY_NUM: 1                 # Cassandra max column family number, default is 1
    S3_UNIT_SIZES_FOR_MEMORY_POOL: [16384]              # Memory pool will be created for each of this unit_size with following properties
-   S3_MOTR_READ_POOL_INITIAL_BUFFER_COUNT: 3          # 10 blocks, the initial pool size, multiple of S3_MOTR_UNIT_SIZE
-   S3_MOTR_READ_POOL_EXPANDABLE_COUNT: 6             # 20 blocks, pool's expandable size, multiple of S3_MOTR_UNIT_SIZE
+   S3_MOTR_READ_POOL_INITIAL_BUFFER_COUNT: 10          # 10 blocks, the initial pool size, multiple of S3_MOTR_UNIT_SIZE
+   S3_MOTR_READ_POOL_EXPANDABLE_COUNT: 50             # 20 blocks, pool's expandable size, multiple of S3_MOTR_UNIT_SIZE
    S3_MOTR_READ_POOL_MAX_THRESHOLD: 104857600         # 100 MB, The maximum memory threshold for the pool, multiple of S3_MOTR_UNIT_SIZE
    S3_MOTR_READ_MEMPOOL_ZERO_BUFFER: false            # Enable Motr Mempool 'zeroing' after use (like secure erase) - disabled by default
    S3_MOTR_OPERATION_WAIT_PERIOD: 90                  # 90 s, Maximum wait duration for sync motr operations.

--- a/s3config.release.yaml.sample
+++ b/s3config.release.yaml.sample
@@ -99,8 +99,8 @@ S3_MOTR_CONFIG:                                     # Section for S3 Motr
    S3_MOTR_CASS_KEYSPACE: "motr_index_keyspace"     # Cassandra keyspace
    S3_MOTR_CASS_MAX_COL_FAMILY_NUM: 1                 # Cassandra max column family number, default is 1
    S3_UNIT_SIZES_FOR_MEMORY_POOL: [16384]            # Memory pool will be created for each of these unit_size with following properties
-   S3_MOTR_READ_POOL_INITIAL_BUFFER_COUNT: 3        # 10 blocks, the initial pool size = multiple of S3_MOTR_UNIT_SIZE
-   S3_MOTR_READ_POOL_EXPANDABLE_COUNT: 6            # 50 blocks, pool's expandable size, multiple of S3_MOTR_UNIT_SIZE
+   S3_MOTR_READ_POOL_INITIAL_BUFFER_COUNT: 10        # 10 blocks, the initial pool size = multiple of S3_MOTR_UNIT_SIZE
+   S3_MOTR_READ_POOL_EXPANDABLE_COUNT: 50            # 50 blocks, pool's expandable size, multiple of S3_MOTR_UNIT_SIZE
    S3_MOTR_READ_POOL_MAX_THRESHOLD: 1048576000        # 1GB, The maximum memory threshold for the pool, multiple of S3_MOTR_UNIT_SIZE
    S3_MOTR_READ_MEMPOOL_ZERO_BUFFER: false           # Enable Motr Mempool 'zeroing' after use (like secure erase) - disabled by default
    S3_MOTR_OPERATION_WAIT_PERIOD: 90                  # 90 s, Maximum wait duration for sync motr operations.

--- a/s3config.release.yaml.sample
+++ b/s3config.release.yaml.sample
@@ -98,9 +98,9 @@ S3_MOTR_CONFIG:                                     # Section for S3 Motr
    S3_MOTR_CASS_CLUSTER_EP: 127.0.0.1                 # Cassandra cluster end point
    S3_MOTR_CASS_KEYSPACE: "motr_index_keyspace"     # Cassandra keyspace
    S3_MOTR_CASS_MAX_COL_FAMILY_NUM: 1                 # Cassandra max column family number, default is 1
-   S3_UNIT_SIZES_FOR_MEMORY_POOL: [4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576] # Memory pool will be created for each of these unit_size with following properties
-   S3_MOTR_READ_POOL_INITIAL_BUFFER_COUNT: 10        # 10 blocks, the initial pool size = multiple of S3_MOTR_UNIT_SIZE
-   S3_MOTR_READ_POOL_EXPANDABLE_COUNT: 50            # 50 blocks, pool's expandable size, multiple of S3_MOTR_UNIT_SIZE
+   S3_UNIT_SIZES_FOR_MEMORY_POOL: [16384]            # Memory pool will be created for each of these unit_size with following properties
+   S3_MOTR_READ_POOL_INITIAL_BUFFER_COUNT: 3        # 10 blocks, the initial pool size = multiple of S3_MOTR_UNIT_SIZE
+   S3_MOTR_READ_POOL_EXPANDABLE_COUNT: 6            # 50 blocks, pool's expandable size, multiple of S3_MOTR_UNIT_SIZE
    S3_MOTR_READ_POOL_MAX_THRESHOLD: 1048576000        # 1GB, The maximum memory threshold for the pool, multiple of S3_MOTR_UNIT_SIZE
    S3_MOTR_READ_MEMPOOL_ZERO_BUFFER: false           # Enable Motr Mempool 'zeroing' after use (like secure erase) - disabled by default
    S3_MOTR_OPERATION_WAIT_PERIOD: 90                  # 90 s, Maximum wait duration for sync motr operations.

--- a/s3config.yaml.sample
+++ b/s3config.yaml.sample
@@ -99,8 +99,8 @@ S3_MOTR_CONFIG:                                     # Section for S3 Motr
    S3_MOTR_CASS_KEYSPACE: "motr_index_keyspace"     # Cassandra keyspace
    S3_MOTR_CASS_MAX_COL_FAMILY_NUM: 1                 # Cassandra max column family number, default is 1
    S3_UNIT_SIZES_FOR_MEMORY_POOL: [16384]              # Memory pool will be created for each of these unit_size with following properties
-   S3_MOTR_READ_POOL_INITIAL_BUFFER_COUNT: 3         # 10 blocks, the initial pool size = multiple of S3_MOTR_UNIT_SIZE
-   S3_MOTR_READ_POOL_EXPANDABLE_COUNT: 6            # 50 blocks, pool's expandable size, multiple of S3_MOTR_UNIT_SIZE
+   S3_MOTR_READ_POOL_INITIAL_BUFFER_COUNT: 10         # 10 blocks, the initial pool size = multiple of S3_MOTR_UNIT_SIZE
+   S3_MOTR_READ_POOL_EXPANDABLE_COUNT: 50            # 50 blocks, pool's expandable size, multiple of S3_MOTR_UNIT_SIZE
    S3_MOTR_READ_POOL_MAX_THRESHOLD: 524288000        # 500 MB, The maximum memory threshold for the pool, multiple of S3_MOTR_UNIT_SIZE
    S3_MOTR_READ_MEMPOOL_ZERO_BUFFER: false           # Enable Motr Mempool 'zeroing' after use (like secure erase) - disabled by default
    S3_MOTR_OPERATION_WAIT_PERIOD: 90                 # 90 s, Maximum wait duration for sync motr operations.

--- a/s3config.yaml.sample
+++ b/s3config.yaml.sample
@@ -98,9 +98,9 @@ S3_MOTR_CONFIG:                                     # Section for S3 Motr
    S3_MOTR_CASS_CLUSTER_EP: 127.0.0.1                 # Cassandra cluster end point
    S3_MOTR_CASS_KEYSPACE: "motr_index_keyspace"     # Cassandra keyspace
    S3_MOTR_CASS_MAX_COL_FAMILY_NUM: 1                 # Cassandra max column family number, default is 1
-   S3_UNIT_SIZES_FOR_MEMORY_POOL: [4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576] # Memory pool will be created for each of these unit_size with following properties
-   S3_MOTR_READ_POOL_INITIAL_BUFFER_COUNT: 10        # 10 blocks, the initial pool size = multiple of S3_MOTR_UNIT_SIZE
-   S3_MOTR_READ_POOL_EXPANDABLE_COUNT: 50            # 50 blocks, pool's expandable size, multiple of S3_MOTR_UNIT_SIZE
+   S3_UNIT_SIZES_FOR_MEMORY_POOL: [16384]              # Memory pool will be created for each of these unit_size with following properties
+   S3_MOTR_READ_POOL_INITIAL_BUFFER_COUNT: 3         # 10 blocks, the initial pool size = multiple of S3_MOTR_UNIT_SIZE
+   S3_MOTR_READ_POOL_EXPANDABLE_COUNT: 6            # 50 blocks, pool's expandable size, multiple of S3_MOTR_UNIT_SIZE
    S3_MOTR_READ_POOL_MAX_THRESHOLD: 524288000        # 500 MB, The maximum memory threshold for the pool, multiple of S3_MOTR_UNIT_SIZE
    S3_MOTR_READ_MEMPOOL_ZERO_BUFFER: false           # Enable Motr Mempool 'zeroing' after use (like secure erase) - disabled by default
    S3_MOTR_OPERATION_WAIT_PERIOD: 90                 # 90 s, Maximum wait duration for sync motr operations.

--- a/server/s3_motr_writer.cc
+++ b/server/s3_motr_writer.cc
@@ -699,10 +699,8 @@ void S3MotrWiter::set_up_motr_data_buffers(struct s3_motr_rw_op_context *rw_ctx,
   if (buf_idx < motr_buf_count) {
     // Allocate place_holder_for_last_unit only if its required.
     // Its required when writing last block of object.
+    unit_size_for_place_holder = 16384;
     reset_buffers_if_any(unit_size_for_place_holder);
-    unit_size_for_place_holder =
-        S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(
-            layout_ids[0]);
     place_holder_for_last_unit =
         (void *)S3MempoolManager::get_instance()->get_buffer_for_unit_size(
             unit_size_for_place_holder);


### PR DESCRIPTION
# Change Summary
## Problem Statement/Description
_[EOS-20328](https://jts.seagate.com/browse/EOS-20328):_
_Tuning the read mempool to reduce memory consumption._

## Solution Overview
1. Removed array of buffers and kept a single 16k buffer size
2. Plugged 16k to write buffer where it is using from read mempool.

## Unit Test Cases
### Case 1:
Ran ST's to check the impact of changes on system.
MP Job : http://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/Mini-Provisioning/job/cortx-s3server/1073/console
Pre-Merge Job : http://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/Component-Test/job/S3Server-PreMerge-Test/1087/console

### Case 2:
Parallelly uploaded 2 100 mb files to s3 server to check if there is any issue. 

Signed-off-by: Deepak Mahale <deepak.mahale@seagate.com>