### PR TITLE
EOS-21106: Handled already exist case for the background delete account

### DIFF
--- a/scripts/provisioning/initcmd.py
+++ b/scripts/provisioning/initcmd.py
@@ -57,6 +57,9 @@ class InitCmd(SetupCmd):
                                 }
       LdapAccountAction(self.ldap_user, self.ldap_passwd).create_account(bgdelete_acc_input_params_dict)
     except Exception as e:
-      self.logger.error(f'Failed to create backgrounddelete service account, error: {e}')
-      raise e
+      if "Already exists" not in str(e):
+        self.logger.error(f'Failed to create backgrounddelete service account, error: {e}')
+        raise(e)
+      else:
+        self.logger.warning("backgrounddelete service account already exist")
     self.logger.info("create background delete account completed")

--- a/scripts/provisioning/resetcmd.py
+++ b/scripts/provisioning/resetcmd.py
@@ -154,5 +154,8 @@ class ResetCmd(SetupCmd):
                                 }
       LdapAccountAction(self.ldap_user, self.ldap_passwd).create_account(bgdelete_acc_input_params_dict)
     except Exception as e:
-      self.logger.error(f'ERROR: Failed to create backgrounddelete service account, error: {e}')
-      raise e
+      if "Already exists" not in str(e):
+        self.logger.error(f'Failed to create backgrounddelete service account, error: {e}')
+        raise(e)
+      else:
+        self.logger.warning("backgrounddelete service account already exist")


### PR DESCRIPTION
# Change Summary
## Problem Statement/Description
_[EOS-21106](https://jts.seagate.com/browse/EOS-21106):_
_Handled already exist case for the background delete account_

## Solution Overview
Handled already exist case for the background delete account for init and reset phase