### PR TITLE
EOS-20605: CopyObject regression

### DIFF
--- a/server/s3_object_data_copier.cc
+++ b/server/s3_object_data_copier.cc
@@ -39,6 +39,7 @@ S3ObjectDataCopier::S3ObjectDataCopier(
 
   request_id = this->request_object->get_request_id();
   size_of_ev_buffer = g_option_instance->get_libevent_pool_buffer_size();
+  assert(read_data_buffer.size() == 0);
   s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 }
 
@@ -90,6 +91,14 @@ void S3ObjectDataCopier::read_data_block_success() {
 
   s3_log(S3_LOG_INFO, request_id, "%s Entry\n", __func__);
   s3_log(S3_LOG_INFO, request_id, "Reading a part of data succeeded");
+  // Save ev buffer containing the read data, which will be freed after
+  // data write completion.
+  struct evbuffer* read_buffer = motr_reader->get_evbuffer_ownership();
+  if (read_buffer) {
+    read_data_buffer.push_back(read_buffer);
+    s3_log(S3_LOG_DEBUG, request_id, "Added read buffer (%p) to queue",
+           read_buffer);
+  }
 
   assert(read_in_progress);
   read_in_progress = false;
@@ -122,7 +131,7 @@ void S3ObjectDataCopier::read_data_block_success() {
   }
   // Calculating actial size of data that has just been read
 
-  for (size_t i = 0, n = data_blocks_read.size() - 1; i < n; ++i) {
+  for (size_t i = 0, n = data_blocks_read.size() - 1; i <= n; ++i) {
     const auto motr_block_size = data_blocks_read[i].second;
     assert(motr_block_size == motr_unit_size);
 
@@ -130,30 +139,15 @@ void S3ObjectDataCopier::read_data_block_success() {
     bytes_in_chunk_count += motr_block_size;
   }
   if (bytes_in_chunk_count >= bytes_left_to_read) {
-    s3_log(S3_LOG_ERROR, request_id,
+    s3_log(S3_LOG_DEBUG, request_id,
            "Too many data has been read. Data left - %zu, got - %zu",
            bytes_left_to_read, bytes_in_chunk_count);
-
-    copy_failed = true;
-    set_s3_error("InternalError");
-
-    if (!write_in_progress) {
-      this->on_failure();
-    }
-    return;
-  }
-  bytes_left_to_read -= bytes_in_chunk_count;
-
-  auto& r_last_block_size =
-      data_blocks_read[data_blocks_read.size() - 1].second;
-
-  if (r_last_block_size >= bytes_left_to_read) {
-    r_last_block_size = bytes_left_to_read;
+    get_buffers(data_blocks_read, bytes_in_chunk_count, bytes_left_to_read);
+    bytes_in_chunk_count = bytes_left_to_read;
     bytes_left_to_read = 0;
   } else {
-    bytes_left_to_read -= r_last_block_size;
+    bytes_left_to_read -= bytes_in_chunk_count;
   }
-  bytes_in_chunk_count += r_last_block_size;
 
   s3_log(S3_LOG_DEBUG, request_id, "Got %zu bytes in %zu blocks",
          bytes_in_chunk_count, data_blocks_read.size());
@@ -225,18 +219,17 @@ void S3ObjectDataCopier::write_data_block() {
 }
 
 void S3ObjectDataCopier::cleanup_blocks_written() {
-  auto* p_mem_pool_man = S3MempoolManager::get_instance();
-  assert(p_mem_pool_man != nullptr);
-
-  while (!data_blocks_writing.empty()) {
-    auto* p_data_block = data_blocks_writing.back().first;
-
-    if (p_data_block) {
-      p_mem_pool_man->release_buffer_for_unit_size(p_data_block,
-                                                   motr_unit_size);
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
+  if (!read_data_buffer.empty()) {
+    struct evbuffer* buffer = read_data_buffer.front();
+    read_data_buffer.pop_front();
+    if (buffer) {
+      s3_log(S3_LOG_DEBUG, request_id, "Released read data block (%p)", buffer);
+      // Below will release buffer to mempool
+      evbuffer_free(buffer);
     }
-    data_blocks_writing.pop_back();
   }
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3ObjectDataCopier::write_data_block_success() {
@@ -342,4 +335,48 @@ void S3ObjectDataCopier::copy(
 
 void S3ObjectDataCopier::set_s3_error(std::string s3_error) {
   this->s3_error = std::move(s3_error);
+}
+
+// Trims the input buffer (in-place) to the specified expected size
+void S3ObjectDataCopier::get_buffers(S3BufferSequence& buffer,
+                                     size_t total_size, size_t expected_size) {
+  s3_log(S3_LOG_INFO, request_id, "%s Entry\n", __func__);
+  assert(buffer.size() > 0);
+  assert(expected_size < total_size);
+  if (buffer.size() > 0 && (expected_size > 0 && expected_size < total_size)) {
+    // Process to shrink buffer
+    // Identify block in 'buffer' after which we need to discard all blocks
+    // For this, identify the last block (0 index based) in 'buffer' sequence
+    // that occupies the 'expected_size' of data
+    size_t last_block_occupied_by_expected_size =
+        ((expected_size + size_of_ev_buffer - 1) / size_of_ev_buffer) - 1;
+    assert(last_block_occupied_by_expected_size < buffer.size());
+    // Re-set the size of last block with data
+    // Also, discard memory of all subsequent blocks
+    size_t size_of_last_block = expected_size % size_of_ev_buffer;
+    if (size_of_last_block > 0) {
+      // The last block is not filled with all data bytes. Re-set its length
+      buffer[last_block_occupied_by_expected_size].second = size_of_last_block;
+    }
+    // Discard subsequent blocks from 'buffer'
+    size_t next_block = last_block_occupied_by_expected_size + 1;
+    if (next_block < buffer.size()) {
+      s3_log(S3_LOG_DEBUG, request_id,
+             "Discarding [%zu] blocks, starting from block index [%zu]",
+             (buffer.size() - last_block_occupied_by_expected_size - 1),
+             next_block);
+      auto* p_mem_pool_man = S3MempoolManager::get_instance();
+      assert(p_mem_pool_man != nullptr);
+      for (size_t i = buffer.size(); i > next_block; --i) {
+        auto* p_data_block = buffer.back().first;
+
+        if (p_data_block) {
+          p_mem_pool_man->release_buffer_for_unit_size(p_data_block,
+                                                       size_of_ev_buffer);
+        }
+        buffer.pop_back();
+      }
+    }
+  }
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_object_data_copier.cc
+++ b/server/s3_object_data_copier.cc
@@ -133,7 +133,7 @@ void S3ObjectDataCopier::read_data_block_success() {
 
   for (size_t i = 0, n = data_blocks_read.size() - 1; i <= n; ++i) {
     const auto motr_block_size = data_blocks_read[i].second;
-    assert(motr_block_size == motr_unit_size);
+    assert(motr_block_size == size_of_ev_buffer);
 
     // We can use multiplication, but something may change in the future
     bytes_in_chunk_count += motr_block_size;

--- a/server/s3_object_data_copier.h
+++ b/server/s3_object_data_copier.h
@@ -63,6 +63,9 @@ class S3ObjectDataCopier {
   bool write_in_progress;
   // Size of each ev buffer (e.g, 16384)
   size_t size_of_ev_buffer;
+  // Queue of ev Buffers containing read data blocks,
+  // which will be freed after write data completion
+  std::deque<struct evbuffer*> read_data_buffer;
 
   void cleanup_blocks_written();
   void read_data_block();
@@ -88,6 +91,11 @@ class S3ObjectDataCopier {
             std::function<void(void)> on_failure);
 
   const std::string& get_s3_error() { return s3_error; }
+  // Trims input 'buffer' to the expected size
+  // Used when we need specific portion of 'buffer', discarding the remianing
+  // data.
+  void get_buffers(S3BufferSequence& buffer, size_t total_size,
+                   size_t expected_size);
 
   friend class S3ObjectDataCopierTest;
 

--- a/ut/s3_object_data_copier_test.cc
+++ b/ut/s3_object_data_copier_test.cc
@@ -165,7 +165,7 @@ TEST_F(S3ObjectDataCopierTest, ReadDataBlockSuccessShouldStartWrite) {
   entity_under_test->read_in_progress = true;
 
   S3BufferSequence data_blocks_read;
-  data_blocks_read.emplace_back(nullptr, 0);
+  data_blocks_read.emplace_back(nullptr, entity_under_test->size_of_ev_buffer);
 
   EXPECT_CALL(*ptr_mock_motr_reader_factory->mock_motr_reader,
               extract_blocks_read())


### PR DESCRIPTION
- Code changes to trim buffer after the source object size(during copy operation)

Note: MD5 checksum of downloaded object is still not matching with the original source object, and investigation for the same is in progress.

Signed-off-by: Dattaprasad <dattaprasad.govekar@seagate.com>