### PR TITLE
EOS-19643: Handling and logging of temporary file hosts_list_file.txt

### DIFF
--- a/scripts/ldap/ldapaccountaction.py
+++ b/scripts/ldap/ldapaccountaction.py
@@ -20,6 +20,7 @@
 
 import ldap
 import sys
+import socket
 from ldap.ldapobject import SimpleLDAPObject
 import ldap.modlist as modlist
 from s3cipher.cortx_s3_cipher import CortxS3Cipher
@@ -58,8 +59,8 @@ class LdapAccountAction:
 
   def __init__(self, ldapuser: str, ldappasswd: str):
     """Constructor."""
-    
-    self.logger = logging.getLogger("s3-deployment-logger")
+    s3deployment_logger_name = "s3-deployment-logger-" + "[" + str(socket.gethostname()) + "]"
+    self.logger = logging.getLogger(s3deployment_logger_name)
     if self.logger.hasHandlers():
       self.logger.info("Logger has valid handler")
     else:

--- a/scripts/provisioning/configcmd.py
+++ b/scripts/provisioning/configcmd.py
@@ -22,6 +22,7 @@ import sys
 import os
 import errno
 import shutil
+from pathlib import Path
 from  ast import literal_eval
 
 from setupcmd import SetupCmd, S3PROVError
@@ -146,20 +147,24 @@ class ConfigCmd(SetupCmd):
       if len(server_nodes_list) > 1:
         self.logger.info(f'Setting ldap-replication for storage_set:{index}')
 
-        with open("hosts_list_file.txt", "w") as f:
+        tmpdir = "/opt/seagate/cortx/s3/tmp"
+        Path(tmpdir).mkdir(parents=True, exist_ok=True)
+        ldap_hosts_list_file = os.path.join(tmpdir, "ldap_hosts_list_file.txt")
+        with open(ldap_hosts_list_file, "w") as f:
           for node_machine_id in server_nodes_list:
             private_fqdn = self.get_confvalue(f'server_node>{node_machine_id}>network>data>private_fqdn')
             f.write(f'{private_fqdn}\n')
+            self.logger.info(f'output of ldap_hosts_list_file.txt: {private_fqdn}')
 
         cmd = ['/opt/seagate/cortx/s3/install/ldap/replication/setupReplicationScript.sh',
              '-h',
-             'hosts_list_file.txt',
+             ldap_hosts_list_file,
              '-p',
              f'{self.rootdn_passwd}']
         handler = SimpleProcess(cmd)
         stdout, stderr, retcode = handler.run()
         self.logger.info(f'output of setupReplicationScript.sh: {stdout}')
-        #os.remove("hosts_list_file.txt")
+        os.remove(ldap_hosts_list_file)
 
         if retcode != 0:
           self.logger.error(f'error of setupReplicationScript.sh: {stderr}')

--- a/scripts/provisioning/s3_haproxy_config.py
+++ b/scripts/provisioning/s3_haproxy_config.py
@@ -20,6 +20,7 @@
 
 import os
 import sys
+import socket
 from s3confstore.cortx_s3_confstore import S3CortxConfStore
 import logging
 
@@ -32,7 +33,8 @@ class S3HaproxyConfig:
   def __init__(self, confstore: str):
     """Constructor."""
 
-    self.logger = logging.getLogger("s3-deployment-logger")
+    s3deployment_logger_name = "s3-deployment-logger-" + "[" + str(socket.gethostname()) + "]"
+    self.logger = logging.getLogger(s3deployment_logger_name)
     if self.logger.hasHandlers():
       self.logger.info("Logger has valid handler")
     else:

--- a/scripts/provisioning/s3_setup
+++ b/scripts/provisioning/s3_setup
@@ -24,10 +24,11 @@ import traceback
 import errno
 import logging
 import os
+import socket
 from logging import handlers
 
 #Logger details
-s3deployment_logger_name = "s3-deployment-logger"
+s3deployment_logger_name = "s3-deployment-logger-" + "[" + str(socket.gethostname()) + "]"
 s3deployment_log_file = "/var/log/seagate/s3/s3deployment/s3deployment.log"
 s3deployment_log_directory = "/var/log/seagate/s3/s3deployment/"
 s3deployment_log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/scripts/provisioning/setupcmd.py
+++ b/scripts/provisioning/setupcmd.py
@@ -23,6 +23,7 @@ import os
 import re
 import shutil
 import glob
+import socket
 from os import path
 from s3confstore.cortx_s3_confstore import S3CortxConfStore
 from s3cipher.cortx_s3_cipher import CortxS3Cipher
@@ -61,8 +62,8 @@ class SetupCmd(object):
 
   def __init__(self,config: str):
     """Constructor."""
-
-    self.logger = logging.getLogger("s3-deployment-logger")
+    s3deployment_logger_name = "s3-deployment-logger-" + "[" + str(socket.gethostname()) + "]"
+    self.logger = logging.getLogger(s3deployment_logger_name)
     
     if config is None:
       self.logger.error(f'Empty Config url')


### PR DESCRIPTION
1. Renamed hosts_list_file.txt to ldap_hosts_list_file.txt
2. Logged the o/p of ldap_hosts_list_file.txt to logger
3. Moved the ldap_hosts_list_file.txt to /opt/seagate/cortx/s3/tmp

UT:
Verified on custom S3 deployment job 
http://eos-jenkins.colo.seagate.com/job/Cortx-Deployment/job/Mini-Provisioner/job/S3-Deploy/252/console
![image](https://user-images.githubusercontent.com/68695688/120298066-5c7f1b80-c2e7-11eb-9918-418288d8a802.png)


