### PR TITLE
EOS-20998: List multipart returns empty, after unsuccessful complete multipart

### DIFF
--- a/server/s3_post_complete_action.cc
+++ b/server/s3_post_complete_action.cc
@@ -411,8 +411,8 @@ bool S3PostCompleteAction::validate_parts() {
         set_s3_error("EntityTooLarge");
         s3_post_complete_action_state =
             S3PostCompleteActionState::validationFailed;
-        set_abort_multipart(true);
-        break;
+        send_response_to_s3_client();
+        return false;
       }
       if (current_parts_size < MINIMUM_ALLOWED_PART_SIZE &&
           store_kv->first != total_parts) {
@@ -424,8 +424,8 @@ bool S3PostCompleteAction::validate_parts() {
         set_s3_error("EntityTooSmall");
         s3_post_complete_action_state =
             S3PostCompleteActionState::validationFailed;
-        set_abort_multipart(true);
-        break;
+        send_response_to_s3_client();
+        return false;
       }
 
       if (part_one_size_in_multipart_metadata != 0) {

--- a/st/clitests/awss3api_spec.py
+++ b/st/clitests/awss3api_spec.py
@@ -1150,6 +1150,8 @@ parts="Parts=[{ETag="+e_tag_1.strip('\n')+",PartNumber=1},{ETag="+e_tag_2.strip(
 print(parts)
 
 result=AwsTest('Aws cannot complete multipart upload when non-last part is less than 5MB').complete_multipart_upload("seagatebuckettag", "10Mbfile", parts, upload_id).execute_test(negative_case=True).command_should_fail().command_error_should_have("EntityTooSmall")
+#Above test would not abort multipart operation, so need to do it explicitly
+result=AwsTest('Aws abort previous multipart upload').abort_multipart_upload("seagatebuckettag", "10Mbfile", upload_id).execute_test(negative_case=True).command_is_successful()
 
 #******* Multipart upload should fail if user completes multipart-upload with wrong ETag ******
 

--- a/ut/s3_post_complete_action_test.cc
+++ b/ut/s3_post_complete_action_test.cc
@@ -510,7 +510,6 @@ TEST_F(S3PostCompleteActionTest, GetPartsSuccessfulEntityTooSmall) {
                action_under_test_ptr->get_s3_error_code().c_str());
   EXPECT_EQ(S3PostCompleteActionState::validationFailed,
             action_under_test_ptr->s3_post_complete_action_state);
-  EXPECT_EQ(true, action_under_test_ptr->is_abort_multipart());
 }
 
 TEST_F(S3PostCompleteActionTest, GetPartsSuccessfulEntityTooLarge) {
@@ -544,7 +543,6 @@ TEST_F(S3PostCompleteActionTest, GetPartsSuccessfulEntityTooLarge) {
                action_under_test_ptr->get_s3_error_code().c_str());
   EXPECT_EQ(S3PostCompleteActionState::validationFailed,
             action_under_test_ptr->s3_post_complete_action_state);
-  EXPECT_EQ(true, action_under_test_ptr->is_abort_multipart());
 }
 
 TEST_F(S3PostCompleteActionTest, GetPartsSuccessfulJsonError) {


### PR DESCRIPTION
Solution:
 - Changed the implementation of Multipart complete API to not abort the multipart operation when object size
 is too small (<5MB) or too large (>5GB).

Note: Verified the change using test mentioned in Jira.

Signed-off-by: Dattaprasad <dattaprasad.govekar@seagate.com>