### PR TITLE
[Bug] EOS-20866: s3: support bundle fix for handling grep command

### DIFF
--- a/scripts/env/dev/init.sh
+++ b/scripts/env/dev/init.sh
@@ -92,8 +92,8 @@ install_pre_requisites() {
   # install kafka server
   sh ${S3_SRC_DIR}/scripts/kafka/install-kafka.sh -c 1 -i $HOSTNAME
   
-  #sleep for 30 secs to make sure all the services are up and running.
-  sleep 30
+  #sleep for 60 secs to make sure all the services are up and running.
+  sleep 60
 
   #create topic
   sh ${S3_SRC_DIR}/scripts/kafka/create-topic.sh -c 1 -i $HOSTNAME

--- a/scripts/env/release/init.sh
+++ b/scripts/env/release/init.sh
@@ -72,8 +72,8 @@ install_pre_requisites() {
   # install kafka server
   sh ${S3_SRC_DIR}/scripts/kafka/install-kafka.sh -c 1 -i $HOSTNAME
 
-  #sleep for 30 secs to make sure all the services are up and running.
-  sleep 30
+  #sleep for 60 secs to make sure all the services are up and running.
+  sleep 60
 
   #create topic
   sh ${S3_SRC_DIR}/scripts/kafka/create-topic.sh -c 1 -i $HOSTNAME

--- a/scripts/env/rpmbuild/init.sh
+++ b/scripts/env/rpmbuild/init.sh
@@ -68,8 +68,8 @@ install_pre_requisites() {
   # install kafka server
   sh ${S3_SRC_DIR}/scripts/kafka/install-kafka.sh -c 1 -i $HOSTNAME
 
-  #sleep for 30 secs to make sure all the services are up and running.
-  sleep 30
+  #sleep for 60 secs to make sure all the services are up and running.
+  sleep 60
 
   #create topic
   sh ${S3_SRC_DIR}/scripts/kafka/create-topic.sh -c 1 -i $HOSTNAME

--- a/scripts/kafka/install-kafka.sh
+++ b/scripts/kafka/install-kafka.sh
@@ -59,6 +59,10 @@ start_services() {
 
   #start zookeeper
   systemctl start kafka-zookeeper
+
+  # add sleep time of 10 sec before starting kafka server
+  sleep 10
+
   systemctl status kafka-zookeeper | grep "active (running)" > /tmp/zookeeper
   if [[ -s /tmp/zookeeper ]]; then
     echo "zookeeper server started successfully."
@@ -68,6 +72,9 @@ start_services() {
 
   # start kafka server
   systemctl start kafka
+  # add sleep time of 10 sec before starting kafka server
+  sleep 10
+
   systemctl status kafka | grep "active (running)" > /tmp/kafka
   if [[ -s /tmp/kafka ]]; then
     echo "kafka server started successfully."

--- a/scripts/s3-support-bundles/s3_bundle_generate.sh
+++ b/scripts/s3-support-bundles/s3_bundle_generate.sh
@@ -110,9 +110,9 @@ then
 fi
 
 # 1. Get log directory path from config file
-s3server_logdir=`cat $s3server_config | grep "S3_LOG_DIR:" | cut -f2 -d: | sed -e 's/^[ \t]*//' -e 's/#.*//' -e 's/^[ \t]*"\(.*\)"[ \t]*$/\1/'`
-authserver_logdir=`cat $authserver_config | grep "logFilePath=" | cut -f2 -d'=' | sed -e 's/^[ \t]*//' -e 's/#.*//' -e 's/^[ \t]*"\(.*\)"[ \t]*$/\1/'`
-backgrounddelete_logdir=`cat $backgrounddelete_config | grep "logger_directory:" | cut -f2 -d: | sed -e 's/^[ \t]*//' -e 's/#.*//' -e 's/^[ \t]*"\(.*\)"[ \t]*$/\1/'`
+s3server_logdir=`cat $s3server_config | grep "S3_LOG_DIR" | cut -f2 -d: | sed -e 's/^[ \t]*//' -e 's/#.*//' -e 's/^[ \t]*"\(.*\)"[ \t]*$/\1/'`
+authserver_logdir=`cat $authserver_config | grep "logFilePath" | cut -f2 -d'=' | sed -e 's/^[ \t]*//' -e 's/#.*//' -e 's/^[ \t]*"\(.*\)"[ \t]*$/\1/'`
+backgrounddelete_logdir=`cat $backgrounddelete_config | grep "logger_directory" | cut -f2 -d: | sed -e 's/^[ \t]*//' -e 's/#.*//' -e 's/^[ \t]*"\(.*\)"[ \t]*$/\1/'`
 
 # Collect call stack of latest <s3_core_files_max_count> s3server core files
 # from s3_core_dir directory, if available

--- a/st/clitests/backgrounddelete_spec.py
+++ b/st/clitests/backgrounddelete_spec.py
@@ -184,7 +184,7 @@ S3fiTest('Disable FI motr entity delete').disable_fi("motr_entity_delete_fail")\
    .execute_test().command_is_successful()
 
 # wait till cleanup process completes and s3server sends response to client
-time.sleep(5)
+time.sleep(15)
 
 # ************ Start Schedular*****************************
 print("Running scheduler...")
@@ -243,7 +243,7 @@ S3fiTest('Disable FI motr entity delete fail').disable_fi("motr_entity_delete_fa
 object2_oid_dict = s3kvs.extract_headers_from_response(result.status.stderr)
 
 # wait till cleanup process completes and s3server sends response to client
-time.sleep(5)
+time.sleep(15)
 
 # ************ Start Schedular*****************************
 print("Running scheduler...")
@@ -285,7 +285,7 @@ result = AwsTest('Upload Object "object3" to bucket "seagatebucket"')\
     .execute_test(ignore_err=True).command_is_successful()
 
 # wait till cleanup process completes and s3server sends response to client
-time.sleep(1)
+time.sleep(15)
 
 object3_old_oid_dict = s3kvs.extract_headers_from_response(result.status.stderr)
 
@@ -303,7 +303,7 @@ result = AwsTest('Upload Object "object3" to bucket "seagatebucket"')\
     .command_error_should_have("InternalError")
 
 # wait till cleanup process completes and s3server sends response to client
-time.sleep(1)
+time.sleep(15)
 
 S3fiTest('Disable FI motr object write fail').disable_fi("motr_obj_write_fail")\
    .execute_test().command_is_successful()
@@ -369,7 +369,7 @@ S3cmdTest('s3cmd can delete multiple objects "object4" and "object5"')\
     .multi_delete_test("seagatebucket").execute_test().command_is_successful()
 
 # wait till cleanup process completes and s3server sends response to client
-time.sleep(1)
+time.sleep(15)
 
 S3fiTest('Disable FI motr entity delete fail')\
     .disable_fi("motr_entity_delete_fail").execute_test()\
@@ -466,7 +466,7 @@ result=AwsTest('Aws can complete multipart upload object6 10Mb file')\
     .command_response_should_have("seagatebucket/object6")
 
 # wait till cleanup process completes and s3server sends response to client
-time.sleep(1)
+time.sleep(15)
 
 S3fiTest('Disable FI motr entity delete fail').disable_fi("motr_entity_delete_fail")\
     .execute_test().command_is_successful()
@@ -530,7 +530,7 @@ result=AwsTest('Aws can abort multipart upload object7 10Mb file')\
     .execute_test().command_is_successful()
 
 # wait till cleanup process completes and s3server sends response to client
-time.sleep(1)
+time.sleep(15)
 
 S3fiTest('Disable FI motr entity delete fail').disable_fi("motr_entity_delete_fail")\
     .execute_test().command_is_successful()
@@ -613,7 +613,7 @@ S3fiTest('Disable FI motr entity delete fail').disable_fi("motr_entity_delete_fa
     .execute_test().command_is_successful()
 
 # wait till cleanup process completes and s3server sends response to client
-time.sleep(5)
+time.sleep(15)
 
 # ************ Start Schedular*****************************
 print("Running scheduler...")
@@ -673,7 +673,7 @@ result = AwsTest('Delete Object "object1" from bucket "seagatebucket"')\
 object1_oid_dict = s3kvs.extract_headers_from_response(result.status.stderr)
 
 # wait till cleanup process completes and s3server sends response to client
-time.sleep(5)
+time.sleep(15)
 
 # ************ Start Schedular*****************************
 print("Running scheduler...")
@@ -717,7 +717,7 @@ result = AwsTest('Upload Object "object1" to bucket "seagatebucket"')\
     .execute_test(ignore_err=True).command_is_successful()
 
 # wait till cleanup process completes and s3server sends response to client
-time.sleep(5)
+time.sleep(15)
 
 # ************ Start Schedular*****************************
 print("Running scheduler...")
@@ -770,7 +770,7 @@ S3cmdTest('s3cmd can delete multiple objects "object2" and "object3"')\
     .multi_delete_test("seagatebucket").execute_test().command_is_successful()
 
 # wait till cleanup process completes and s3server sends response to client
-time.sleep(1)
+time.sleep(15)
 
 
 # ************ Start Schedular*****************************

--- a/st/clitests/s3fi.py
+++ b/st/clitests/s3fi.py
@@ -82,7 +82,7 @@ class S3fiTest(PyCliTest):
         # sleep to avoid the impact on previous request cleanup of fault injection
         # TODO fault injection should be embeded into actual request.
         # This will restrict the fault injection scope/lifetime to that specific request only.
-        time.sleep(1)
+        time.sleep(2)
         curl_cmd = "curl -sS --header \"x-seagate-faultinjection: "
         self.opcode = opcode
         self.tag = tag


### PR DESCRIPTION
Fixed grep command in support bundle.
`[root@ssc-vm-2383 s3]# cd /opt/seagate/cortx/auth/resources/
[root@ssc-vm-2383 resources]#  authserver_logdir=`cat ./authserver.properties | grep "logFilePath=" | cut -f2 -d'=' | sed -e 's/^[ \t]*//' -e 's/#.*//' -e 's/^[ \t]*"\(.*\)"[ \t]*$/\1/'`
[root@ssc-vm-2383 resources]#
[root@ssc-vm-2383 resources]# echo $authserver_logdir

[root@ssc-vm-2383 resources]#
[root@ssc-vm-2383 resources]# below is valid command
[root@ssc-vm-2383 resources]#
[root@ssc-vm-2383 resources]#  authserver_logdir=`cat ./authserver.properties | grep "logFilePath" | cut -f2 -d'=' | sed -e 's/^[ \t]*//' -e 's/#.*//' -e 's/^[ \t]*"\(.*\)"[ \t]*$/\1/'`
[root@ssc-vm-2383 resources]# echo $authserver_logdir
/var/log/seagate/auth/server
[root@ssc-vm-2383 resources]#`

Also handled kafka timeout issues for dev vm. 
Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>