### PR TITLE
[EOS-20794] s3iamcli: Delete Account error message fix

### DIFF
--- a/auth-utils/s3iamcli/s3iamcli/account.py
+++ b/auth-utils/s3iamcli/s3iamcli/account.py
@@ -122,7 +122,7 @@ class Account:
     # delete account
     def delete(self):
         if self.cli_args.name is None:
-            print('Account name is required.')
+            message = "Account name is required."
             CLIResponse.send_error_out(message)
         # Get host value from url https://iam.seagate.com:9443
         url_parse_result  = urllib.parse.urlparse(Config.endpoint)


### PR DESCRIPTION
Fix error message output for delete account in case of s3iamcli commands.
e.g
[root@ssc-vm-2496 ~]# s3iamcli DeleteAccount --access_key AKIAWuGrR44RRmqeBKwJ_rbzRA --secret_key YoIRQ2HjdlzWdpqE3d5IXkk6BPJT3B0RW2BaUAdI
Account name is required.
**local variable 'message' referenced before assignment**
[root@ssc-vm-2496 ~]#

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>