### PR TITLE
[EOS-20643]  Getting and Verifying Checksums stored in Motr

### DIFF
--- a/s3config-test.yaml
+++ b/s3config-test.yaml
@@ -33,7 +33,7 @@ S3_SERVER_CONFIG:                                     # Section for S3 Server
    S3_READ_DATA_INTEGRITY_CHECK: true                   # TBD
    S3_METADATA_INTEGRITY_CHECK: true                    # TBD
    S3_SALT_CHECKSUM: true                               # TBD 
-   S3_PI_TYPE: 1                                        # Currently only supported value is 1, valid values 0-7
+   S3_PI_TYPE: "PI_TYPE_MD5_INC_CONTEXT"                  # TBD
    S3_MOTR_HTTP_REUSEPORT: true                         # Enable reusing motr http server port
    S3_IAM_CERT_FILE: "/etc/ssl/stx-s3/s3/ca.crt"        # IAM Auth certificate file
    S3_LOG_FLUSH_FREQUENCY: 3                            # Time in seconds, after which logs will be flushed. Valid only if S3_LOG_ENABLE_BUFFERING is true. Default is 30 seconds.

--- a/s3config-test.yaml
+++ b/s3config-test.yaml
@@ -33,6 +33,7 @@ S3_SERVER_CONFIG:                                     # Section for S3 Server
    S3_READ_DATA_INTEGRITY_CHECK: true                   # TBD
    S3_METADATA_INTEGRITY_CHECK: true                    # TBD
    S3_SALT_CHECKSUM: true                               # TBD 
+   S3_PI_TYPE: 1                                        # Currently only supported value is 1, valid values 0-7
    S3_MOTR_HTTP_REUSEPORT: true                         # Enable reusing motr http server port
    S3_IAM_CERT_FILE: "/etc/ssl/stx-s3/s3/ca.crt"        # IAM Auth certificate file
    S3_LOG_FLUSH_FREQUENCY: 3                            # Time in seconds, after which logs will be flushed. Valid only if S3_LOG_ENABLE_BUFFERING is true. Default is 30 seconds.

--- a/s3config.release.yaml.sample
+++ b/s3config.release.yaml.sample
@@ -27,12 +27,13 @@ S3_SERVER_CONFIG:                                       # Section for S3 Server
    S3_LOG_MODE: INFO                                    # logging levels, levels can be DEBUG, INFO, WARN, ERROR, FATAL, default is INFO
    S3_LOG_FILE_MAX_SIZE: 100                            # Maximum log file size in MB, default is 100 MB
    S3_LOG_ENABLE_BUFFERING: true                        # DEBUG, INFO & WARN logs are buffered if buffering is enabled. ERROR and FATAL logs are always flushed. Default is true.
-   S3_ENABLE_AUTH_SSL: false                             # Enable ssl communication between s3 server and auth server
+   S3_ENABLE_AUTH_SSL: false                            # Enable ssl communication between s3 server and auth server
    S3_REUSEPORT: true                                   # Enable reusing s3 server port
    S3_WRITE_DATA_INTEGRITY_CHECK: true                  # TBD
    S3_READ_DATA_INTEGRITY_CHECK: true                   # TBD
    S3_METADATA_INTEGRITY_CHECK: true                    # TBD
    S3_SALT_CHECKSUM: true                               # TBD 
+   S3_PI_TYPE: 1                                        # Currently only supported value is 1, valid values 0-7
    S3_MOTR_HTTP_REUSEPORT: true                         # Enable reusing motr http server port
    S3_IAM_CERT_FILE: "/etc/ssl/stx-s3/s3auth/s3authserver.crt" # IAM Auth certificate file
    S3_LOG_FLUSH_FREQUENCY: 30                           # Time in seconds, after which logs will be flushed. Valid only if S3_LOG_ENABLE_BUFFERING is true. Default is 30 seconds.

--- a/s3config.release.yaml.sample
+++ b/s3config.release.yaml.sample
@@ -33,7 +33,7 @@ S3_SERVER_CONFIG:                                       # Section for S3 Server
    S3_READ_DATA_INTEGRITY_CHECK: true                   # TBD
    S3_METADATA_INTEGRITY_CHECK: true                    # TBD
    S3_SALT_CHECKSUM: true                               # TBD 
