### PR TITLE
EOS-20656: Fixed Cleanup phase failure in deleting BG delete account

### DIFF
--- a/scripts/ldap/ldapaccountaction.py
+++ b/scripts/ldap/ldapaccountaction.py
@@ -314,7 +314,7 @@ class LdapAccountAction:
   def __delete_access_key(self, ldap_conn: SimpleLDAPObject, userid: str):
     """Delete access key of given s3userid."""
     try:
-      access_key = LdapAccountAction.__get_accesskey(ldap_conn, userid)
+      access_key = self.__get_accesskey(ldap_conn, userid)
       ldap_conn.delete_s(f'ak={access_key},ou=accesskeys,dc=s3,dc=seagate,dc=com')
     except ldap.NO_SUCH_OBJECT:
       pass


### PR DESCRIPTION
# Change Summary
## Problem Statement/Description
_[EOS-20656](https://jts.seagate.com/browse/EOS-20656):_
_Cleanup phase failure in deleting BG delete account _

## Solution Overview
Fixed the access of __get_accesskey() method. 

## Unit Test Cases
Successfully ran Cleanup phase on mini provisioner vm 

<details>
  <summary>Cleanup Phase</summary>
[root@ssc-vm-3407 ~]# /opt/seagate/cortx/s3/bin/s3_setup cleanup --config "yaml:///opt/seagate/cortx/s3/conf/s3.cleanup.tmpl.1-node"


/usr/local/lib64/python3.6/site-packages/cryptography/hazmat/backends/openssl/hmac.py:59: UserWarning: implicit cast from 'char *' to a different pointer type: will be forbidden in the future (check that the types are as you expect; use an explicit ffi.cast() if they are correct)
  res = self._backend._lib.HMAC_Update(self._ctx, data_ptr, len(data))
/usr/local/lib64/python3.6/site-packages/cryptography/hazmat/backends/openssl/ciphers.py:114: UserWarning: implicit cast from 'char *' to a different pointer type: will be forbidden in the future (check that the types are as you expect; use an explicit ffi.cast() if they are correct)
  operation
/usr/local/lib64/python3.6/site-packages/cryptography/hazmat/backends/openssl/ciphers.py:140: UserWarning: implicit cast from 'char *' to a different pointer type: will be forbidden in the future (check that the types are as you expect; use an explicit ffi.cast() if they are correct)
  self._backend._ffi.from_buffer(data), len(data)
2021-05-20 03:04:11,887 - s3-deployment-logger - INFO - Processing cleanup yaml:///opt/seagate/cortx/s3/conf/s3.cleanup.tmpl.1-node

2021-05-20 03:04:11,888 - s3-deployment-logger - INFO - Validations running from /opt/seagate/cortx/s3/mini-prov/s3setup_prereqs.json

2021-05-20 03:04:13,252 - s3-deployment-logger - INFO - Validation complete

2021-05-20 03:04:13,252 - s3-deployment-logger - INFO - validating S3 config files for cleanup.

2021-05-20 03:04:13,252 - s3-deployment-logger - INFO - validating config file /opt/seagate/cortx/s3/conf/s3config.yaml.

2021-05-20 03:04:13,304 - s3-deployment-logger - INFO - config file /opt/seagate/cortx/s3/conf/s3config.yaml validated successfully.

2021-05-20 03:04:13,304 - s3-deployment-logger - INFO - validating config file /opt/seagate/cortx/auth/resources/authserver.properties.

2021-05-20 03:04:13,305 - s3-deployment-logger - INFO - config file /opt/seagate/cortx/auth/resources/authserver.properties validated successfully.

2021-05-20 03:04:13,305 - s3-deployment-logger - INFO - validating config file /opt/seagate/cortx/auth/resources/keystore.properties.

2021-05-20 03:04:13,305 - s3-deployment-logger - INFO - config file /opt/seagate/cortx/auth/resources/keystore.properties validated successfully.

2021-05-20 03:04:13,305 - s3-deployment-logger - INFO - validating config file /opt/seagate/cortx/s3/s3backgrounddelete/config.yaml.

2021-05-20 03:04:13,327 - s3-deployment-logger - INFO - config file /opt/seagate/cortx/s3/s3backgrounddelete/config.yaml validated successfully.

2021-05-20 03:04:13,328 - s3-deployment-logger - INFO - validating config file /opt/seagate/cortx/s3/s3backgrounddelete/s3_cluster.yaml.

2021-05-20 03:04:13,331 - s3-deployment-logger - INFO - config file /opt/seagate/cortx/s3/s3backgrounddelete/s3_cluster.yaml validated successfully.

2021-05-20 03:04:13,332 - s3-deployment-logger - INFO - Skippped Delete of S3 Deployment log file
2021-05-20 03:04:13,332 - s3-deployment-logger - INFO - checking if ldap service is running or not...

2021-05-20 03:04:13,332 - s3-deployment-logger - INFO - Validations running from /opt/seagate/cortx/s3/mini-prov/s3setup_prereqs.json

2021-05-20 03:04:13,338 - s3-deployment-logger - INFO - slapd service is not running hence starting it...

2021-05-20 03:04:13,339 - s3-deployment-logger - INFO - starting slapd

2021-05-20 03:04:13,353 - s3-deployment-logger - INFO - slapd service is running...

2021-05-20 03:04:13,354 - s3-deployment-logger - INFO - Processing cleanup detect_if_reset_done

2021-05-20 03:04:13,354 - s3-deployment-logger - INFO - Validating ldap account entries

2021-05-20 03:04:13,354 - s3-deployment-logger - INFO - Logger has valid handler
2021-05-20 03:04:13,355 - s3-deployment-logger - INFO - Validation of ldap account entries successful.

2021-05-20 03:04:13,356 - s3-deployment-logger - INFO - Processing cleanup detect_if_reset_done completed successfully..

2021-05-20 03:04:13,356 - s3-deployment-logger - INFO - Logger has valid handler
2021-05-20 03:04:13,369 - s3-deployment-logger - INFO - /etc/openldap/slapd.d/cn=config/cn=schema/cn={1}s3user.ldif removed

2021-05-20 03:04:13,369 - s3-deployment-logger - INFO - /etc/openldap/slapd.d/cn=config/cn=module{0}.ldif removed

2021-05-20 03:04:13,369 - s3-deployment-logger - INFO - /etc/openldap/slapd.d/cn=config/cn=module{1}.ldif removed

2021-05-20 03:04:13,370 - s3-deployment-logger - INFO - /etc/openldap/slapd.d/cn=config/olcDatabase={2}mdb.ldif removed

2021-05-20 03:04:13,370 - s3-deployment-logger - INFO - /etc/openldap/slapd.d/cn=config/cn=schema/cn={2}ppolicy.ldif removed

2021-05-20 03:04:13,371 - s3-deployment-logger - INFO - /etc/openldap/slapd.d/cn=config/olcDatabase={2}mdb removed

2021-05-20 03:04:13,371 - s3-deployment-logger - INFO - /var/lib/ldap removed

2021-05-20 03:04:13,517 - s3-deployment-logger - INFO -  Deleting topic.

2021-05-20 03:04:14,555 - s3-deployment-logger - INFO - Topic deletion successful.

2021-05-20 03:04:14,556 - s3-deployment-logger - INFO -  Reverting config files.

2021-05-20 03:04:14,557 - s3-deployment-logger - INFO -  Reverting config files successful.

2021-05-20 03:04:14,557 - s3-deployment-logger - INFO - Stopping slapd service...

2021-05-20 03:04:14,557 - s3-deployment-logger - INFO - shutting down slapd

2021-05-20 03:04:14,583 - s3-deployment-logger - INFO - Stopped slapd service...

2021-05-20 03:04:14,584 - s3-deployment-logger - INFO - /var/lib/ldap removed

2021-05-20 03:04:14,584 - s3-deployment-logger - INFO - Skippped Delete of S3 Deployment log file
2021-05-20 03:04:14,584 - s3-deployment-logger - INFO - cleanup successful.

[root@ssc-vm-3407 ~]#

</details>