### PR TITLE
[EOS-19670] Parsing of extended metadata key, since object name can contain delimiter |

### DIFF
--- a/server/s3_addb_map_auto.c
+++ b/server/s3_addb_map_auto.c
@@ -25,7 +25,7 @@
 
 #include "s3_addb_map.h"
 
-const uint64_t g_s3_to_addb_idx_func_name_map_size = 214;
+const uint64_t g_s3_to_addb_idx_func_name_map_size = 215;
 
 const char* g_s3_to_addb_idx_func_name_map[] = {
     "Action::check_authentication",

--- a/server/s3_get_bucket_action.cc
+++ b/server/s3_get_bucket_action.cc
@@ -223,7 +223,6 @@ void S3GetBucketAction::get_next_objects_successful() {
   bool last_key_in_common_prefix = false;
   bool skip_no_further_prefix_match = false;
   bool b_skip_remaining_common_prefixes = false;
-  bool b_this_is_last_resultset = false;
   std::string last_common_prefix = "";
   auto& kvps = motr_kv_reader->get_key_values();
   size_t length = kvps.size();
@@ -265,11 +264,6 @@ void S3GetBucketAction::get_next_objects_successful() {
   // Statistics - Total keys visited/loaded
   if (!kvps.empty()) {
     total_keys_visited += length;
-    // Check if last key in the result key set starts with "~"
-    if (kvps.rbegin()->first.rfind(EXTENDED_METADATA_OBJECT_PREFIX, 0) !=
-        std::string::npos) {
-      b_this_is_last_resultset = true;
-    }
   }
 
   for (auto& kv : kvps) {
@@ -330,17 +324,6 @@ void S3GetBucketAction::get_next_objects_successful() {
       }
     }
 
-    if (b_this_is_last_resultset) {
-      // This is the last result set; check each key for "~"
-      if (kv.first.rfind(EXTENDED_METADATA_OBJECT_PREFIX, 0) !=
-          std::string::npos) {
-        // Hit extended object entries
-        // Set length to 0 to set truncation flag off
-        length = 0;
-        s3_log(S3_LOG_DEBUG, request_id, "Reached the end of index\n");
-        break;
-      }
-    }
     auto object = object_metadata_factory->create_object_metadata_obj(request);
     size_t delimiter_pos = std::string::npos;
     if (request_prefix.empty() && request_delimiter.empty()) {

--- a/server/s3_object_metadata.cc
+++ b/server/s3_object_metadata.cc
@@ -903,7 +903,7 @@ S3ObjectExtendedMetadata::S3ObjectExtendedMetadata(
   } else {
     mote_kv_writer_factory = std::make_shared<S3MotrKVSWriterFactory>();
   }
-  last_object = EXTENDED_METADATA_OBJECT_PREFIX + objectname;
+  last_object = objectname;
 }
 
 void S3ObjectExtendedMetadata::load(std::function<void(void)> on_success,
@@ -953,7 +953,7 @@ void S3ObjectExtendedMetadata::get_obj_ext_entries_successful() {
            kv.second.second.c_str());
     last_object = kv.first;
     // Check if fetched key starts with object prefix
-    std::string object_prefix = EXTENDED_METADATA_OBJECT_PREFIX + object_name;
+    std::string object_prefix = object_name;
     bool prefix_match = (kv.first.find(object_prefix) == 0) ? true : false;
     if (!prefix_match) {
       end_of_enumeration = true;
@@ -1035,9 +1035,9 @@ void S3ObjectExtendedMetadata::save_extended_metadata_failed() {
 }
 
 int S3ObjectExtendedMetadata::from_json(std::string key, std::string content) {
-  // key of simple object with fragment := ~ObjectOne|versionID|F1
+  // key of simple object with fragment := ObjectOne|versionID|F1
   // or
-  // Key of multpart object with fragment := ~ObjectTwo|versionId|P1|F1 
+  // Key of multpart object with fragment := ObjectTwo|versionId|P1|F1 
   s3_log(S3_LOG_DEBUG, request_id, "Extended object metadata value [%s]\n",
          content.c_str());
   Json::Value newroot;
@@ -1051,14 +1051,24 @@ int S3ObjectExtendedMetadata::from_json(std::string key, std::string content) {
   item_ctx.is_multipart = false;
 
   std::vector<std::string> tokens;
-  // Check type of item: whether part or fragment
-  // e.g., key:= ~ObjectOne|versionID|F1
-  std::istringstream in(key);
+  // As object name can contain a delimiter (|) character, skip object name
+  // from below parsing logic.
+  assert(object_name.size() != 0);
+  int pos_after_skipping_object_name = object_name.size();
+  // (pos_after_skipping_object_name + 1) is done below to skip first '|'
+  // after the object name.
+  std::istringstream in(key.substr(pos_after_skipping_object_name + 1));
+  // First token is always the object name
+  tokens.push_back(object_name);
+
   std::string token;
   std::string sep = EXTENDED_METADATA_OBJECT_SEP;
   while (getline(in, token, sep[0])) {
     tokens.push_back(token);
   }
+  // Check the type of item: whether just part or fragment on part
+  // e.g., if key:= ObjectOne|versionID|F1, it has only fragment
+  // if key:= ObjectOne|versionID|P1|F1, it has one fragment on first part.
   if ((tokens.size() == 4) ||
       ((tokens.size() == 3) && (tokens[2].find("P", 0) != std::string::npos))) {
     // multipart (could be fragmented)
@@ -1112,7 +1122,7 @@ std::string S3ObjectExtendedMetadata::to_json() {
       std::vector<s3_part_frag_context> fragments;
       fragments = ext_objects[0];
       std::ostringstream buffer;
-      buffer << EXTENDED_METADATA_OBJECT_PREFIX << object_name
+      buffer << object_name
              << EXTENDED_METADATA_OBJECT_SEP << << frag_counter;
 
       root[buffer.str()] = ext_objects;
@@ -1121,7 +1131,7 @@ std::string S3ObjectExtendedMetadata::to_json() {
   } else {
     // This is multipart object
     for (const auto& ext_obj : ext_objects) {
-      std::string key = EXTENDED_METADATA_OBJECT_PREFIX + object_name +
+      std::string key = object_name +
                         EXTENDED_METADATA_OBJECT_SEP root[key] = ;
     }
   }
@@ -1150,8 +1160,7 @@ S3ObjectExtendedMetadata::get_kv_list_of_extended_entries() {
       std::string frag_field = "F" + std::to_string(frag_index);
       sskey.str("");
       sskey.clear();
-      sskey << EXTENDED_METADATA_OBJECT_PREFIX << object_name
-            << EXTENDED_METADATA_OBJECT_SEP << version_id;
+      sskey << object_name << EXTENDED_METADATA_OBJECT_SEP << version_id;
 
       if (part_field.empty()) {
         sskey << EXTENDED_METADATA_OBJECT_SEP << frag_field;

--- a/server/s3_object_metadata.h
+++ b/server/s3_object_metadata.h
@@ -35,13 +35,6 @@
 #include "s3_request_object.h"
 #include "s3_timer.h"
 
-// Object list index table is divided into objects and their extended parts, if
-// any.
-// All extended object entries start/prefix with special character "~",
-// to make them at the bottom of object list index table.
-// This special character is chosen, as it is not allowed in S3 object name and
-// also higher in the lexographical order.
-#define EXTENDED_METADATA_OBJECT_PREFIX "~"
 #define EXTENDED_METADATA_OBJECT_SEP "|"
 
 enum class S3ObjectMetadataState {

--- a/server/s3_put_multiobject_action.cc
+++ b/server/s3_put_multiobject_action.cc
@@ -144,7 +144,7 @@ void S3PutMultiObjectAction::check_part_details() {
   } else if (request->get_header_size() > MAX_HEADER_SIZE ||
              request->get_user_metadata_size() > MAX_USER_METADATA_SIZE) {
     s3_put_action_state = S3PutPartActionState::validationFailed;
-    set_s3_error("BadRequest");
+    set_s3_error("MetadataTooLarge");
     send_response_to_s3_client();
   } else if ((request->get_object_name()).length() > MAX_OBJECT_KEY_LENGTH) {
     s3_put_action_state = S3PutPartActionState::validationFailed;


### PR DESCRIPTION
- Changed the parsing logic
- Also, removed code that relates to "~" as start object prefix used in earlier design of
  S3 fault tolerance feature.

Signed-off-by: Dattaprasad <dattaprasad.govekar@seagate.com>