-   S3_PI_TYPE: 1                                        # Currently only supported value is 1, valid values 0-7
+   S3_PI_TYPE: "PI_TYPE_MD5_INC_CONTEXT"                  # TBD
    S3_MOTR_HTTP_REUSEPORT: true                         # Enable reusing motr http server port
    S3_IAM_CERT_FILE: "/etc/ssl/stx-s3/s3auth/s3authserver.crt" # IAM Auth certificate file
    S3_LOG_FLUSH_FREQUENCY: 30                           # Time in seconds, after which logs will be flushed. Valid only if S3_LOG_ENABLE_BUFFERING is true. Default is 30 seconds.

--- a/s3config.yaml.sample
+++ b/s3config.yaml.sample
@@ -33,7 +33,7 @@ S3_SERVER_CONFIG:
    S3_READ_DATA_INTEGRITY_CHECK: true                   # TBD
    S3_METADATA_INTEGRITY_CHECK: true                    # TBD
    S3_SALT_CHECKSUM: true                               # TBD 
-   S3_PI_TYPE: 1                                        # Currently only supported value is 1, valid values 0-7
+   S3_PI_TYPE: "PI_TYPE_MD5_INC_CONTEXT"                # TBD
    S3_MOTR_HTTP_REUSEPORT: true                         # Enable reusing motr http server port
    S3_IAM_CERT_FILE: "/etc/ssl/stx-s3/s3auth/s3authserver.crt" # IAM Auth certificate file
    S3_LOG_FLUSH_FREQUENCY: 30                           # Time in seconds, after which logs will be flushed. Valid only if S3_LOG_ENABLE_BUFFERING is true. Default is 30 seconds.

--- a/s3config.yaml.sample
+++ b/s3config.yaml.sample
@@ -33,6 +33,7 @@ S3_SERVER_CONFIG:
    S3_READ_DATA_INTEGRITY_CHECK: true                   # TBD
    S3_METADATA_INTEGRITY_CHECK: true                    # TBD
    S3_SALT_CHECKSUM: true                               # TBD 
+   S3_PI_TYPE: 1                                        # Currently only supported value is 1, valid values 0-7
    S3_MOTR_HTTP_REUSEPORT: true                         # Enable reusing motr http server port
    S3_IAM_CERT_FILE: "/etc/ssl/stx-s3/s3auth/s3authserver.crt" # IAM Auth certificate file
    S3_LOG_FLUSH_FREQUENCY: 30                           # Time in seconds, after which logs will be flushed. Valid only if S3_LOG_ENABLE_BUFFERING is true. Default is 30 seconds.

--- a/server/s3_evbuffer_wrapper.cc
+++ b/server/s3_evbuffer_wrapper.cc
@@ -20,6 +20,7 @@
 
 #include "s3_evbuffer_wrapper.h"
 #include "s3_motr_context.h"
+#include "s3_option.h"
 
 // Create evbuffer of size buf_sz, with each basic buffer buf_unit_sz
 S3Evbuffer::S3Evbuffer(const std::string req_id, size_t buf_sz,
@@ -71,7 +72,9 @@ void S3Evbuffer::to_motr_read_buffers(struct s3_motr_rw_op_context* rw_ctx,
     *last_index += len;
 
     /* we don't want any attributes */
-    rw_ctx->attr->ov_vec.v_count[i] = 0;
+    if (!S3Option::get_instance()->is_s3_write_di_check_enabled()) {
+      rw_ctx->attr->ov_vec.v_count[i] = 0;
+    }
   }
 }
 

