### PR TITLE
EOS-19860: Auth: netty jar upgrade 4.1.42.Final -> 4.1.63.Final

### DIFF
--- a/auth/server/pom.xml
+++ b/auth/server/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.65.Final</version>
+            <version>4.1.63.Final</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/auth/server/pom.xml
+++ b/auth/server/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.42.Final</version>
+            <version>4.1.65.Final</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>


### PR DESCRIPTION
Update netty package version,
**From** : 4.1.42.Final
**To** : 4.1.63.Final
maven repo : https://mvnrepository.com/artifact/io.netty/netty-all

Tried using latest 4.1.65.Final version of netty but that seems to be failing while doing signature calculation which uses FullHttpRequest object (isuss is FullHttpRequest has empty content  field which causes Signature mismatch in our case)
hence using 4.1.63.Final version for upgrade .
Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>