--- a/server/s3_md5_hash.h
+++ b/server/s3_md5_hash.h
@@ -39,11 +39,11 @@ class MD5hash {
   MD5hash(bool call_init);
   int Update(const char *input, size_t length);
   void save_motr_unit_checksum(unsigned char *curr_digest);
-  void save_motr_unit_checksum_for_unaligned_bufs(
-      unsigned char *curr_digest_at_unit);
+  void save_motr_unit_checksum_for_unaligned_bufs(unsigned char *curr_digest_at_unit);
   bool is_checksum_saved();
   void *get_prev_write_checksum();
   void *get_prev_unaligned_checksum();
+  
   int Finalize();
   void Finalized();
   void Reset();

--- a/server/s3_motr_context.cc
+++ b/server/s3_motr_context.cc
@@ -164,8 +164,8 @@ int free_basic_op_ctx(struct s3_motr_op_context *ctx) {
 
 unsigned long get_sizeof_pi_info(struct s3_motr_rw_op_context *ctx) {
   switch (ctx->pi.hdr.pi_type) {
-    case M0_PI_TYPE_MD5_INC_DIGEST:
-      return sizeof(m0_md5_inc_digest_pi);
+    case M0_PI_TYPE_MD5_INC_CONTEXT:
+      return sizeof(m0_md5_inc_context_pi);
     default:
       s3_log(S3_LOG_ERROR, "", "%s Invalid PI Type\n", __func__);
       return 0;

--- a/server/s3_motr_context.cc
+++ b/server/s3_motr_context.cc
@@ -209,7 +209,8 @@ struct s3_motr_rw_op_context *create_basic_rw_op_ctx(
     return NULL;
   }
 
-  if (S3Option::get_instance()->is_s3_write_di_check_enabled()) {
+  if (S3Option::get_instance()->is_s3_write_di_check_enabled() ||
+      S3Option::get_instance()->is_s3_read_di_check_enabled()) {
     rc = m0_bufvec_alloc(ctx->pi_bufvec, buffers_per_motr_unit, sizeof(void *));
     if (rc != 0) {
       s3_bufvec_free_aligned(ctx->data, unit_size, allocate_bufs);

--- a/server/s3_motr_context.h
+++ b/server/s3_motr_context.h
@@ -90,6 +90,8 @@ int free_obj_context(struct s3_motr_obj_context *ctx);
 struct s3_motr_op_context *create_basic_op_ctx(size_t op_count);
 int free_basic_op_ctx(struct s3_motr_op_context *ctx);
 
+unsigned long get_sizeof_pi_info(struct s3_motr_rw_op_context *ctx);
+
 struct s3_motr_rw_op_context *create_basic_rw_op_ctx(
     size_t motr_buf_count, size_t motr_checksums_buf_count, size_t unit_size,
     bool allocate_bufs = false);

--- a/server/s3_motr_reader.cc
+++ b/server/s3_motr_reader.cc
@@ -290,6 +290,40 @@ bool S3MotrReader::read_object() {
   return true;
 }
 
+bool S3MotrReader::ValidateStoredMD5Chksum(m0_bufvec *motr_data_unit,
+                                           struct m0_generic_pi *pi_info,
+                                           struct m0_pi_seed *seed) {
+  assert(NULL != motr_data_unit);
+  assert(NULL != pi_info);
+  assert(NULL != seed);
+
+  unsigned char current_digest[PI_DIGEST_LENGTH] = {0};
+  m0_md5_inc_digest_pi md5_info = {0};
+
+  memcpy(md5_info.prev_digest, ((m0_md5_inc_digest_pi *)(pi_info))->prev_digest,
+         PI_DIGEST_LENGTH);
+  md5_info.hdr.pi_type = M0_PI_TYPE_MD5_INC_DIGEST;
+
+  int rc = m0_client_calculate_pi((struct m0_generic_pi *)&md5_info, seed,
+                                  motr_data_unit, M0_PI_CALC_FINAL,
+                                  current_digest, NULL);
+  if (rc != 0) {
+    s3_log(S3_LOG_ERROR, "", "%s Motr API to Calculate PI Info failed.",
+           __func__);
+    return false;
+  }
+
+  if (0 != memcmp(md5_info.pi_value,
+                  ((m0_md5_inc_digest_pi *)(pi_info))->pi_value,
+                  PI_DIGEST_LENGTH)) {
+    s3_log(S3_LOG_ERROR, "", "%s Saved and Calculated Pi dont match.",
+           __func__);
+    return false;
+  }
+
+  return true;
+}
+
 bool S3MotrReader::ValidateStoredChksum() {
 
   uint32_t data_buffer_count =
@@ -302,8 +336,13 @@ bool S3MotrReader::ValidateStoredChksum() {
   assert(data_buffer_count % pi_buffer_count == 0);
 
   uint32_t pi_to_data_buffer_ratio = data_buffer_count / pi_buffer_count;
+
   s3_log(S3_LOG_INFO, "", "%s pi_to_data_buffer_ratio %u", __func__,
          pi_to_data_buffer_ratio);
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Motr Data Buffer count %u \n",
+         __func__, databuf->ov_vec.v_nr);
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Attr PI Buffer count %u \n",
+         __func__, pibuf->ov_vec.v_nr);
 
   uint32_t start_offset = 0;
   uint32_t end_offset = pi_to_data_buffer_ratio;
@@ -313,15 +352,12 @@ bool S3MotrReader::ValidateStoredChksum() {
 
     assert(end_offset <= data_buffer_count);
 
-    struct m0_pi_seed seed;
+    struct m0_pi_seed seed = {0};
     seed.data_unit_offset = current_index;
     seed.obj_id.f_container = oid.u_hi;
     seed.obj_id.f_key = oid.u_lo;
 
-    unsigned char current_digest[PI_DIGEST_LENGTH] = {0};
     m0_bufvec motr_data_unit = {0};
-    m0_md5_inc_digest_pi md5_info = {0};
-
     motr_data_unit.ov_vec.v_nr = pi_to_data_buffer_ratio;
     motr_data_unit.ov_vec.v_count = databuf->ov_vec.v_count + start_offset;
     motr_data_unit.ov_buf = databuf->ov_buf + start_offset;
@@ -330,43 +366,24 @@ bool S3MotrReader::ValidateStoredChksum() {
     s3_log(S3_LOG_INFO, "", "%s end_offset %u", __func__, end_offset);
     s3_log(S3_LOG_INFO, "", "%s current_index %lu", __func__, current_index);
 
-    memcpy(md5_info.prev_digest,
-           ((m0_md5_inc_digest_pi *)(pibuf->ov_buf[i]))->prev_digest,
-           PI_DIGEST_LENGTH);
-    md5_info.hdr.pi_type = M0_PI_TYPE_MD5_INC_DIGEST;
+    struct m0_generic_pi *pi_info = ((struct m0_generic_pi **)pibuf->ov_buf)[i];
 
-    int rc = m0_client_calculate_pi((struct m0_generic_pi *)&md5_info, &seed,
-                                    &motr_data_unit, M0_PI_CALC_FINAL,
-                                    current_digest, NULL);
-    if (rc != 0) {
-      return false;
-    }
-
-    if (0 != memcmp(md5_info.pi_value,
-                    ((m0_md5_inc_digest_pi *)(pibuf->ov_buf[i]))->pi_value,
-                    PI_DIGEST_LENGTH)) {
-      return false;
+    switch (pi_info->hdr.pi_type) {
+      case M0_PI_TYPE_MD5_INC_DIGEST:
+        if (false == ValidateStoredMD5Chksum(&motr_data_unit, pi_info, &seed)) {
+          s3_log(S3_LOG_ERROR, "", "%s Saved and Calculated Pi dont match.",
+                 __func__);
+          return false;
+        }
+        break;
+      default:
+        return false;
     }
 
     start_offset = end_offset;
     end_offset += pi_to_data_buffer_ratio;
     current_index += 1;
   }
-
-  //
-  // pi
-  // seed
-  // data
-  // flag
-  // current digest buffer
-  // NULL
-  //
-
-  // PI Comparison here.
-  s3_log(S3_LOG_INFO, stripped_request_id, "%s Motr Buffer count %u \n",
-         __func__, reader_context->get_motr_rw_op_ctx()->data->ov_vec.v_nr);
-  s3_log(S3_LOG_INFO, stripped_request_id, "%s Attr Buffer count %u \n",
-         __func__, reader_context->get_motr_rw_op_ctx()->attr->ov_vec.v_nr);
 
   return true;
 }

--- a/server/s3_motr_reader.cc
+++ b/server/s3_motr_reader.cc
@@ -292,6 +292,76 @@ bool S3MotrReader::read_object() {
 
 bool S3MotrReader::ValidateStoredChksum() {
 
+  uint32_t data_buffer_count =
+      reader_context->get_motr_rw_op_ctx()->data->ov_vec.v_nr;
+  uint32_t pi_buffer_count =
+      reader_context->get_motr_rw_op_ctx()->attr->ov_vec.v_nr;
+  m0_bufvec *databuf = reader_context->get_motr_rw_op_ctx()->data;
+  m0_bufvec *pibuf = reader_context->get_motr_rw_op_ctx()->attr;
+
+  assert(data_buffer_count % pi_buffer_count == 0);
+
+  uint32_t pi_to_data_buffer_ratio = data_buffer_count / pi_buffer_count;
+  s3_log(S3_LOG_INFO, "", "%s pi_to_data_buffer_ratio %u", __func__,
+         pi_to_data_buffer_ratio);
+
+  uint32_t start_offset = 0;
+  uint32_t end_offset = pi_to_data_buffer_ratio;
+  uint64_t current_index = last_index;
+
+  for (uint32_t i = 0; i < pi_buffer_count; i++) {
+
+    assert(end_offset <= data_buffer_count);
+
+    struct m0_pi_seed seed;
+    seed.data_unit_offset = current_index;
+    seed.obj_id.f_container = oid.u_hi;
+    seed.obj_id.f_key = oid.u_lo;
+
+    unsigned char current_digest[PI_DIGEST_LENGTH] = {0};
+    m0_bufvec motr_data_unit = {0};
+    m0_md5_inc_digest_pi md5_info = {0};
+
+    motr_data_unit.ov_vec.v_nr = pi_to_data_buffer_ratio;
+    motr_data_unit.ov_vec.v_count = databuf->ov_vec.v_count + start_offset;
+    motr_data_unit.ov_buf = databuf->ov_buf + start_offset;
+
+    s3_log(S3_LOG_INFO, "", "%s start_offset %u", __func__, start_offset);
+    s3_log(S3_LOG_INFO, "", "%s end_offset %u", __func__, end_offset);
+    s3_log(S3_LOG_INFO, "", "%s current_index %lu", __func__, current_index);
+
+    memcpy(md5_info.prev_digest,
+           ((m0_md5_inc_digest_pi *)(pibuf->ov_buf[i]))->prev_digest,
+           PI_DIGEST_LENGTH);
+    md5_info.hdr.pi_type = M0_PI_TYPE_MD5_INC_DIGEST;
+
+    int rc = m0_client_calculate_pi((struct m0_generic_pi *)&md5_info, &seed,
+                                    &motr_data_unit, M0_PI_CALC_FINAL,
+                                    current_digest, NULL);
+    if (rc != 0) {
+      return false;
+    }
+
+    if (0 != memcmp(md5_info.pi_value,
+                    ((m0_md5_inc_digest_pi *)(pibuf->ov_buf[i]))->pi_value,
+                    PI_DIGEST_LENGTH)) {
+      return false;
+    }
+
+    start_offset = end_offset;
+    end_offset += pi_to_data_buffer_ratio;
+    current_index += 1;
+  }
+
+  //
+  // pi
+  // seed
+  // data
+  // flag
+  // current digest buffer
+  // NULL
+  //
+
   // PI Comparison here.
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Motr Buffer count %u \n",
          __func__, reader_context->get_motr_rw_op_ctx()->data->ov_vec.v_nr);

--- a/server/s3_motr_reader.cc
+++ b/server/s3_motr_reader.cc
@@ -290,6 +290,17 @@ bool S3MotrReader::read_object() {
   return true;
 }
 
+bool S3MotrReader::ValidateStoredChksum() {
+
+  // PI Comparison here.
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Motr Buffer count %u \n",
+         __func__, reader_context->get_motr_rw_op_ctx()->data->ov_vec.v_nr);
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Attr Buffer count %u \n",
+         __func__, reader_context->get_motr_rw_op_ctx()->attr->ov_vec.v_nr);
+
+  return true;
+}
+
 void S3MotrReader::read_object_successful() {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_INFO, stripped_request_id,
@@ -320,6 +331,15 @@ void S3MotrReader::read_object_successful() {
         memset(bv->ov_buf[i], 0, bv->ov_vec.v_count[i]);
     }
   }
+
+  if (S3Option::get_instance()->is_s3_read_di_check_enabled()) {
+    if (!this->ValidateStoredChksum()) {
+      state = S3MotrReaderOpState::failed;
+      this->handler_on_failed();
+      return;
+    }
+  }
+
   state = S3MotrReaderOpState::success;
   this->handler_on_success();
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);

--- a/server/s3_motr_reader.h
+++ b/server/s3_motr_reader.h
@@ -99,8 +99,8 @@ class S3MotrReaderContext : public S3AsyncOpContextBase {
         S3Option::get_instance()->get_libevent_pool_buffer_size();
     size_t buf_count_in_evbuf =
         (total_read_sz + (evbuf_unit_buf_sz - 1)) / evbuf_unit_buf_sz;
-    motr_rw_op_context =
-        create_basic_rw_op_ctx(buf_count_in_evbuf, 0, evbuf_unit_buf_sz);
+    motr_rw_op_context = create_basic_rw_op_ctx(
+        buf_count_in_evbuf, motr_block_count, evbuf_unit_buf_sz);
     if (motr_rw_op_context == NULL) {
       // out of memory
       return false;
@@ -198,6 +198,7 @@ class S3MotrReader {
   // opened.
   virtual bool read_object();
   void read_object_successful();
+  bool ValidateStoredChksum();
   void read_object_failed();
 
   void clean_up_contexts();

--- a/server/s3_motr_reader.h
+++ b/server/s3_motr_reader.h
@@ -199,6 +199,9 @@ class S3MotrReader {
   virtual bool read_object();
   void read_object_successful();
   bool ValidateStoredChksum();
+  bool ValidateStoredMD5Chksum(m0_bufvec* motr_data_unit,
+                               struct m0_generic_pi* pi_info,
+                               struct m0_pi_seed* seed);
   void read_object_failed();
 
   void clean_up_contexts();

--- a/server/s3_motr_writer.cc
+++ b/server/s3_motr_writer.cc
@@ -773,10 +773,10 @@ void S3MotrWiter::set_up_motr_data_buffers(struct s3_motr_rw_op_context *rw_ctx,
         } else {
           if ((chksum_buf_idx == 0) && md5crypt.is_checksum_saved()) {
             // If there is checksum from previous write-set, then take that
-            memcpy(((struct m0_md5_inc_digest_pi *)((struct m0_generic_pi *)
-                                                    rw_ctx->attr->ov_buf
-                                                        [chksum_buf_idx])->t_pi)
-                       ->prev_digest,
+            memcpy(((struct m0_md5_inc_context_pi *)((struct m0_generic_pi *)
+                                                     rw_ctx->attr->ov_buf
+                                                         [chksum_buf_idx])
+                        ->t_pi)->prev_context,
                    md5crypt.get_prev_write_checksum(), sizeof(MD5_CTX));
           }
         }
@@ -799,10 +799,10 @@ void S3MotrWiter::set_up_motr_data_buffers(struct s3_motr_rw_op_context *rw_ctx,
         assert(chksum_buf_idx <= rw_ctx->motr_checksums_buf_count);
         if (chksum_buf_idx < rw_ctx->motr_checksums_buf_count) {
           // Save the current running checksum as prev_context of next unit
-          memcpy(((struct m0_md5_inc_digest_pi *)((struct m0_generic_pi *)
-                                                  rw_ctx->attr->ov_buf
-                                                      [chksum_buf_idx])->t_pi)
-                     ->prev_digest,
+          memcpy(((struct m0_md5_inc_context_pi *)((struct m0_generic_pi *)
+                                                   rw_ctx->attr->ov_buf
+                                                       [chksum_buf_idx])->t_pi)
+                     ->prev_context,
                  rw_ctx->current_digest, sizeof(MD5_CTX));
         }
 
@@ -904,8 +904,8 @@ void S3MotrWiter::set_up_motr_data_buffers(struct s3_motr_rw_op_context *rw_ctx,
   // those unaligned buffers and finalize
   if (!calculated_chksum_at_unit_boundary) {
     struct m0_generic_pi generic_pi_for_unaligned;
-    struct m0_md5_inc_digest_pi s3_md5_inc_digest_pi;
-    generic_pi_for_unaligned.hdr.pi_type = M0_PI_TYPE_MD5_INC_DIGEST;
+    struct m0_md5_inc_context_pi s3_md5_inc_digest_pi;
+    generic_pi_for_unaligned.hdr.pi_type = M0_PI_TYPE_MD5_INC_CONTEXT;
     generic_pi_for_unaligned.t_pi = &s3_md5_inc_digest_pi;
     if ((saved_last_index == 0) || (initial_buffers_part_write)) {
       // If the write is with offset as 0 or multipart part
@@ -914,9 +914,10 @@ void S3MotrWiter::set_up_motr_data_buffers(struct s3_motr_rw_op_context *rw_ctx,
       flag = M0_PI_CALC_UNIT_ZERO;
     } else {
       // Copy the checksum at last unit boundary
-      memcpy((void *)((struct m0_md5_inc_digest_pi *)(generic_pi_for_unaligned
-                                                          .t_pi))->prev_digest,
-             md5crypt.get_prev_unaligned_checksum(), sizeof(MD5_CTX));
+      memcpy(
+          (void *)((struct m0_md5_inc_context_pi *)(generic_pi_for_unaligned
+                                                        .t_pi))->prev_context,
+          md5crypt.get_prev_unaligned_checksum(), sizeof(MD5_CTX));
     }
 
     // Let only unaligned buffers be taken into consideration

--- a/server/s3_motr_writer.cc
+++ b/server/s3_motr_writer.cc
@@ -872,11 +872,11 @@ void S3MotrWiter::set_up_motr_data_buffers(struct s3_motr_rw_op_context *rw_ctx,
       } else {
         if (md5crypt.is_checksum_saved()) {
             // If there is checksum from previous write-set, then take that
-            memcpy(((struct m0_md5_inc_digest_pi *)((struct m0_generic_pi *)
-                                                    rw_ctx->attr->ov_buf
-                                                        [chksum_buf_idx])->t_pi)
-                       ->prev_digest,
-                   md5crypt.get_prev_write_checksum(), sizeof(MD5_CTX));
+          memcpy(((struct m0_md5_inc_context_pi *)((struct m0_generic_pi *)
+                                                   rw_ctx->attr->ov_buf
+                                                       [chksum_buf_idx])->t_pi)
+                     ->prev_context,
+                 md5crypt.get_prev_write_checksum(), sizeof(MD5_CTX));
           }
       }
 

--- a/server/s3_option.cc
+++ b/server/s3_option.cc
@@ -25,6 +25,12 @@
 #include "s3_motr_layout.h"
 #include "s3_log.h"
 #include "s3_common_utilities.h"
+#include <map>
+#include <string>
+#include "motr/client.h"
+
+std::map<std::string, int> g_pi_map = {
+    {std::string("PI_TYPE_MD5_INC_CONTEXT"), (int)M0_PI_TYPE_MD5_INC_CONTEXT}};
 
 S3Option* S3Option::option_instance = NULL;
 
@@ -61,7 +67,15 @@ bool S3Option::load_section(std::string section_name,
       S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_WRITE_DATA_INTEGRITY_CHECK");
       s3_write_data_integrity_check =
           s3_option_node["S3_WRITE_DATA_INTEGRITY_CHECK"].as<bool>();
-      s3_pi_type = s3_option_node["S3_PI_TYPE"].as<int>();
+      std::string pi_val = s3_option_node["S3_PI_TYPE"].as<std::string>();
+      std::map<std::string, int>::iterator pi_map_iterator =
+          g_pi_map.find(pi_val);
+      if (pi_map_iterator == g_pi_map.end()) {
+        fprintf(stderr, "%s:%d:option [%s] has incorrect value\n", __FILE__,
+                __LINE__, pi_val.c_str());
+        return false;
+      }
+      s3_pi_type = pi_map_iterator->second;
       S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_READ_DATA_INTEGRITY_CHECK");
       s3_read_data_integrity_check =
           s3_option_node["S3_READ_DATA_INTEGRITY_CHECK"].as<bool>();
@@ -460,7 +474,15 @@ bool S3Option::load_section(std::string section_name,
       S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_WRITE_DATA_INTEGRITY_CHECK");
       s3_write_data_integrity_check =
           s3_option_node["S3_WRITE_DATA_INTEGRITY_CHECK"].as<bool>();
-      s3_pi_type = s3_option_node["S3_PI_TYPE"].as<int>();
+      std::string pi_val = s3_option_node["S3_PI_TYPE"].as<std::string>();
+      std::map<std::string, int>::iterator pi_map_iterator =
+          g_pi_map.find(pi_val);
+      if (pi_map_iterator == g_pi_map.end()) {
+        fprintf(stderr, "%s:%d:option [%s] has incorrect value\n", __FILE__,
+                __LINE__, pi_val.c_str());
+        return false;
+      }
+      s3_pi_type = pi_map_iterator->second;
       S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_READ_DATA_INTEGRITY_CHECK");
       s3_read_data_integrity_check =
           s3_option_node["S3_READ_DATA_INTEGRITY_CHECK"].as<bool>();

--- a/server/s3_option.cc
+++ b/server/s3_option.cc
@@ -61,6 +61,7 @@ bool S3Option::load_section(std::string section_name,
       S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_WRITE_DATA_INTEGRITY_CHECK");
       s3_write_data_integrity_check =
           s3_option_node["S3_WRITE_DATA_INTEGRITY_CHECK"].as<bool>();
+      s3_pi_type = s3_option_node["S3_PI_TYPE"].as<int>();
       S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_READ_DATA_INTEGRITY_CHECK");
       s3_read_data_integrity_check =
           s3_option_node["S3_READ_DATA_INTEGRITY_CHECK"].as<bool>();
@@ -459,6 +460,7 @@ bool S3Option::load_section(std::string section_name,
       S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_WRITE_DATA_INTEGRITY_CHECK");
       s3_write_data_integrity_check =
           s3_option_node["S3_WRITE_DATA_INTEGRITY_CHECK"].as<bool>();
+      s3_pi_type = s3_option_node["S3_PI_TYPE"].as<int>();
       S3_OPTION_ASSERT_AND_RET(s3_option_node, "S3_READ_DATA_INTEGRITY_CHECK");
       s3_read_data_integrity_check =
           s3_option_node["S3_READ_DATA_INTEGRITY_CHECK"].as<bool>();
@@ -1178,6 +1180,8 @@ bool S3Option::is_s3_ssl_auth_enabled() { return s3_enable_auth_ssl; }
 bool S3Option::is_s3_write_di_check_enabled() {
   return s3_write_data_integrity_check;
 }
+
+int S3Option::get_pi_type() { return s3_pi_type; }
 
 bool S3Option::is_s3_read_di_check_enabled() {
   return s3_read_data_integrity_check;

--- a/server/s3_option.h
+++ b/server/s3_option.h
@@ -130,6 +130,7 @@ class S3Option {
   bool s3server_obj_delayed_del_enabled;
   bool s3_reuseport;
   bool s3_write_data_integrity_check;
+  int s3_pi_type;
   bool s3_read_data_integrity_check;
   bool s3_metadata_integrity_check;
   bool s3_salt_checksum;
@@ -384,6 +385,7 @@ class S3Option {
   int get_log_file_max_size_in_mb();
   bool is_s3_ssl_auth_enabled();
   bool is_s3_write_di_check_enabled();
+  int get_pi_type();
   bool is_s3_read_di_check_enabled();
   bool is_s3_metadata_integrity_check_enabled();
   bool is_s3_salt_checksum_enabled();


### PR DESCRIPTION
# Change Summary
## Problem Statement/Description
_[EOS-20643](https://jts.seagate.com/browse/EOS-20643):_
_[EOS-19705](https://jts.seagate.com/browse/EOS-19705):_
_Code for Getting and Verifying Checksums stored in Motr._

## Solution Overview

1. Allocate attr structure based on protection info to be used.
2. Make read call, motr should populate attr structure with relevant data.
3. On Read success, calculate pi of the data returned and compare it with the stored.
4. Fail Read Operation if above step fails.

## Unit Test Cases
Currently this implementation is only Code Complete. Code can be compiled with the relevant motr commit id, but UT's and ST's are failing.

Signed-off-by: Deepak Mahale <deepak.mahale@seagate.com>