### PR TITLE
EOS-17572: S3 Multipart Post Complete api implementation (Multipart re-design)

### DIFF
--- a/server/s3_bucket_metadata.h
+++ b/server/s3_bucket_metadata.h
@@ -109,7 +109,7 @@ class S3BucketMetadata {
   virtual const struct m0_uint128& get_object_list_index_oid() const;
   virtual const struct m0_uint128& get_objects_version_list_index_oid() const;
   const struct m0_uint128& get_multipart_index_oid() const;
-  const struct m0_uint128& get_extended_metadata_index_oid() const;
+  virtual const struct m0_uint128& get_extended_metadata_index_oid() const;
 
   void set_multipart_index_oid(struct m0_uint128 id);
   void set_object_list_index_oid(struct m0_uint128 id);

--- a/server/s3_get_object_action.cc
+++ b/server/s3_get_object_action.cc
@@ -42,7 +42,12 @@ S3GetObjectAction::S3GetObjectAction(
       first_byte_offset_to_read(0),
       last_byte_offset_to_read(0),
       total_blocks_to_read(0),
-      read_object_reply_started(false) {
+      read_object_reply_started(false),
+      total_objects(0),
+      total_objects_to_read(0),
+      next_fragment_object(0),
+      total_blocks_to_read_all_objects(0),
+      data_sent_to_client_for_object(0) {
   s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
 
   s3_log(S3_LOG_INFO, stripped_request_id,
@@ -85,22 +90,27 @@ void S3GetObjectAction::fetch_bucket_info_failed() {
 }
 
 void S3GetObjectAction::fetch_object_info_failed() {
-  object_list_oid = bucket_metadata->get_object_list_index_oid();
-  if (object_list_oid.u_hi == 0ULL && object_list_oid.u_lo == 0ULL) {
-    s3_log(S3_LOG_ERROR, request_id, "Object not found\n");
-    set_s3_error("NoSuchKey");
-  } else if (object_metadata->get_state() == S3ObjectMetadataState::missing) {
-    s3_log(S3_LOG_DEBUG, request_id, "Object not found\n");
-    set_s3_error("NoSuchKey");
-  } else if (object_metadata->get_state() ==
-             S3ObjectMetadataState::failed_to_launch) {
-    s3_log(S3_LOG_ERROR, request_id,
-           "Object metadata load operation failed due to pre launch "
-           "failure\n");
-    set_s3_error("ServiceUnavailable");
-  } else {
-    s3_log(S3_LOG_DEBUG, request_id, "Object metadata fetch failed\n");
-    set_s3_error("InternalError");
+  if (bucket_metadata->get_state() == S3BucketMetadataState::present) {
+    s3_log(S3_LOG_DEBUG, request_id, "Found bucket metadata\n");
+    object_list_oid = bucket_metadata->get_object_list_index_oid();
+    if (object_list_oid.u_hi == 0ULL && object_list_oid.u_lo == 0ULL) {
+      s3_log(S3_LOG_ERROR, request_id, "Object not found\n");
+      set_s3_error("NoSuchKey");
+    } else {
+      if (object_metadata->get_state() == S3ObjectMetadataState::missing) {
+        s3_log(S3_LOG_DEBUG, request_id, "Object not found\n");
+        set_s3_error("NoSuchKey");
+      } else if (object_metadata->get_state() ==
+                 S3ObjectMetadataState::failed_to_launch) {
+        s3_log(S3_LOG_ERROR, request_id,
+               "Object metadata load operation failed due to pre launch "
+               "failure\n");
+        set_s3_error("ServiceUnavailable");
+      } else {
+        s3_log(S3_LOG_DEBUG, request_id, "Object metadata fetch failed\n");
+        set_s3_error("InternalError");
+      }
+    }
   }
   send_response_to_s3_client();
 }
@@ -140,17 +150,133 @@ void S3GetObjectAction::validate_object_info() {
     request->send_reply_start(S3HttpSuccess200);
     send_response_to_s3_client();
   } else {
-    size_t motr_unit_size =
-        S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(
-            object_metadata->get_layout_id());
-    s3_log(S3_LOG_DEBUG, request_id,
-           "motr_unit_size = %zu for layout_id = %d\n", motr_unit_size,
-           object_metadata->get_layout_id());
-    /* Count Data blocks from data size */
-    total_blocks_in_object =
-        (content_length + (motr_unit_size - 1)) / motr_unit_size;
-    s3_log(S3_LOG_DEBUG, request_id, "total_blocks_in_object: (%zu)\n",
-           total_blocks_in_object);
+    if (this->object_metadata->get_number_of_fragments() == 0) {
+      // Object is normal (not fragmented)
+      total_objects = 1;
+      size_t motr_unit_size =
+          S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(
+              object_metadata->get_layout_id());
+      s3_log(S3_LOG_DEBUG, request_id,
+             "motr_unit_size = %zu for layout_id = %d\n", motr_unit_size,
+             object_metadata->get_layout_id());
+      /* Count Data blocks from data size */
+      total_blocks_in_object =
+          (content_length + (motr_unit_size - 1)) / motr_unit_size;
+      s3_log(S3_LOG_DEBUG, request_id, "total_blocks_in_object: (%zu)\n",
+             total_blocks_in_object);
+    } else {
+      bool is_multipart = false;
+      // Object is fragmented and/or parts
+      unsigned int ext_entry_index = 0;
+      if (object_metadata->get_number_of_parts() == 0) {
+        // Object is only fragmented then:= total objects = fragments + 1
+        total_objects = object_metadata->get_number_of_fragments() + 1;
+      } else {
+        // Object is multipart (fragmented or not) then total object = fragments
+        // When object is multipart, object_metadata->get_number_of_parts() > 0
+        total_objects = object_metadata->get_number_of_fragments();
+        is_multipart = true;
+      }
+      s3_log(S3_LOG_DEBUG, request_id, "Total objects : (%zu)\n",
+             total_objects);
+      const std::shared_ptr<S3ObjectExtendedMetadata>& ext_obj =
+          object_metadata->get_extended_object_metadata();
+      const std::map<int, std::vector<struct s3_part_frag_context>>&
+          ext_entries = ext_obj->get_raw_extended_entries();
+      for (unsigned int i = 0; i < total_objects; i++) {
+        struct S3ExtendedObjectInfo obj_info;
+        if (!is_multipart) {
+          // non-multipart fragmented object
+          if (i == 0) {
+            // Primary object
+            obj_info.start_offset_in_object = 0;
+            obj_info.object_OID = object_metadata->get_oid();
+            obj_info.object_layout = object_metadata->get_layout_id();
+            obj_info.object_pvid = object_metadata->get_pvid();
+            obj_info.object_size = object_metadata->get_primary_obj_size();
+            obj_info.requested_object_size = obj_info.object_size;
+            size_t motr_unit_size =
+                S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(
+                    object_metadata->get_layout_id());
+            /* Count Data blocks from data size */
+            obj_info.total_blocks_in_object =
+                (obj_info.object_size + (motr_unit_size - 1)) / motr_unit_size;
+            total_blocks_in_object += obj_info.total_blocks_in_object;
+            s3_log(S3_LOG_DEBUG, request_id,
+                   "motr_unit_size = %zu for layout_id = %d in object (oid) ="
+                   "%" SCNx64 " : %" SCNx64 " with blocks in object = (%zu)\n",
+                   motr_unit_size, object_metadata->get_layout_id(),
+                   obj_info.object_OID.u_hi, obj_info.object_OID.u_lo,
+                   obj_info.total_blocks_in_object);
+            extended_objects.push_back(obj_info);
+          } else {
+            obj_info.start_offset_in_object =
+                extended_objects[i - 1].start_offset_in_object +
+                extended_objects[i - 1].object_size;
+            const struct s3_part_frag_context& frag_info =
+                (ext_entries.at(0)).at(ext_entry_index);
+            obj_info.object_OID = frag_info.motr_OID;
+            obj_info.object_layout = frag_info.layout_id;
+            obj_info.object_pvid = frag_info.PVID;
+            obj_info.object_size = frag_info.item_size;
+            obj_info.requested_object_size = obj_info.object_size;
+            size_t motr_unit_size =
+                S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(
+                    obj_info.object_layout);
+            /* Count Data blocks from data size */
+            obj_info.total_blocks_in_object =
+                (obj_info.object_size + (motr_unit_size - 1)) / motr_unit_size;
+            total_blocks_in_object += obj_info.total_blocks_in_object;
+            s3_log(S3_LOG_DEBUG, request_id,
+                   "motr_unit_size = %zu for layout_id = %d in object (oid) ="
+                   "%" SCNx64 " : %" SCNx64 " with blocks in object = (%zu)\n",
+                   motr_unit_size, obj_info.object_layout,
+                   obj_info.object_OID.u_hi, obj_info.object_OID.u_lo,
+                   obj_info.total_blocks_in_object);
+            extended_objects.push_back(obj_info);
+            ++ext_entry_index;
+          }
+        } else {
+          // multipart (may be fragmented) object
+          // For now, ext_entry_index is always 0,
+          // assuming multipart is not fragmented.
+          ext_entry_index = 0;
+          if (i == 0) {
+            // first part object
+            obj_info.start_offset_in_object = 0;
+          } else {
+            obj_info.start_offset_in_object =
+                extended_objects[i - 1].start_offset_in_object +
+                extended_objects[i - 1].object_size;
+          }
+          // For multipart, ext_entries are indexed from key=1 onwards
+          const struct s3_part_frag_context& frag_info =
+              (ext_entries.at(i + 1)).at(ext_entry_index);
+          obj_info.object_OID = frag_info.motr_OID;
+          obj_info.object_layout = frag_info.layout_id;
+          obj_info.object_pvid = frag_info.PVID;
+          obj_info.object_size = frag_info.item_size;
+          obj_info.requested_object_size = obj_info.object_size;
+          size_t motr_unit_size =
+              S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(
+                  obj_info.object_layout);
+          /* Count Data blocks from data size */
+          obj_info.total_blocks_in_object =
+              (obj_info.object_size + (motr_unit_size - 1)) / motr_unit_size;
+          total_blocks_in_object += obj_info.total_blocks_in_object;
+          s3_log(S3_LOG_DEBUG, request_id,
+                 "motr_unit_size = %zu for layout_id = %d in object (oid) ="
+                 "%" SCNx64 " : %" SCNx64 " with blocks in object = (%zu)\n",
+                 motr_unit_size, obj_info.object_layout,
+                 obj_info.object_OID.u_hi, obj_info.object_OID.u_lo,
+                 obj_info.total_blocks_in_object);
+          extended_objects.push_back(obj_info);
+        }
+      }  // End of For loop
+      s3_log(S3_LOG_DEBUG, request_id,
+             "total_blocks_in_all_fragmented_object: (%zu)\n",
+             total_blocks_in_object);
+    }
     next();
   }
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
@@ -164,6 +290,7 @@ void S3GetObjectAction::set_total_blocks_to_read_from_object() {
     total_blocks_to_read = total_blocks_in_object;
   } else {
     // object read for valid range
+    // get total number blocks to read for a given valid range
     size_t motr_unit_size =
         S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(
             object_metadata->get_layout_id());
@@ -176,6 +303,154 @@ void S3GetObjectAction::set_total_blocks_to_read_from_object() {
     // get total number blocks to read for a given valid range
     total_blocks_to_read = last_byte_offset_block - first_byte_offset_block + 1;
   }
+}
+
+void S3GetObjectAction::set_total_blocks_to_read_from_fragmented_object() {
+  if ((first_byte_offset_to_read == 0) &&
+      (last_byte_offset_to_read == (content_length - 1))) {
+    // Number of blocks to read from all objects, starting from primary
+    // object to last extended object.
+    for (unsigned int i = 0; i < total_objects; i++) {
+      total_blocks_to_read_all_objects +=
+          extended_objects[i].total_blocks_in_object;
+    }
+    // In order to read complete object, total number of objects to read
+    // is equal to total number of objects
+    total_objects_to_read = total_objects;
+  } else {
+    // TODO: Correct the implementtaion below for fragmented object,
+    // when byte range is specified.
+    // object read for valid range
+    // TODO: Find the object (i.e index in extended_objects) containing
+    // first_byte_offset_to_read
+    unsigned int first_byte_object_index = 0,
+                 last_byte_object_index = total_objects - 1;
+    total_objects_to_read = total_objects;
+    for (unsigned int i = 0; i < total_objects; i++) {
+      if (first_byte_offset_to_read <
+          (extended_objects[i].start_offset_in_object +
+           extended_objects[i].object_size)) {
+        // Found first_byte_offset_to_read in object at index i
+        first_byte_object_index = i;
+        break;
+      }
+    }
+    // TODO: Find the object containing last_byte_offset_to_read
+    for (unsigned int j = first_byte_object_index; j < total_objects; j++) {
+      if (last_byte_offset_to_read <
+          (extended_objects[j].start_offset_in_object +
+           extended_objects[j].object_size)) {
+        // Found last_byte_offset_to_read in object at index i
+        last_byte_object_index = j;
+        break;
+      }
+    }
+    // Calculate the actual requested content in first object
+    // (first_byte_object_index) and last object (last_byte_object_index)
+    if (last_byte_object_index == first_byte_object_index) {
+      // If both first byte offset and last byte offset are in same object
+      extended_objects[first_byte_object_index].requested_object_size =
+          last_byte_offset_to_read - first_byte_offset_to_read + 1;
+    } else {
+      extended_objects[first_byte_object_index].requested_object_size =
+          (extended_objects[first_byte_object_index].object_size -
+           (first_byte_offset_to_read -
+            extended_objects[first_byte_object_index].start_offset_in_object));
+
+      extended_objects[last_byte_object_index].requested_object_size =
+          last_byte_offset_to_read -
+          (extended_objects[last_byte_object_index].start_offset_in_object);
+    }
+
+    // Get the block of first_byte_offset_to_read from object at
+    // index first_byte_object_index
+    size_t unit_size_of_object_with_first_byte = 0,
+           unit_size_of_object_with_last_byte = 0;
+    unit_size_of_object_with_first_byte =
+        S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(
+            extended_objects[first_byte_object_index].object_layout);
+    if (last_byte_object_index != first_byte_object_index) {
+      unit_size_of_object_with_last_byte =
+          S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(
+              extended_objects[last_byte_object_index].object_layout);
+    } else {
+      // Both offsets belong to same object
+      unit_size_of_object_with_last_byte = unit_size_of_object_with_first_byte;
+    }
+
+    size_t first_byte_offset_block =
+        (first_byte_offset_to_read -
+         extended_objects[first_byte_object_index].start_offset_in_object +
+         unit_size_of_object_with_first_byte) /
+        unit_size_of_object_with_first_byte;
+
+    // Get the block of last_byte_offset_to_read from object at
+    // index 'last_byte_object_index'
+    size_t last_byte_offset_block =
+        (last_byte_offset_to_read -
+         extended_objects[last_byte_object_index].start_offset_in_object +
+         unit_size_of_object_with_last_byte) /
+        unit_size_of_object_with_last_byte;
+
+    // Get total number blocks to read for a given valid range
+    for (unsigned int k = first_byte_object_index; k <= last_byte_object_index;
+         k++) {
+      // Calculate blocks in each object in the valid object range with offsets
+      if (k == first_byte_object_index) {
+        total_blocks_to_read_all_objects +=
+            extended_objects[k].total_blocks_in_object -
+            first_byte_offset_block + 1;
+      } else if (k == last_byte_object_index) {
+        total_blocks_to_read_all_objects += last_byte_offset_block;
+      } else {
+        total_blocks_to_read_all_objects +=
+            extended_objects[k].total_blocks_in_object;
+      }
+    }
+    // Check if 'extended_objects' needs to be shrunk, due to specified byte
+    // range
+    bool need_to_shrink_front = false, need_to_shrink_end = false;
+    // First, check for first byte offset object
+    if (first_byte_object_index != 0 &&
+        first_byte_object_index < total_objects) {
+      // First byte to read is not in first object, so shrink the array of
+      // objects
+      need_to_shrink_front = true;
+    }
+    // Second, check for last byte offset object
+    if (last_byte_object_index != (total_objects - 1) &&
+        last_byte_object_index < total_objects) {
+      // Last byte to read is not in the last object, so shrink the array of
+      // objects
+      need_to_shrink_end = true;
+    }
+    std::vector<struct S3ExtendedObjectInfo> new_set_of_extended_objects;
+    if (need_to_shrink_front || need_to_shrink_end) {
+      if (need_to_shrink_front && need_to_shrink_end) {
+        std::copy(extended_objects.begin() + first_byte_object_index,
+                  (extended_objects.begin() + last_byte_object_index + 1),
+                  back_inserter(new_set_of_extended_objects));
+      } else if (need_to_shrink_front) {
+        // Shrink front only
+        std::copy(extended_objects.begin() + first_byte_object_index,
+                  extended_objects.end(),
+                  back_inserter(new_set_of_extended_objects));
+      } else {
+        // Shrink end only
+        std::copy(extended_objects.begin(),
+                  (extended_objects.begin() + last_byte_object_index + 1),
+                  back_inserter(new_set_of_extended_objects));
+      }
+      // Re-set the array of objects to read data from
+      extended_objects = new_set_of_extended_objects;
+      // Re-calculate total objects to read data from
+      total_objects_to_read = extended_objects.size();
+    }
+  }
+  s3_log(S3_LOG_DEBUG, request_id,
+         "total_objects_to_read: (%zu)\n,total_blocks_to_read_across_objects: "
+         "(%zu)\n",
+         total_objects_to_read, total_blocks_to_read_all_objects);
 }
 
 bool S3GetObjectAction::validate_range_header_and_set_read_options(
@@ -318,8 +593,42 @@ void S3GetObjectAction::check_full_or_range_object_read() {
 
 void S3GetObjectAction::read_fragmented_object() {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
-  // TODO
+
+  set_total_blocks_to_read_from_next_object();
+  motr_reader = motr_reader_factory->create_motr_reader(
+      request, extended_objects[next_fragment_object].object_OID,
+      extended_objects[next_fragment_object].object_layout,
+      extended_objects[next_fragment_object].object_pvid);
+  // get the block,in which first_byte_offset_to_read is present
+  // and initilaize the last index with starting offset of the block
+  size_t block_start_offset = 0;
+  if (next_fragment_object == 0) {
+    size_t unit_size_of_object_with_first_byte =
+        S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(
+            extended_objects[next_fragment_object].object_layout);
+
+    size_t first_byte_offset_block =
+        (first_byte_offset_to_read -
+         extended_objects[next_fragment_object].start_offset_in_object +
+         unit_size_of_object_with_first_byte) /
+        unit_size_of_object_with_first_byte;
+
+    block_start_offset =
+        (first_byte_offset_block - 1) * unit_size_of_object_with_first_byte;
+  }
+  motr_reader->set_last_index(block_start_offset);
+  read_object_data();
   s3_log(S3_LOG_INFO, "", "%s Exit", __func__);
+}
+
+void S3GetObjectAction::set_total_blocks_to_read_from_next_object() {
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
+  blocks_already_read = 0;
+  data_sent_to_client_for_object = 0;
+  total_blocks_to_read =
+      extended_objects[next_fragment_object].total_blocks_in_object;
+
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Exit\n", __func__);
 }
 
 void S3GetObjectAction::read_object() {
@@ -341,7 +650,8 @@ void S3GetObjectAction::read_object() {
     motr_reader->set_last_index(block_start_offset);
     read_object_data();
   } else {
-    next();
+    set_total_blocks_to_read_from_fragmented_object();
+    read_fragmented_object();
   }
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
@@ -355,9 +665,14 @@ void S3GetObjectAction::read_object_data() {
 
   size_t max_blocks_in_one_read_op =
       S3Option::get_instance()->get_motr_units_per_request();
-  size_t motr_unit_size =
-      S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(
-          object_metadata->get_layout_id());
+  size_t motr_unit_size = 0;
+  if (!object_metadata->is_object_extended()) {
+    motr_unit_size = S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(
+        object_metadata->get_layout_id());
+  } else {
+    motr_unit_size = S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(
+        extended_objects[next_fragment_object].object_layout);
+  }
   blocks_to_read = 0;
 
   s3_log(S3_LOG_DEBUG, request_id, "max_blocks_in_one_read_op: (%zu)\n",
@@ -367,7 +682,7 @@ void S3GetObjectAction::read_object_data() {
   s3_log(S3_LOG_DEBUG, request_id, "total_blocks_to_read: (%zu)\n",
          total_blocks_to_read);
   if (blocks_already_read != total_blocks_to_read) {
-    if (blocks_already_read == 0 &&
+    if (blocks_already_read == 0 && next_fragment_object == 0 &&
         content_length > max_blocks_in_one_read_op * motr_unit_size) {
       size_t first_blocks_to_read =
           S3Option::get_instance()->get_motr_first_read_size();
@@ -404,7 +719,21 @@ void S3GetObjectAction::read_object_data() {
     }
   } else {
     // We are done Reading
-    send_response_to_s3_client();
+    // Check if this is an extended object. If not, send response to client.
+    // If extended object, open next fragmented object, and continue calling
+    // read_fragmented_object()
+    if (this->object_metadata->get_number_of_fragments() != 0) {
+      // Read next fragmented object
+      next_fragment_object++;
+      if (next_fragment_object < total_objects_to_read) {
+        read_fragmented_object();
+      } else {
+        send_response_to_s3_client();
+      }
+    } else {
+      // This is normal object
+      send_response_to_s3_client();
+    }
   }
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
@@ -456,9 +785,14 @@ void S3GetObjectAction::send_data_to_client() {
          data_sent_to_client);
 
   S3Evbuffer* p_evbuffer = motr_reader->get_evbuffer();
-  size_t obj_unit_sz =
-      S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(
-          object_metadata->get_layout_id());
+  size_t obj_unit_sz = 0;
+  if (!object_metadata->is_object_extended()) {
+    obj_unit_sz = S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(
+        object_metadata->get_layout_id());
+  } else {
+    obj_unit_sz = S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(
+        extended_objects[next_fragment_object].object_layout);
+  }
   size_t requested_content_length = get_requested_content_length();
   s3_log(S3_LOG_DEBUG, request_id,
          "object requested content length size(%zu).\n",
@@ -466,12 +800,24 @@ void S3GetObjectAction::send_data_to_client() {
   size_t length_in_evbuf = blocks_to_read * obj_unit_sz;
   blocks_already_read += blocks_to_read;
   if (data_sent_to_client == 0) {
+    size_t read_data_start_offset = 0;
     // get starting offset from the block,
     // condition true for only statring block read object.
     // this is to set get first offset byte from initial read block
     // eg: read_data_start_offset will be set to 1000 on initial read block
     // for a given range 1000-1500 to read from 2mb object
-    size_t read_data_start_offset = first_byte_offset_to_read % obj_unit_sz;
+    if (!object_metadata->is_object_extended()) {
+      read_data_start_offset =
+          first_byte_offset_to_read %
+          S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(
+              object_metadata->get_layout_id());
+    } else {
+      // Fragmented object
+      read_data_start_offset =
+          first_byte_offset_to_read %
+          S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(
+              extended_objects[next_fragment_object].object_layout);
+    }
     if (read_data_start_offset) {
       // Move the starting range (1000-) if specified.
       p_evbuffer->drain_data(read_data_start_offset);
@@ -487,19 +833,44 @@ void S3GetObjectAction::send_data_to_client() {
     int length = requested_content_length - data_sent_to_client;
     p_evbuffer->read_drain_data_from_buffer(length);
   }
-  data_sent_to_client += p_evbuffer->get_evbuff_length();
+  size_t bytes_sent = p_evbuffer->get_evbuff_length();
+  data_sent_to_client += bytes_sent;
+  request->set_bytes_sent(data_sent_to_client);
+  data_sent_to_client_for_object += data_sent_to_client;
   // Send data to client. evbuf_body will be free'ed internally
   request->send_reply_body(p_evbuffer->release_ownership());
+  s3_log(S3_LOG_DEBUG, request_id, "Sending %zu bytes to client.\n",
+         bytes_sent);
   s3_timer.stop();
 
-  if (data_sent_to_client != requested_content_length) {
-    read_object_data();
-  } else {
-    const auto mss = s3_timer.elapsed_time_in_millisec();
-    LOG_PERF("get_object_send_data_ms", request_id.c_str(), mss);
-    s3_stats_timing("get_object_send_data", mss);
+  if (!object_metadata->is_object_extended()) {
+    // For normal object
+    if (data_sent_to_client != requested_content_length) {
+      read_object_data();
+    } else {
+      const auto mss = s3_timer.elapsed_time_in_millisec();
+      LOG_PERF("get_object_send_data_ms", request_id.c_str(), mss);
+      s3_stats_timing("get_object_send_data", mss);
 
-    send_response_to_s3_client();
+      send_response_to_s3_client();
+    }
+  } else {
+    // For fragmented object
+    if (data_sent_to_client_for_object !=
+        extended_objects[next_fragment_object].requested_object_size) {
+      read_object_data();
+    } else {
+      // Read next fragmented object
+      next_fragment_object++;
+      if (next_fragment_object < total_objects_to_read) {
+        s3_log(S3_LOG_DEBUG, request_id,
+               "Read next object fragment at index (%u)\n",
+               next_fragment_object);
+        read_fragmented_object();
+      } else {
+        send_response_to_s3_client();
+      }
+    }
   }
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
@@ -567,5 +938,5 @@ void S3GetObjectAction::send_response_to_s3_client() {
   }
   S3_RESET_SHUTDOWN_SIGNAL;  // for shutdown testcases
   done();
-  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_get_object_action.h
+++ b/server/s3_get_object_action.h
@@ -32,6 +32,27 @@
 #include "s3_factory.h"
 #include "s3_timer.h"
 
+struct S3ExtendedObjectInfo {
+ public:
+  S3ExtendedObjectInfo() {
+    start_offset_in_object = 0;
+    object_OID = {0, 0};
+    object_layout = -1;
+    object_pvid = {0, 0};
+    total_blocks_in_object = 0;
+    object_size = 0;
+    requested_object_size = 0;
+  }
+  size_t start_offset_in_object;
+  size_t total_blocks_in_object;
+  size_t object_size;
+  // Actual length to be returned to client
+  size_t requested_object_size;
+  struct m0_uint128 object_OID;
+  int object_layout;
+  struct m0_fid object_pvid;
+};
+
 class S3GetObjectAction : public S3ObjectAction {
 
   std::shared_ptr<S3MotrReader> motr_reader;
@@ -49,6 +70,14 @@ class S3GetObjectAction : public S3ObjectAction {
   bool read_object_reply_started;
   std::shared_ptr<S3MotrReaderFactory> motr_reader_factory;
   S3Timer s3_timer;
+
+  // TODO: Data structures for extended object type
+  size_t total_objects;
+  size_t total_objects_to_read;
+  unsigned int next_fragment_object;
+  std::vector<struct S3ExtendedObjectInfo> extended_objects;
+  size_t total_blocks_to_read_all_objects;
+  size_t data_sent_to_client_for_object;
 
   size_t get_requested_content_length() const {
     return last_byte_offset_to_read - first_byte_offset_to_read + 1;
@@ -69,9 +98,12 @@ class S3GetObjectAction : public S3ObjectAction {
   void validate_object_info();
   void check_full_or_range_object_read();
   void set_total_blocks_to_read_from_object();
+  void set_total_blocks_to_read_from_fragmented_object();
+
   bool validate_range_header_and_set_read_options(
       const std::string& range_value);
   void read_fragmented_object();
+  void set_total_blocks_to_read_from_next_object();
   void read_object();
 
   void read_object_data();

--- a/server/s3_object_action_base.cc
+++ b/server/s3_object_action_base.cc
@@ -106,33 +106,43 @@ void S3ObjectAction::fetch_object_info() {
 }
 
 void S3ObjectAction::fetch_object_info_success() {
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   request->set_object_size(object_metadata->get_content_length());
   // TODO: Read extended object's parts/fragments, depending on the type of
   // primary object.
   // If object is extended, create S3ObjectExtendedMetadata and load extended
   // entries.
   if (object_metadata->is_object_extended()) {
-    // Read the extended parts of the object
-    extended_obj_metadata =
+    // Read the extended parts of the object from extended index table
+    std::shared_ptr<S3ObjectExtendedMetadata> extended_obj_metadata =
         object_metadata_factory->create_object_ext_metadata_obj(
             request, request->get_bucket_name(), request->get_object_name(),
             object_metadata->get_obj_version_key(),
             object_metadata->get_number_of_parts(),
-            object_metadata->get_number_of_fragments(), object_list_oid);
-
+            object_metadata->get_number_of_fragments(),
+            bucket_metadata->get_extended_metadata_index_oid());
+    object_metadata->set_extended_object_metadata(extended_obj_metadata);
     extended_obj_metadata->load(
         std::bind(&S3ObjectAction::fetch_ext_object_info_success, this),
         std::bind(&S3ObjectAction::fetch_ext_object_info_failed, this));
   } else {
     next();
   }
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit\n", __func__);
 }
 
-void S3ObjectAction::fetch_ext_object_info_success() { next(); }
+void S3ObjectAction::fetch_ext_object_info_success() {
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
+  next();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit\n", __func__);
+}
 
 void S3ObjectAction::fetch_ext_object_info_failed() {
-  // TBD: Add code to handle failure in loading extended entries.
+  // Add code in derived class to better handle
+  // failure in loading extended entries.
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   next();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit\n", __func__);
 }
 
 void S3ObjectAction::load_metadata() { fetch_bucket_info(); }

--- a/server/s3_object_action_base.h
+++ b/server/s3_object_action_base.h
@@ -47,7 +47,6 @@ class S3ObjectAction : public S3Action {
 
  protected:
   std::shared_ptr<S3ObjectMetadata> object_metadata;
-  std::shared_ptr<S3ObjectExtendedMetadata> extended_obj_metadata;
   std::shared_ptr<S3BucketMetadata> bucket_metadata;
   std::shared_ptr<S3BucketMetadataFactory> bucket_metadata_factory;
   std::shared_ptr<S3ObjectMetadataFactory> object_metadata_factory;
@@ -61,7 +60,7 @@ class S3ObjectAction : public S3Action {
   virtual void fetch_object_info_success();
   virtual void fetch_bucket_info_success();
   virtual void fetch_ext_object_info_success();
-  void fetch_ext_object_info_failed();
+  virtual void fetch_ext_object_info_failed();
 
   // Sets appropriate Fault points for any shutdown tests.
   void setup_fi_for_shutdown_tests();
@@ -90,3 +89,4 @@ class S3ObjectAction : public S3Action {
 };
 
 #endif
+

--- a/server/s3_object_metadata.cc
+++ b/server/s3_object_metadata.cc
@@ -283,19 +283,6 @@ std::string S3ObjectMetadata::get_content_length_str() {
   return system_defined_attribute["Content-Length"];
 }
 
-// TODO - Remove it later
-void S3ObjectMetadata::set_part_one_size(const size_t& part_size) {
-  system_defined_attribute["Part-One-Size"] = std::to_string(part_size);
-}
-// TODO - Remove it later
-size_t S3ObjectMetadata::get_part_one_size() {
-  if (system_defined_attribute["Part-One-Size"] == "") {
-    return 0;
-  } else {
-    return std::stoul(system_defined_attribute["Part-One-Size"].c_str());
-  }
-}
-
 void S3ObjectMetadata::set_md5(std::string md5) {
   system_defined_attribute["Content-MD5"] = md5;
 }
@@ -822,11 +809,15 @@ int S3ObjectMetadata::from_json(std::string content) {
     primary_obj_size = newroot["Size"].asUInt64();
   }
 
-  if (obj_fragments == 0 && obj_parts != 0) {
+  if (obj_fragments != 0 && obj_parts != 0 && (obj_fragments == obj_parts)) {
+    // In case of multipart upload, no. of fragments == no. of parts
     obj_type = S3ObjectMetadataType::only_parts;
   } else if (obj_fragments != 0 && obj_parts == 0) {
     obj_type = S3ObjectMetadataType::only_frgments;
-  } else if (obj_fragments != 0 && obj_parts != 0) {
+  } else if (obj_fragments != 0 && obj_parts != 0 &&
+             (obj_fragments > obj_parts)) {
+    // In case of multipart upload with some parts with fragmented object,
+    // no. of fragments > no. of parts
     obj_type = S3ObjectMetadataType::parts_fragments;
   }
 
@@ -1065,6 +1056,9 @@ void S3ObjectExtendedMetadata::get_obj_ext_entries_successful() {
              "%" SCNx64 " : %" SCNx64 ", Key = %s, Value = %s\n",
              object_list_index_oid.u_hi, object_list_index_oid.u_lo,
              object_name.c_str(), motr_kv_reader->get_value().c_str());
+      state = S3ObjectMetadataState::invalid;
+      this->handler_on_failed();
+      return;
     } else {
       // Added extended entry.
       s3_log(S3_LOG_DEBUG, request_id, "Added extended object key [%s]\n",
@@ -1081,6 +1075,36 @@ void S3ObjectExtendedMetadata::get_obj_ext_entries_successful() {
 }
 
 void S3ObjectExtendedMetadata::get_obj_ext_entries_failed() {
+  switch (motr_kv_reader->get_state()) {
+    case S3MotrKVSReaderOpState::failed_to_launch:
+      state = S3ObjectMetadataState::failed_to_launch;
+      s3_log(S3_LOG_WARN, request_id,
+             "Extended object metadata load failed to launch - "
+             "ServiceUnavailable\n");
+      break;
+    case S3MotrKVSReaderOpState::failed:
+    case S3MotrKVSReaderOpState::failed_e2big:
+      s3_log(S3_LOG_WARN, request_id,
+             "Internal server error - InternalError\n");
+      state = S3ObjectMetadataState::failed;
+      break;
+    case S3MotrKVSReaderOpState::missing:
+      state = S3ObjectMetadataState::missing;
+      s3_log(S3_LOG_DEBUG, request_id, "Object metadata missing for %s\n",
+             object_name.c_str());
+      break;
+    case S3MotrKVSReaderOpState::present:
+      // This state is allowed here only if validaton failed
+      if (state != S3ObjectMetadataState::invalid) {
+        s3_log(S3_LOG_ERROR, request_id, "Invalid state - InternalError\n");
+        state = S3ObjectMetadataState::failed;
+      }
+      break;
+    default:  // S3MotrKVSReaderOpState::{empty,start}
+      s3_log(S3_LOG_ERROR, request_id, "Unexpected state - InternalError\n");
+      state = S3ObjectMetadataState::failed;
+      break;
+  }
   this->handler_on_failed();
 }
 
@@ -1176,7 +1200,7 @@ int S3ObjectExtendedMetadata::from_json(std::string key, std::string content) {
 
   item_ctx.motr_OID =
       S3M0Uint128Helper::to_m0_uint128(newroot["OID"].asString());
-  item_ctx.PVID = S3M0Uint128Helper::to_m0_uint128(newroot["PVID"].asString());
+  S3M0Uint128Helper::to_m0_fid(newroot["PVID"].asString(), item_ctx.PVID);
   item_ctx.item_size = newroot["size"].asUInt64();
   item_ctx.layout_id = newroot["layout-id"].asInt();
   total_size += item_ctx.item_size;
@@ -1189,6 +1213,7 @@ int S3ObjectExtendedMetadata::from_json(std::string key, std::string content) {
         S3CommonUtilities::stoi(tokens[2].substr(pos + 1), ext_objects_key)) {
       // key is the part number
       ext_objects[ext_objects_key].push_back(item_ctx);
+      parts = ext_objects_key;
     } else {
       s3_log(S3_LOG_ERROR, request_id, "Failed to retrive part number\n");
       return -1;
@@ -1276,7 +1301,9 @@ std::string S3ObjectExtendedMetadata::get_json_str(
     struct s3_part_frag_context& frag_entry) {
   Json::Value root;
   root["OID"] = S3M0Uint128Helper::to_string(frag_entry.motr_OID);
-  root["PVID"] = S3M0Uint128Helper::to_string(frag_entry.PVID);
+  std::string pvid_str;
+  S3M0Uint128Helper::to_string(frag_entry.PVID, pvid_str);
+  root["PVID"] = pvid_str;
   root["size"] = Json::Value((Json::Value::UInt64)(frag_entry.item_size));
   root["layout-id"] = Json::Value((Json::Value::UInt)frag_entry.layout_id);
   Json::FastWriter fastWriter;

--- a/server/s3_object_metadata.h
+++ b/server/s3_object_metadata.h
@@ -221,14 +221,12 @@ class S3ObjectMetadata : private S3ObjectMetadataCopyable {
 
   virtual void set_content_length(std::string length);
   virtual size_t get_content_length();
-  virtual size_t get_part_one_size();
   virtual void rename_object_name(std::string new_object_name);
   virtual std::string get_content_length_str();
   virtual void set_content_type(std::string content_type);
   virtual std::string get_content_type();
 
   virtual void set_md5(std::string md5);
-  virtual void set_part_one_size(const size_t& part_size);
   virtual std::string get_md5();
 
   virtual void set_oid(struct m0_uint128 id);
@@ -319,8 +317,8 @@ class S3ObjectMetadata : private S3ObjectMetadataCopyable {
   // Remove object metadata from object list index & versions list index
   virtual void remove(std::function<void(void)> on_success,
                       std::function<void(void)> on_failed);
-  void remove_version_metadata(std::function<void(void)> on_success,
-                               std::function<void(void)> on_failed);
+  virtual void remove_version_metadata(std::function<void(void)> on_success,
+                                       std::function<void(void)> on_failed);
 
   virtual S3ObjectMetadataState get_state() { return state; }
 
@@ -420,7 +418,7 @@ class S3ObjectMetadata : private S3ObjectMetadataCopyable {
 // Fragment or the part detail structure
 struct s3_part_frag_context {
   struct m0_uint128 motr_OID;
-  struct m0_uint128 PVID;
+  struct m0_fid PVID;
   std::string versionID;
   size_t item_size;
   int layout_id;
@@ -455,10 +453,9 @@ class S3ObjectExtendedMetadata : private S3ObjectMetadataCopyable {
   // 0 if fragments of simple object.
   std::map<int, std::vector<struct s3_part_frag_context>> ext_objects;
 
-  void get_obj_ext_entries(std::string last_object);
-  int from_json(std::string key, std::string content);
-  // TODO: Do we need this - void to_json();
-  std::string get_json_str(struct s3_part_frag_context& frag_entry);
+  virtual void get_obj_ext_entries(std::string last_object);
+  virtual int from_json(std::string key, std::string content);
+  virtual std::string get_json_str(struct s3_part_frag_context& frag_entry);
 
  protected:
   void save_extended_metadata();
@@ -482,37 +479,40 @@ class S3ObjectExtendedMetadata : private S3ObjectMetadataCopyable {
 
   // Virtual Destructor
   virtual ~S3ObjectExtendedMetadata() {};
-  bool has_entries() { return (ext_objects.size() > 0) ? true : false; }
-  inline const std::map<int, std::vector<struct s3_part_frag_context>>&
+  virtual bool has_entries() { return (ext_objects.size() > 0) ? true : false; }
+  virtual inline const std::map<int, std::vector<struct s3_part_frag_context>>&
   get_raw_extended_entries() {
     return ext_objects;
   }
 
-  unsigned int get_fragment_count() { return fragments; }
-  void load(std::function<void(void)> on_success,
-            std::function<void(void)> on_failed);
-  void save(std::function<void(void)> on_success,
-            std::function<void(void)> on_failed);
-  void set_object_list_index_oid(struct m0_uint128 id) {
+  virtual unsigned int get_fragment_count() { return fragments; }
+  virtual unsigned int get_part_count() { return parts; }
+  virtual void load(std::function<void(void)> on_success,
+                    std::function<void(void)> on_failed);
+  virtual void save(std::function<void(void)> on_success,
+                    std::function<void(void)> on_failed);
+  virtual void set_object_list_index_oid(struct m0_uint128 id) {
     object_list_index_oid.u_hi = id.u_hi;
     object_list_index_oid.u_lo = id.u_lo;
   };
+  void set_version_id(const std::string& versionid) { version_id = versionid; }
   void get_obj_ext_entries_failed();
   void get_obj_ext_entries_successful();
   inline size_t get_size() { return total_size; }
   // Returns extended key/value pair of entries of object with fragments/parts
-  std::map<std::string, std::string> get_kv_list_of_extended_entries();
+  virtual std::map<std::string, std::string> get_kv_list_of_extended_entries();
   // Adds an extended entry, when object write fails due to degradation
   // For first part, part_no=1 and for first fragment on part, fragment_no=1
-  void add_extended_entry(struct s3_part_frag_context& part_frag_ctx,
-                          unsigned int fragment_no, unsigned int part_no);
+  virtual void add_extended_entry(struct s3_part_frag_context& part_frag_ctx,
+                                  unsigned int fragment_no,
+                                  unsigned int part_no);
   void set_size_of_extended_entry(size_t fragment_size,
                                   unsigned int fragment_no,
                                   unsigned int part_no);
 
   // Delete extended metadata entries
-  void remove(std::function<void(void)> on_success,
-              std::function<void(void)> on_failed);
+  virtual void remove(std::function<void(void)> on_success,
+                      std::function<void(void)> on_failed);
 
   void remove_ext_object_metadata();
   void remove_ext_object_metadata_successful();

--- a/server/s3_part_metadata.cc
+++ b/server/s3_part_metadata.cc
@@ -39,7 +39,7 @@ void S3PartMetadata::initialize(std::string uploadid, int part_num) {
   salt = "index_salt_";
   collision_attempt_count = 0;
   s3_motr_api = std::make_shared<ConcreteMotrAPI>();
-
+  pvid_str = "";
   // Set the defaults
   system_defined_attribute["Date"] = "";
   system_defined_attribute["Content-Length"] = "";
@@ -176,6 +176,21 @@ void S3PartMetadata::add_system_attribute(std::string key, std::string val) {
 void S3PartMetadata::add_user_defined_attribute(std::string key,
                                                 std::string val) {
   user_defined_attribute[key] = val;
+}
+
+struct m0_fid S3PartMetadata::get_pvid() {
+  struct m0_fid pvid;
+  S3M0Uint128Helper::to_m0_fid(pvid_str, pvid);
+  return pvid;
+}
+
+void S3PartMetadata::set_pvid(const struct m0_fid* p_pvid) {
+  if (p_pvid) {
+    S3M0Uint128Helper::to_string(*p_pvid, pvid_str);
+  } else {
+    s3_log(S3_LOG_DEBUG, request_id, "%s - NULL pointer", __func__);
+    pvid_str.clear();
+  }
 }
 
 void S3PartMetadata::load(std::function<void(void)> on_success,
@@ -458,6 +473,7 @@ std::string S3PartMetadata::to_json() {
   root["Part-Num"] = part_number;
   root["motr_oid"] = motr_oid_str;
   root["layout_id"] = layout_id;
+  root["PVID"] = this->pvid_str;
 
   for (auto sit : system_defined_attribute) {
     root["System-Defined"][sit.first] = sit.second;
@@ -492,6 +508,7 @@ int S3PartMetadata::from_json(std::string content) {
   motr_oid_str = newroot["motr_oid"].asString();
   oid = S3M0Uint128Helper::to_m0_uint128(motr_oid_str);
   layout_id = newroot["layout_id"].asInt();
+  pvid_str = newroot["PVID"].asString();
 
   Json::Value::Members members = newroot["System-Defined"].getMemberNames();
   for (auto it : members) {

--- a/server/s3_part_metadata.h
+++ b/server/s3_part_metadata.h
@@ -83,6 +83,7 @@ class S3PartMetadata {
   struct m0_uint128 part_index_name_oid;
   struct m0_uint128 oid = M0_ID_APP;
   std::string motr_oid_str;
+  std::string pvid_str;
 
   // Used to report to caller.
   std::function<void()> handler_on_success;
@@ -138,12 +139,16 @@ class S3PartMetadata {
   virtual void reset_date_time_to_current();
   virtual std::string get_storage_class();
   virtual std::string get_upload_id();
-  std::string get_part_number();
-  const virtual struct m0_uint128 get_oid() { return oid; }
+  virtual std::string get_part_number();
+  virtual const struct m0_uint128 get_oid() { return oid; }
   virtual std::string get_oid_str() { return motr_oid_str; }
   virtual void set_oid(struct m0_uint128 id);
   void set_layout_id(int id) { layout_id = id; }
   virtual int get_layout_id() { return layout_id; }
+  struct m0_fid get_pvid();
+  void set_pvid(const struct m0_fid* p_pvid);
+  const std::string& get_pvid_str() const { return pvid_str; }
+  void set_pvid_str(const std::string& val) { pvid_str = val; }
 
   // Load attributes.
   std::string get_system_attribute(std::string key);

--- a/server/s3_post_complete_action.cc
+++ b/server/s3_post_complete_action.cc
@@ -115,12 +115,6 @@ void S3PostCompleteAction::setup_steps() {
   // ...
 }
 
-void S3PostCompleteAction::fetch_bucket_info_success() {
-  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
-  next();
-  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
-}
-
 void S3PostCompleteAction::fetch_bucket_info_failed() {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   s3_post_complete_action_state = S3PostCompleteActionState::validationFailed;
@@ -153,6 +147,26 @@ void S3PostCompleteAction::fetch_object_info_failed() {
     send_response_to_s3_client();
   }
   s3_log(S3_LOG_DEBUG, stripped_request_id, "Exiting\n");
+}
+
+void S3PostCompleteAction::fetch_ext_object_info_failed() {
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
+  auto omds = object_metadata->get_state();
+  if (omds == S3ObjectMetadataState::missing) {
+    s3_log(S3_LOG_ERROR, request_id,
+           "Extended object md not found for object [%s]\n",
+           object_metadata->get_object_name().c_str());
+    set_s3_error("InternalError");
+  } else {
+    s3_log(S3_LOG_ERROR, request_id, "Metadata load state %d\n", (int)omds);
+    if (omds == S3ObjectMetadataState::failed_to_launch) {
+      set_s3_error("ServiceUnavailable");
+    } else {
+      set_s3_error("InternalError");
+    }
+  }
+  send_response_to_s3_client();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit\n", __func__);
 }
 
 void S3PostCompleteAction::load_and_validate_request() {
@@ -364,8 +378,6 @@ bool S3PostCompleteAction::is_abort_multipart() {
 
 bool S3PostCompleteAction::validate_parts() {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
-  size_t part_one_size_in_multipart_metadata =
-      multipart_metadata->get_part_one_size();
   if (part_metadata == NULL) {
     part_metadata = part_metadata_factory->create_part_metadata_obj(
         request, multipart_metadata->get_part_index_oid(), upload_id, 0);
@@ -411,8 +423,9 @@ bool S3PostCompleteAction::validate_parts() {
         set_s3_error("EntityTooLarge");
         s3_post_complete_action_state =
             S3PostCompleteActionState::validationFailed;
-        set_abort_multipart(true);
-        break;
+        // set_abort_multipart(true);
+        send_response_to_s3_client();
+        return false;
       }
       if (current_parts_size < MINIMUM_ALLOWED_PART_SIZE &&
           store_kv->first != total_parts) {
@@ -424,77 +437,152 @@ bool S3PostCompleteAction::validate_parts() {
         set_s3_error("EntityTooSmall");
         s3_post_complete_action_state =
             S3PostCompleteActionState::validationFailed;
-        set_abort_multipart(true);
-        break;
-      }
-
-      if (part_one_size_in_multipart_metadata != 0) {
-        // In non chunked mode if current part size is not same as
-        // that in multipart metadata and its not the last part,
-        // then bail out
-        if (current_parts_size != part_one_size_in_multipart_metadata &&
-            store_kv->first != total_parts) {
-          s3_log(S3_LOG_ERROR, request_id,
-                 "The part %s size (%zu) is not "
-                 "matching with part one size (%zu) "
-                 "in multipart metadata\n",
-                 store_kv->first.c_str(), current_parts_size,
-                 part_one_size_in_multipart_metadata);
-          set_s3_error("InvalidObjectState");
-          s3_post_complete_action_state =
-              S3PostCompleteActionState::validationFailed;
-          set_abort_multipart(true);
-          break;
-        }
-      }
-      if ((prev_fetched_parts_size != 0) &&
-          (prev_fetched_parts_size != current_parts_size)) {
-        if (store_kv->first == total_parts) {
-          // This is the last part, ignore it after size calculation
-          object_size += part_metadata->get_content_length();
-          awsetag.add_part_etag(part_metadata->get_md5());
-          part_kv = parts.erase(part_kv);
-          continue;
-        }
-        s3_log(S3_LOG_ERROR, request_id,
-               "The part %s size(%zu) is different "
-               "from previous part size(%zu), Will be "
-               "destroying the parts\n",
-               store_kv->first.c_str(), current_parts_size,
-               prev_fetched_parts_size);
-        // Will be deleting complete object along with the part index and
-        // multipart kv
-        set_s3_error("InvalidObjectState");
-        s3_post_complete_action_state =
-            S3PostCompleteActionState::validationFailed;
-        set_abort_multipart(true);
-        break;
-      } else {
-        prev_fetched_parts_size = current_parts_size;
+        // set_abort_multipart(true);
+        send_response_to_s3_client();
+        return false;
       }
       object_size += part_metadata->get_content_length();
       awsetag.add_part_etag(part_metadata->get_md5());
       // Remove the entry from parts map, so that in next
       // validate_parts() we dont have to scan it again
       part_kv = parts.erase(part_kv);
+      // Add part object to new object's extended metadata potion
+      add_part_object_to_object_extended(part_metadata, new_object_metadata);
     }
   }
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return true;
 }
 
+void S3PostCompleteAction::add_part_object_to_object_extended(
+    const std::shared_ptr<S3PartMetadata>& part_metadata,
+    std::shared_ptr<S3ObjectMetadata>& object_metadata) {
+  s3_log(S3_LOG_DEBUG, stripped_request_id, "%s Entry\n", __func__);
+  if (!object_metadata) {
+    // Create new object metadata
+    object_metadata = object_metadata_factory->create_object_metadata_obj(
+        request, bucket_metadata->get_object_list_index_oid());
+    object_metadata->set_objects_version_list_index_oid(
+        bucket_metadata->get_objects_version_list_index_oid());
+    // Dummy oid and layout id for new object
+    object_metadata->set_oid(new_object_oid);
+    object_metadata->set_layout_id(layout_id);
+
+    // Generate version id for the new obj as it will become live to s3 clients.
+    object_metadata->regenerate_version_id();
+    // Create extended metadata object and add object parts to it.
+    const std::shared_ptr<S3ObjectExtendedMetadata>& ext_object_metadata =
+        object_metadata->get_extended_object_metadata();
+    if (!ext_object_metadata) {
+      std::shared_ptr<S3ObjectExtendedMetadata> new_ext_object_metadata =
+          object_metadata_factory->create_object_ext_metadata_obj(
+              request, request->get_bucket_name(), request->get_object_name(),
+              object_metadata->get_obj_version_key(), 0, 0,
+              bucket_metadata->get_extended_metadata_index_oid());
+
+      object_metadata->set_extended_object_metadata(new_ext_object_metadata);
+      s3_log(S3_LOG_DEBUG, stripped_request_id,
+             "Created extended object metadata to store object parts");
+    }
+  }
+  const std::shared_ptr<S3ObjectExtendedMetadata>& new_object_ext_metadata =
+      object_metadata->get_extended_object_metadata();
+
+  if (new_object_ext_metadata) {
+    // Add object part to new object's extended metadata
+    struct s3_part_frag_context part_frag_ctx = {};
+    part_frag_ctx.motr_OID = part_metadata->get_oid();
+    part_frag_ctx.PVID = part_metadata->get_pvid();
+    part_frag_ctx.versionID = object_metadata->get_obj_version_key();
+    part_frag_ctx.item_size = part_metadata->get_content_length();
+    part_frag_ctx.layout_id = part_metadata->get_layout_id();
+    part_frag_ctx.is_multipart = true;
+    const int part_number =
+        strtoul(part_metadata->get_part_number().c_str(), NULL, 0);
+    // For multipart object, pass the part_no as object part number
+    // and fragment_no=1 (part is not further fragmented)
+    new_object_ext_metadata->add_extended_entry(part_frag_ctx, 1, part_number);
+    object_metadata->set_number_of_fragments(
+        new_object_ext_metadata->get_fragment_count());
+    object_metadata->set_number_of_parts(
+        new_object_ext_metadata->get_part_count());
+    s3_log(S3_LOG_DEBUG, request_id,
+           "Added object part [%d] with object oid"
+           "[%" SCNx64 " : %" SCNx64 "] to extended md\n",
+           part_number, part_frag_ctx.motr_OID.u_hi,
+           part_frag_ctx.motr_OID.u_lo);
+  }
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
+
+// Add object parts of specified object (old or new) to
+// the specified probable dead oid list
+void S3PostCompleteAction::add_part_object_to_probable_dead_oid_list(
+    const std::shared_ptr<S3ObjectMetadata>& object_metadata,
+    std::vector<std::unique_ptr<S3ProbableDeleteRecord>>&
+        parts_probable_del_rec_list,
+    bool is_old_object) {
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
+  const std::shared_ptr<S3ObjectExtendedMetadata>& object_ext_metadata =
+      object_metadata->get_extended_object_metadata();
+  unsigned int total_parts =
+      object_ext_metadata ? object_ext_metadata->get_part_count() : 0;
+  if (total_parts) {
+    s3_log(S3_LOG_DEBUG, request_id, "Total parts available [%u]\n",
+           total_parts);
+    // object has some parts
+    const std::map<int, std::vector<struct s3_part_frag_context>>&
+        ext_entries_mp = object_ext_metadata->get_raw_extended_entries();
+    struct m0_uint128 old_oid, part_list_index_oid;
+    bool is_multipart = false;
+    for (unsigned int key_indx = 1; key_indx <= total_parts; key_indx++) {
+      const std::vector<struct s3_part_frag_context>& part_entry =
+          ext_entries_mp.at(key_indx);
+      // Assuming part is not fragmented, the only part is at part_entry[0]
+      if (part_entry.size() != 0 &&
+          (part_entry[0].motr_OID.u_hi || part_entry[0].motr_OID.u_lo)) {
+        std::string ext_oid_str =
+            S3M0Uint128Helper::to_string(part_entry[0].motr_OID);
+        // prepending a char depending on the size of the object (size based
+        // bucketing of object)
+        S3CommonUtilities::size_based_bucketing_of_objects(
+            ext_oid_str, part_entry[0].item_size);
+        if (is_old_object) {
+          // key = oldoid + "-" + newoid; // (newoid = dummy oid of new object)
+          ext_oid_str = ext_oid_str + '-' + new_oid_str;
+          old_oid = {0ULL, 0ULL};
+          part_list_index_oid = {0ULL, 0ULL};
+        } else {
+          is_multipart = true;
+          part_list_index_oid = multipart_metadata->get_part_index_oid();
+          old_oid = old_object_oid;
+        }
+
+        s3_log(S3_LOG_DEBUG, request_id,
+               "Adding part object, with oid [%" SCNx64 " : %" SCNx64
+               "]"
+               ", key [%s] to probable delete record\n",
+               part_entry[0].motr_OID.u_hi, part_entry[0].motr_OID.u_lo,
+               ext_oid_str.c_str());
+
+        std::unique_ptr<S3ProbableDeleteRecord> ext_del_rec;
+        ext_del_rec.reset(new S3ProbableDeleteRecord(
+            ext_oid_str, old_oid, object_metadata->get_object_name(),
+            part_entry[0].motr_OID, part_entry[0].layout_id,
+            bucket_metadata->get_object_list_index_oid(),
+            bucket_metadata->get_objects_version_list_index_oid(),
+            object_metadata->get_version_key_in_index(),
+            false /* force_delete */, is_multipart, part_list_index_oid, 1,
+            key_indx, bucket_metadata->get_extended_metadata_index_oid()));
+
+        parts_probable_del_rec_list.push_back(std::move(ext_del_rec));
+      }
+    }  // End of For
+  }
+}
+
 void S3PostCompleteAction::add_object_oid_to_probable_dead_oid_list() {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
-
-  new_object_metadata = object_metadata_factory->create_object_metadata_obj(
-      request, bucket_metadata->get_object_list_index_oid());
-  new_object_metadata->set_objects_version_list_index_oid(
-      bucket_metadata->get_objects_version_list_index_oid());
-
-  new_object_metadata->set_oid(new_object_oid);
-  new_object_metadata->set_layout_id(layout_id);
-  // Generate version id for the new obj as it will become live to s3 clients.
-  new_object_metadata->regenerate_version_id();
 
   if (!motr_kv_writer) {
     motr_kv_writer =
@@ -505,76 +593,56 @@ void S3PostCompleteAction::add_object_oid_to_probable_dead_oid_list() {
     // Mark new object for probable deletion, we delete obj only after object
     // metadata is deleted.
     assert(!new_oid_str.empty());
-
-    // prepending a char depending on the size of the object (size based
-    // bucketing
-    // of object)
-    S3CommonUtilities::size_based_bucketing_of_objects(new_oid_str,
-                                                       object_size);
-
-    s3_log(S3_LOG_DEBUG, request_id,
-           "Adding new_probable_del_rec with key [%s]\n", new_oid_str.c_str());
-
-    new_probable_del_rec.reset(new S3ProbableDeleteRecord(
-        new_oid_str, old_object_oid, multipart_metadata->get_object_name(),
-        new_object_oid, layout_id, bucket_metadata->get_multipart_index_oid(),
-        bucket_metadata->get_objects_version_list_index_oid(),
-        new_object_metadata->get_version_key_in_index(),
-        false /* force_delete */, true /* is_multipart */,
-        multipart_metadata->get_part_index_oid()));
-    // backgrounddelete will delete this entry if multipart metadata has
-    // been deleted
-    motr_kv_writer->put_keyval(
-        global_probable_dead_object_list_index_oid, new_oid_str,
-        new_probable_del_rec->to_json(),
-        std::bind(&S3PostCompleteAction::
-                       add_object_oid_to_probable_dead_oid_list_success,
-                  this),
-        std::bind(&S3PostCompleteAction::
-                       add_object_oid_to_probable_dead_oid_list_failed,
-                  this));
-  } else {
-    // TODO add probable part list index delete record.
-
-    // Mark old object if any for probable deletion.
-    // store old object oid
-    if (old_object_oid.u_hi || old_object_oid.u_lo) {
-      assert(!old_oid_str.empty());
-      assert(!new_oid_str.empty());
-
-      // prepending a char depending on the size of the object (size based
-      // bucketing
-      // of object)
-
-      S3CommonUtilities::size_based_bucketing_of_objects(old_oid_str,
-                                                         object_size);
-
-      s3_log(S3_LOG_DEBUG, request_id,
-             "Adding old_probable_del_rec with key [%s]\n",
-             old_oid_str.c_str());
-
-      // key = oldoid + "-" + newoid
-      std::string old_oid_rec_key = old_oid_str + '-' + new_oid_str;
-
-      old_probable_del_rec.reset(new S3ProbableDeleteRecord(
-          old_oid_rec_key, {0ULL, 0ULL}, multipart_metadata->get_object_name(),
-          old_object_oid, old_layout_id,
-          bucket_metadata->get_object_list_index_oid(),
-          bucket_metadata->get_objects_version_list_index_oid(),
-          multipart_metadata->get_version_key_in_index(),
-          false /* force_delete */
-          ));
-      // backgrounddelete will delete this entry if current object metadata has
-      // moved on
+    add_part_object_to_probable_dead_oid_list(new_object_metadata,
+                                              new_parts_probable_del_rec_list);
+    std::map<std::string, std::string> kv_list;
+    for (auto& probable_rec : new_parts_probable_del_rec_list) {
+      kv_list[probable_rec->get_key()] = probable_rec->to_json();
+      new_obj_oids.push_back(probable_rec->get_current_object_oid());
+    }
+    if (!kv_list.empty()) {
+      // S3 Background delete will delete new object parts, when multipart
+      // metadata has been deleted
       motr_kv_writer->put_keyval(
-          global_probable_dead_object_list_index_oid, old_oid_rec_key,
-          old_probable_del_rec->to_json(),
+          global_probable_dead_object_list_index_oid, kv_list,
           std::bind(&S3PostCompleteAction::
                          add_object_oid_to_probable_dead_oid_list_success,
                     this),
           std::bind(&S3PostCompleteAction::
                          add_object_oid_to_probable_dead_oid_list_failed,
                     this));
+    } else {
+      next();
+    }
+  } else {
+    // TODO add probable part list index delete record.
+    // Mark old object if any for probable deletion.
+    // store old object oid
+    if (old_object_oid.u_hi || old_object_oid.u_lo) {
+      assert(!old_oid_str.empty());
+      assert(!new_oid_str.empty());
+      add_part_object_to_probable_dead_oid_list(
+          object_metadata, old_parts_probable_del_rec_list, true);
+      std::map<std::string, std::string> kv_list;
+      for (auto& probable_rec : old_parts_probable_del_rec_list) {
+        kv_list[probable_rec->get_key()] = probable_rec->to_json();
+        old_obj_oids.push_back(probable_rec->get_current_object_oid());
+      }
+      if (!kv_list.empty()) {
+        // S3 Background delete will delete old object parts, when current
+        // object metadata has
+        // moved on
+        motr_kv_writer->put_keyval(
+            global_probable_dead_object_list_index_oid, kv_list,
+            std::bind(&S3PostCompleteAction::
+                           add_object_oid_to_probable_dead_oid_list_success,
+                      this),
+            std::bind(&S3PostCompleteAction::
+                           add_object_oid_to_probable_dead_oid_list_failed,
+                      this));
+      } else {
+        next();
+      }
     } else {
       // Not an overwrite case, complete multipart upload for brand new object
       next();
@@ -609,15 +677,9 @@ void S3PostCompleteAction::save_metadata() {
   if (is_abort_multipart()) {
     next();
   } else {
-    // Mark it as non-multipart, create final object metadata.
-    // object_metadata->mark_as_non_multipart();
     for (auto it : multipart_metadata->get_user_attributes()) {
       new_object_metadata->add_user_defined_attribute(it.first, it.second);
     }
-    // save part size for checksum calculation in GET for multipart upload case
-    new_object_metadata->set_part_one_size(
-        multipart_metadata->get_part_one_size());
-
     // to rest Date and Last-Modfied time object metadata
     new_object_metadata->reset_date_time_to_current();
     new_object_metadata->set_tags(multipart_metadata->get_tags());
@@ -899,18 +961,24 @@ void S3PostCompleteAction::mark_old_oid_for_deletion() {
   assert(!old_oid_str.empty());
   assert(!new_oid_str.empty());
 
-  // key = oldoid + "-" + newoid
-  std::string old_oid_rec_key = old_oid_str + '-' + new_oid_str;
+  if (old_parts_probable_del_rec_list.size() == 0) {
+    next();
+    return;
+  }
 
-  // update old oid, force_del = true
-  old_probable_del_rec->set_force_delete(true);
-
+  std::map<std::string, std::string> oid_key_val_mp;
+  for (auto& delete_rec : old_parts_probable_del_rec_list) {
+    // force_del = true
+    delete_rec->set_force_delete(true);
+    std::string old_oid_rec_key = delete_rec->get_key();
+    oid_key_val_mp[old_oid_rec_key] = delete_rec->to_json();
+  }
   if (!motr_kv_writer) {
     motr_kv_writer =
         mote_kv_writer_factory->create_motr_kvs_writer(request, s3_motr_api);
   }
   motr_kv_writer->put_keyval(global_probable_dead_object_list_index_oid,
-                             old_oid_rec_key, old_probable_del_rec->to_json(),
+                             oid_key_val_mp,
                              std::bind(&S3PostCompleteAction::next, this),
                              std::bind(&S3PostCompleteAction::next, this));
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
@@ -933,32 +1001,87 @@ void S3PostCompleteAction::delete_old_object() {
     next();
     return;
   }
-  motr_writer->delete_object(
-      std::bind(&S3PostCompleteAction::remove_old_object_version_metadata,
-                this),
-      std::bind(&S3PostCompleteAction::next, this), old_object_oid,
-      old_layout_id, multipart_metadata->get_pvid());
+  size_t object_count = old_obj_oids.size();
+  if (object_count > 0) {
+    struct m0_uint128 old_oid = old_obj_oids.back();
+    motr_writer->set_oid(old_oid);
+    motr_writer->delete_object(
+        std::bind(&S3PostCompleteAction::delete_old_object_success, this),
+        std::bind(&S3PostCompleteAction::next, this), old_oid, layout_id);
+  }
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
 
+void S3PostCompleteAction::delete_old_object_success() {
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
+  size_t object_count = old_obj_oids.size();
+  if (object_count == 0) {
+    next();
+    return;
+  }
+  s3_log(S3_LOG_INFO, request_id,
+         "Deleted old part object oid "
+         "[%" SCNx64 " : %" SCNx64 "]",
+         (old_obj_oids.back()).u_hi, (old_obj_oids.back()).u_lo);
+  old_obj_oids.pop_back();
+
+  if (old_obj_oids.size() > 0) {
+    delete_old_object();
+  } else {
+    remove_old_object_version_metadata();
+  }
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::remove_old_object_version_metadata() {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
-  object_metadata = object_metadata_factory->create_object_metadata_obj(
-      request, bucket_metadata->get_object_list_index_oid());
-  object_metadata->set_objects_version_list_index_oid(
-      bucket_metadata->get_objects_version_list_index_oid());
+  if (object_metadata) {
+    assert(multipart_metadata->get_object_name() == request->get_object_name());
+    object_metadata->set_oid(old_object_oid);
+    object_metadata->set_layout_id(old_layout_id);
+    object_metadata->set_version_id(
+        multipart_metadata->get_old_obj_version_id());
 
-  assert(multipart_metadata->get_object_name() == request->get_object_name());
-  object_metadata->set_oid(old_object_oid);
-  object_metadata->set_layout_id(old_layout_id);
-  object_metadata->set_version_id(multipart_metadata->get_old_obj_version_id());
-
-  object_metadata->remove_version_metadata(
-      std::bind(&S3PostCompleteAction::remove_old_oid_probable_record, this),
-      std::bind(&S3PostCompleteAction::next, this));
+    object_metadata->remove_version_metadata(
+        std::bind(&S3PostCompleteAction::remove_old_fragments, this),
+        std::bind(&S3PostCompleteAction::remove_old_fragments, this));
+  }
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
+
+// Delete entries corresponding to old objects
+// from extended md index
+void S3PostCompleteAction::remove_old_fragments() {
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
+  if (object_metadata && object_metadata->is_object_extended()) {
+    const std::shared_ptr<S3ObjectExtendedMetadata>& ext_metadata =
+        object_metadata->get_extended_object_metadata();
+    if (ext_metadata->has_entries()) {
+      // Delete fragments, if any
+      ext_metadata->remove(
+          std::bind(&S3PostCompleteAction::remove_old_ext_metadata_successful,
+                    this),
+          std::bind(&S3PostCompleteAction::remove_old_ext_metadata_successful,
+                    this));
+    } else {
+      // Extended object exist, but no fragments, delete probbale index entries
+      remove_old_oid_probable_record();
+    }
+  } else {
+    // If this is not extended object, delete entries from probable index
+    remove_old_oid_probable_record();
+  }
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
+
+void S3PostCompleteAction::remove_old_ext_metadata_successful() {
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
+  s3_log(S3_LOG_DEBUG, request_id,
+         "Removed extended metadata for Object [%s].\n",
+         (object_metadata->get_object_name()).c_str());
+  remove_old_oid_probable_record();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::remove_old_oid_probable_record() {
@@ -966,15 +1089,22 @@ void S3PostCompleteAction::remove_old_oid_probable_record() {
   assert(!old_oid_str.empty());
   assert(!new_oid_str.empty());
 
-  // key = oldoid + "-" + newoid
-  std::string old_oid_rec_key = old_oid_str + '-' + new_oid_str;
+  if (old_parts_probable_del_rec_list.size() == 0) {
+    next();
+    return;
+  }
+  std::vector<std::string> keys_to_delete;
+  for (auto& probable_rec : old_parts_probable_del_rec_list) {
+    std::string old_oid_rec_key = probable_rec->get_key();
+    keys_to_delete.push_back(old_oid_rec_key);
+  }
 
   if (!motr_kv_writer) {
     motr_kv_writer =
         mote_kv_writer_factory->create_motr_kvs_writer(request, s3_motr_api);
   }
   motr_kv_writer->delete_keyval(global_probable_dead_object_list_index_oid,
-                                old_oid_rec_key,
+                                keys_to_delete,
                                 std::bind(&S3PostCompleteAction::next, this),
                                 std::bind(&S3PostCompleteAction::next, this));
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
@@ -985,17 +1115,27 @@ void S3PostCompleteAction::mark_new_oid_for_deletion() {
   assert(!new_oid_str.empty());
   assert(is_abort_multipart());
 
-  // update new oid, key = newoid, force_del = true
-  new_probable_del_rec->set_force_delete(true);
+  if (new_parts_probable_del_rec_list.size() == 0) {
+    next();
+    return;
+  }
 
+  std::map<std::string, std::string> oid_key_val_mp;
+  for (auto& delete_rec : new_parts_probable_del_rec_list) {
+    // force_del = true
+    delete_rec->set_force_delete(true);
+    std::string new_oid_rec_key = delete_rec->get_key();
+    oid_key_val_mp[new_oid_rec_key] = delete_rec->to_json();
+  }
   if (!motr_kv_writer) {
     motr_kv_writer =
         mote_kv_writer_factory->create_motr_kvs_writer(request, s3_motr_api);
   }
   motr_kv_writer->put_keyval(global_probable_dead_object_list_index_oid,
-                             new_oid_str, new_probable_del_rec->to_json(),
+                             oid_key_val_mp,
                              std::bind(&S3PostCompleteAction::next, this),
                              std::bind(&S3PostCompleteAction::next, this));
+
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
@@ -1007,22 +1147,89 @@ void S3PostCompleteAction::delete_new_object() {
   if (!motr_writer) {
     motr_writer = motr_writer_factory->create_motr_writer(request);
   }
-  motr_writer->delete_object(
-      std::bind(&S3PostCompleteAction::remove_new_oid_probable_record, this),
-      std::bind(&S3PostCompleteAction::next, this), new_object_oid, layout_id);
+  unsigned int object_count = new_obj_oids.size();
+  if (object_count > 0) {
+    struct m0_uint128 new_oid = new_obj_oids.back();
+    motr_writer->set_oid(new_oid);
+    motr_writer->delete_object(
+        std::bind(&S3PostCompleteAction::delete_new_object_success, this),
+        std::bind(&S3PostCompleteAction::next, this), new_oid, layout_id);
+  }
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
+
+void S3PostCompleteAction::delete_new_object_success() {
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
+  unsigned int object_count = new_obj_oids.size();
+  if (object_count == 0) {
+    return;
+  }
+  s3_log(S3_LOG_INFO, request_id,
+         "Deleted new object oid "
+         "[%" SCNx64 " : %" SCNx64 "]",
+         (new_obj_oids.back()).u_hi, (new_obj_oids.back()).u_lo);
+  new_obj_oids.pop_back();
+
+  if (new_obj_oids.size() > 0) {
+    delete_new_object();
+  } else {
+    // All created objects have been deleted. Try to delete fragment
+    // entries from extended metadata index, if any
+    remove_new_fragments();
+  }
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
+
+void S3PostCompleteAction::remove_new_fragments() {
+  s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
+  if (new_object_metadata && new_object_metadata->is_object_extended()) {
+    const std::shared_ptr<S3ObjectExtendedMetadata>& ext_metadata =
+        new_object_metadata->get_extended_object_metadata();
+    if (ext_metadata->has_entries()) {
+      // Delete fragments, if any
+      ext_metadata->remove(
+          std::bind(&S3PostCompleteAction::remove_new_ext_metadata_successful,
+                    this),
+          std::bind(&S3PostCompleteAction::remove_new_ext_metadata_successful,
+                    this));
+    } else {
+      // Extended object exist, but no fragments, delete probbale index entries
+      remove_new_oid_probable_record();
+    }
+  } else {
+    // If this is not extended object, delete entries from probable index
+    remove_new_oid_probable_record();
+  }
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
+void S3PostCompleteAction::remove_new_ext_metadata_successful() {
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
+  s3_log(S3_LOG_DEBUG, request_id,
+         "Removed extended metadata for Object [%s].\n",
+         (new_object_metadata->get_object_name()).c_str());
+  remove_new_oid_probable_record();
+  s3_log(S3_LOG_DEBUG, request_id, "%s Exit", __func__);
 }
 
 void S3PostCompleteAction::remove_new_oid_probable_record() {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   assert(!new_oid_str.empty());
 
+  if (new_parts_probable_del_rec_list.size() == 0) {
+    next();
+    return;
+  }
+  std::vector<std::string> keys_to_delete;
+  for (auto& probable_rec : new_parts_probable_del_rec_list) {
+    keys_to_delete.push_back(probable_rec->get_key());
+  }
+
   if (!motr_kv_writer) {
     motr_kv_writer =
         mote_kv_writer_factory->create_motr_kvs_writer(request, s3_motr_api);
   }
   motr_kv_writer->delete_keyval(global_probable_dead_object_list_index_oid,
-                                new_oid_str,
+                                keys_to_delete,
                                 std::bind(&S3PostCompleteAction::next, this),
                                 std::bind(&S3PostCompleteAction::next, this));
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);

--- a/server/s3_post_complete_action.h
+++ b/server/s3_post_complete_action.h
@@ -85,10 +85,19 @@ class S3PostCompleteAction : public S3ObjectAction {
 
   // Probable delete record for old object OID in case of overwrite
   std::string old_oid_str;  // Key for old probable delete rec
-  std::unique_ptr<S3ProbableDeleteRecord> old_probable_del_rec;
   // Probable delete record for new object OID in case of current req failure
   std::string new_oid_str;  // Key for new probable delete rec
-  std::unique_ptr<S3ProbableDeleteRecord> new_probable_del_rec;
+
+  // List of part object oids belong to new object
+  std::vector<struct m0_uint128> new_obj_oids;
+  // List of part object oids belong to old object
+  std::vector<struct m0_uint128> old_obj_oids;
+
+  // Probable delete record for object parts
+  std::vector<std::unique_ptr<S3ProbableDeleteRecord>>
+      new_parts_probable_del_rec_list;
+  std::vector<std::unique_ptr<S3ProbableDeleteRecord>>
+      old_parts_probable_del_rec_list;
 
  public:
   S3PostCompleteAction(
@@ -108,12 +117,12 @@ class S3PostCompleteAction : public S3ObjectAction {
   void load_and_validate_request();
   void consume_incoming_content();
   bool validate_request_body(std::string &xml_str);
-  void fetch_bucket_info_success();
   void fetch_bucket_info_failed();
   void fetch_object_info_failed();
   void fetch_multipart_info();
   void fetch_multipart_info_success();
   void fetch_multipart_info_failed();
+  void fetch_ext_object_info_failed();
 
   void get_next_parts_info();
   void get_next_parts_info_successful();
@@ -138,13 +147,33 @@ class S3PostCompleteAction : public S3ObjectAction {
   void add_object_oid_to_probable_dead_oid_list_success();
   void add_object_oid_to_probable_dead_oid_list_failed();
 
+  // Add object part to the new object's extended metadata portion
+  void add_part_object_to_object_extended(
+      const std::shared_ptr<S3PartMetadata> &part_metadata,
+      std::shared_ptr<S3ObjectMetadata> &object_metadata);
+  void add_part_object_to_probable_dead_oid_list(
+      const std::shared_ptr<S3ObjectMetadata> &,
+      std::vector<std::unique_ptr<S3ProbableDeleteRecord>> &,
+      bool is_old_object = false);
+
   void startcleanup() override;
   void mark_old_oid_for_deletion();
   void delete_old_object();
+  void delete_old_object_success();
   void remove_old_object_version_metadata();
   void remove_old_oid_probable_record();
+  // Delete old entries corresponding to old object parts
+  // from the extended md index
+  void remove_old_fragments();
+  void remove_old_ext_metadata_successful();
+
   void mark_new_oid_for_deletion();
   void delete_new_object();
+  void delete_new_object_success();
+  // During failure due to md failure, delete fragments,
+  // if existed any, from the extended index
+  void remove_new_fragments();
+  void remove_new_ext_metadata_successful();
   void remove_new_oid_probable_record();
 
   std::string get_part_index_name() {

--- a/server/s3_post_multipartobject_action.cc
+++ b/server/s3_post_multipartobject_action.cc
@@ -139,8 +139,6 @@ void S3PostMultipartObjectAction::fetch_bucket_info_failed() {
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
-void S3PostMultipartObjectAction::fetch_object_info_success() { next(); }
-
 void S3PostMultipartObjectAction::validate_x_amz_tagging_if_present() {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   std::string new_object_tags = request->get_header_value("x-amz-tagging");
@@ -377,7 +375,8 @@ void S3PostMultipartObjectAction::save_upload_metadata() {
       request->get_object_name() + "|" + upload_id;
   object_multipart_metadata->rename_object_name(multipart_object_name);
   object_multipart_metadata->set_layout_id(layout_id);
-  object_multipart_metadata->set_pvid(motr_writer->get_ppvid());
+  // Save empty pv id string
+  object_multipart_metadata->set_pvid(nullptr);
 
   for (auto it : request->get_in_headers_copy()) {
     if (it.first.find("x-amz-meta-") != std::string::npos) {

--- a/server/s3_post_multipartobject_action.h
+++ b/server/s3_post_multipartobject_action.h
@@ -81,7 +81,6 @@ class S3PostMultipartObjectAction : public S3ObjectAction {
   void validate_tags();
   void fetch_bucket_info_failed();
   void check_bucket_object_state();
-  void fetch_object_info_success();
   void fetch_object_info_failed();
   void check_upload_is_inprogress();
   void create_new_oid(struct m0_uint128 current_oid);

--- a/server/s3_probable_delete_record.cc
+++ b/server/s3_probable_delete_record.cc
@@ -34,7 +34,8 @@ S3ProbableDeleteRecord::S3ProbableDeleteRecord(
     std::string obj_key_in_index, struct m0_uint128 new_oid, int layout_id,
     struct m0_uint128 obj_list_idx_oid,
     struct m0_uint128 objs_version_list_idx_oid, std::string ver_key_in_index,
-    bool force_del, bool is_multipart, struct m0_uint128 part_list_oid)
+    bool force_del, bool is_multipart, struct m0_uint128 part_list_oid,
+    unsigned int frg, unsigned int prt, struct m0_uint128 extended_idx)
     : record_key(rec_key),
       old_object_oid(old_oid),
       object_key_in_index(obj_key_in_index),
@@ -45,7 +46,10 @@ S3ProbableDeleteRecord::S3ProbableDeleteRecord(
       version_key_in_index(ver_key_in_index),
       force_delete(force_del),
       is_multipart(is_multipart),
-      part_list_idx_oid(part_list_oid) {
+      part_list_idx_oid(part_list_oid),
+      fragment(frg),
+      part(prt),
+      extended_md_idx_oid(extended_idx) {
   // Assertions
   s3_log(S3_LOG_DEBUG, "", "object_key_in_index = %s\n",
          object_key_in_index.c_str());
@@ -60,7 +64,6 @@ S3ProbableDeleteRecord::S3ProbableDeleteRecord(
     s3_log(S3_LOG_DEBUG, "", "part_list_idx_oid = %" SCNx64 " : %" SCNx64 "\n",
            part_list_idx_oid.u_hi, part_list_idx_oid.u_lo);
   } else {
-    assert(!object_key_in_index.empty());
     s3_log(S3_LOG_DEBUG, "",
            "objects_version_list_idx_oid = %" SCNx64 " : %" SCNx64 "\n",
            objects_version_list_idx_oid.u_hi,
@@ -72,6 +75,7 @@ S3ProbableDeleteRecord::S3ProbableDeleteRecord(
 
 std::string S3ProbableDeleteRecord::to_json() {
   Json::Value root;
+
   // current_object_oid is key for this record, hence not stored in json
 
   // Will be 0 for new object record or first object.
@@ -97,6 +101,19 @@ std::string S3ProbableDeleteRecord::to_json() {
   } else {
     root["is_multipart"] = "false";
     root["version_key_in_index"] = version_key_in_index;
+  }
+  // If fragmented object, include fragment number
+  if (fragment) {
+    root["fno"] = fragment;
+  }
+  // If multipart object, include part number
+  if (part) {
+    root["part"] = part;
+  }
+  if (fragment || part) {
+    // Add extended metadata(a.k.a fragment) index index oid
+    root["extended_md_idx_oid"] =
+        S3M0Uint128Helper::to_string(extended_md_idx_oid);
   }
   S3DateTime current_time;
   current_time.init_current_time();

--- a/server/s3_probable_delete_record.h
+++ b/server/s3_probable_delete_record.h
@@ -48,6 +48,9 @@ class S3ProbableDeleteRecord {
                       // delete object
   bool is_multipart;
   struct m0_uint128 part_list_idx_oid;  // present in case of multipart
+  unsigned int fragment;
+  unsigned int part;
+  struct m0_uint128 extended_md_idx_oid;
 
  public:
   S3ProbableDeleteRecord(std::string rec_key, struct m0_uint128 old_oid,
@@ -57,13 +60,18 @@ class S3ProbableDeleteRecord {
                          struct m0_uint128 objs_version_list_idx_oid,
                          std::string ver_key_in_index, bool force_del = false,
                          bool is_multipart = false,
-                         struct m0_uint128 part_list_oid = {0ULL, 0ULL});
+                         struct m0_uint128 part_list_oid = {0ULL, 0ULL},
+                         unsigned int frg = 0, unsigned int prt = 0,
+                         struct m0_uint128 extended_idx = {0ULL, 0ULL});
   virtual ~S3ProbableDeleteRecord() {}
 
   virtual const std::string& get_key() const { return record_key; }
 
   virtual struct m0_uint128 get_current_object_oid() const {
     return current_object_oid;
+  }
+  virtual struct m0_uint128 get_old_object_oid() const {
+    return old_object_oid;
   }
 
   // Override force delete flag

--- a/server/s3_put_multiobject_action.cc
+++ b/server/s3_put_multiobject_action.cc
@@ -360,6 +360,7 @@ void S3PutMultiObjectAction::create_part_object_successful() {
       part_number);
   part_metadata->set_oid(motr_writer->get_oid());
   part_metadata->set_layout_id(layout_id);
+  part_metadata->set_pvid(motr_writer->get_ppvid());
   new_oid_str = S3M0Uint128Helper::to_string(new_object_oid);
 
   add_object_oid_to_probable_dead_oid_list();
@@ -639,19 +640,21 @@ void S3PutMultiObjectAction::add_object_oid_to_probable_dead_oid_list() {
     // prepending a char depending on the size of the object (size based
     // bucketing of object)
     S3CommonUtilities::size_based_bucketing_of_objects(
-        old_oid_str, object_metadata->get_content_length());
+        old_oid_str, part_metadata->get_content_length());
 
     // key = oldoid + "-" + newoid
     std::string old_oid_rec_key = old_oid_str + '-' + new_oid_str;
     s3_log(S3_LOG_DEBUG, request_id,
            "Adding old_probable_del_rec with key [%s]\n",
            old_oid_rec_key.c_str());
-    // TODO - Revisit later to see the changes needed here
     old_probable_del_rec.reset(new S3ProbableDeleteRecord(
-        old_oid_rec_key, {0ULL, 0ULL}, std::to_string(part_number),
-        old_object_oid, old_layout_id, part_metadata->get_part_index_oid(),
+        old_oid_rec_key, {0ULL, 0ULL},
+        object_multipart_metadata->get_object_name(), old_object_oid,
+        old_layout_id, bucket_metadata->get_multipart_index_oid(),
         bucket_metadata->get_objects_version_list_index_oid(), "",
-        false /* force_delete */, true, part_metadata->get_part_index_oid()));
+        false /* force_delete */, true, part_metadata->get_part_index_oid(), 0,
+        strtoul(part_metadata->get_part_number().c_str(), NULL, 0),
+        bucket_metadata->get_extended_metadata_index_oid()));
 
     probable_oid_list[old_oid_rec_key] = old_probable_del_rec->to_json();
   }
@@ -663,10 +666,12 @@ void S3PutMultiObjectAction::add_object_oid_to_probable_dead_oid_list() {
   s3_log(S3_LOG_DEBUG, request_id,
          "Adding new_probable_del_rec with key [%s]\n", new_oid_str.c_str());
   new_probable_del_rec.reset(new S3ProbableDeleteRecord(
-      new_oid_str, old_object_oid, std::to_string(part_number), new_object_oid,
-      layout_id, part_metadata->get_part_index_oid(),
+      new_oid_str, old_object_oid, object_multipart_metadata->get_object_name(),
+      new_object_oid, layout_id, bucket_metadata->get_multipart_index_oid(),
       bucket_metadata->get_objects_version_list_index_oid(), "",
-      false /* force_delete */, true, part_metadata->get_part_index_oid()));
+      false /* force_delete */, true, part_metadata->get_part_index_oid(), 0,
+      strtoul(part_metadata->get_part_number().c_str(), NULL, 0),
+      bucket_metadata->get_extended_metadata_index_oid()));
   // store new oid, key = newoid
   probable_oid_list[new_oid_str] = new_probable_del_rec->to_json();
 

--- a/ut/mock_s3_bucket_metadata.h
+++ b/ut/mock_s3_bucket_metadata.h
@@ -63,6 +63,8 @@ class MockS3BucketMetadata : public S3BucketMetadata {
   MOCK_CONST_METHOD0(get_object_list_index_oid, const struct m0_uint128&());
   MOCK_CONST_METHOD0(get_objects_version_list_index_oid,
                      const struct m0_uint128&());
+  MOCK_CONST_METHOD0(get_extended_metadata_index_oid,
+                     const struct m0_uint128&());
 };
 
 #endif

--- a/ut/mock_s3_factory.h
+++ b/ut/mock_s3_factory.h
@@ -40,6 +40,7 @@
 #include "mock_s3_request_object.h"
 #include "mock_s3_put_tag_body.h"
 #include "mock_s3_global_bucket_index_metadata.h"
+#include "mock_s3_object_extended_metadata.h"
 #include "s3_factory.h"
 
 class MockS3BucketMetadataFactory : public S3BucketMetadataFactory {
@@ -65,10 +66,13 @@ class MockS3ObjectMetadataFactory : public S3ObjectMetadataFactory {
       : S3ObjectMetadataFactory() {
     mock_object_metadata =
         std::make_shared<MockS3ObjectMetadata>(req, s3_motr_mock_ptr);
+    mock_object_extnd_metadata =
+        std::make_shared<MockS3ObjectExtendedMetadata>(req, s3_motr_mock_ptr);
   }
 
   void set_object_list_index_oid(struct m0_uint128 id) {
     mock_object_metadata->set_object_list_index_oid(id);
+    mock_object_extnd_metadata->set_object_list_index_oid(id);
   }
 
   std::shared_ptr<S3ObjectMetadata> create_object_metadata_obj(
@@ -86,7 +90,18 @@ class MockS3ObjectMetadataFactory : public S3ObjectMetadataFactory {
     return mock_object_metadata;
   }
 
+  std::shared_ptr<S3ObjectExtendedMetadata> create_object_ext_metadata_obj(
+      std::shared_ptr<S3RequestObject> req, const std::string& bucket_name,
+      const std::string& object_name, const std::string& versionid,
+      unsigned int parts = 0, unsigned int fragments = 0,
+      m0_uint128 indx_oid = {0ULL, 0ULL}) {
+    mock_object_extnd_metadata->set_object_list_index_oid(indx_oid);
+    mock_object_extnd_metadata->set_version_id(versionid);
+    return mock_object_extnd_metadata;
+  }
+
   std::shared_ptr<MockS3ObjectMetadata> mock_object_metadata;
+  std::shared_ptr<MockS3ObjectExtendedMetadata> mock_object_extnd_metadata;
 };
 
 class MockS3PartMetadataFactory : public S3PartMetadataFactory {

--- a/ut/mock_s3_object_extended_metadata.h
+++ b/ut/mock_s3_object_extended_metadata.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+#pragma once
+
+#ifndef __S3_UT_MOCK_S3_OBJECT_EXTND_METADATA_H__
+#define __S3_UT_MOCK_S3_OBJECT_EXTND_METADATA_H__
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "mock_s3_motr_wrapper.h"
+#include "s3_object_metadata.h"
+#include "s3_request_object.h"
+
+using ::testing::_;
+using ::testing::Return;
+
+class MockS3ObjectExtendedMetadata : public S3ObjectExtendedMetadata {
+ public:
+  MockS3ObjectExtendedMetadata(std::shared_ptr<S3RequestObject> req,
+                               std::shared_ptr<MockS3Motr> motr_api = nullptr)
+      : S3ObjectExtendedMetadata(req, "", "", "", 0, 0, nullptr, nullptr,
+                                 motr_api) {}
+  MOCK_METHOD1(get_obj_ext_entries, void(std::string));
+  MOCK_METHOD2(from_json, int(std::string, std::string));
+  MOCK_METHOD1(get_json_str, std::string(struct s3_part_frag_context&));
+  MOCK_METHOD0(has_entries, bool());
+  MOCK_METHOD0(
+      get_raw_extended_entries,
+      const std::map<int, std::vector<struct s3_part_frag_context>>&());
+  MOCK_METHOD0(get_fragment_count, unsigned int());
+  MOCK_METHOD0(get_part_count, unsigned int());
+  MOCK_METHOD2(load,
+               void(std::function<void(void)>, std::function<void(void)>));
+  MOCK_METHOD2(save,
+               void(std::function<void(void)>, std::function<void(void)>));
+  MOCK_METHOD0(get_kv_list_of_extended_entries,
+               std::map<std::string, std::string>());
+  MOCK_METHOD3(add_extended_entry,
+               void(struct s3_part_frag_context&, unsigned int, unsigned int));
+  MOCK_METHOD2(remove,
+               void(std::function<void(void)>, std::function<void(void)>));
+};
+
+#endif

--- a/ut/mock_s3_object_metadata.h
+++ b/ut/mock_s3_object_metadata.h
@@ -78,6 +78,10 @@ class MockS3ObjectMetadata : public S3ObjectMetadata {
   MOCK_METHOD2(save_metadata, void(std::function<void(void)> on_success,
                                    std::function<void(void)> on_failed));
   MOCK_METHOD1(from_json, int(std::string content));
+  MOCK_METHOD0(get_obj_version_key, std::string());
+  MOCK_METHOD2(remove_version_metadata,
+               void(std::function<void(void)> on_success,
+                    std::function<void(void)> on_failed));
 };
 
 #endif

--- a/ut/mock_s3_part_metadata.h
+++ b/ut/mock_s3_part_metadata.h
@@ -57,6 +57,10 @@ class MockS3PartMetadata : public S3PartMetadata {
   MOCK_METHOD0(get_storage_class, std::string());
   MOCK_METHOD0(get_object_name, std::string());
   MOCK_METHOD0(get_upload_id, std::string());
+  MOCK_METHOD0(get_part_number, std::string());
+  MOCK_METHOD0(get_oid, const struct m0_uint128());
+  MOCK_METHOD0(get_pvid, struct m0_fid());
+  MOCK_METHOD0(get_layout_id, int());
 };
 
 #endif

--- a/ut/s3_copy_object_action_test.cc
+++ b/ut/s3_copy_object_action_test.cc
@@ -91,8 +91,9 @@ S3CopyObjectActionTest::S3CopyObjectActionTest() {
   EXPECT_CALL(*ptr_mock_request, get_bucket_name())
       .WillRepeatedly(ReturnRef(destination_bucket_name));
 
-  EXPECT_CALL(*ptr_mock_request, get_object_name()).Times(AtLeast(1)).WillOnce(
-      ReturnRef(destination_object_name));
+  EXPECT_CALL(*ptr_mock_request, get_object_name())
+      .Times(AtLeast(1))
+      .WillRepeatedly(ReturnRef(destination_object_name));
 
   ptr_mock_bucket_meta_factory =
       std::make_shared<MockS3BucketMetadataFactory>(ptr_mock_request);

--- a/ut/s3_delete_bucket_action_test.cc
+++ b/ut/s3_delete_bucket_action_test.cc
@@ -138,7 +138,10 @@ TEST_F(S3DeleteBucketActionTest, FetchFirstObjectMetadataPresent) {
               get_object_list_index_oid())
       .Times(1)
       .WillOnce(ReturnRef(oid));
-
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),
+              get_extended_metadata_index_oid())
+      .Times(1)
+      .WillOnce(ReturnRef(oid));
   struct m0_uint128 version_list_oid = {0x1ffff, 0x1ffff};
 
   EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),
@@ -159,7 +162,10 @@ TEST_F(S3DeleteBucketActionTest, FetchFirstObjectMetadataEmptyBucket) {
       bucket_meta_factory->mock_bucket_metadata;
   EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata), get_state())
       .WillOnce(Return(S3BucketMetadataState::present));
-
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),
+              get_extended_metadata_index_oid())
+      .Times(1)
+      .WillOnce(ReturnRef(oid));
   // set the OID
   action_under_test->bucket_metadata->set_object_list_index_oid(zero_oid);
 

--- a/ut/s3_put_object_action_test.cc
+++ b/ut/s3_put_object_action_test.cc
@@ -96,13 +96,13 @@ class S3PutObjectActionTest : public testing::Test {
     ptr_mock_request = std::make_shared<MockS3RequestObject>(
         req, evhtp_obj_ptr, async_buffer_factory);
     EXPECT_CALL(*ptr_mock_request, get_bucket_name())
+        .Times(AtLeast(1))
         .WillRepeatedly(ReturnRef(bucket_name));
     EXPECT_CALL(*ptr_mock_request, get_object_name())
         .Times(AtLeast(1))
-        .WillOnce(ReturnRef(object_name));
+        .WillRepeatedly(ReturnRef(object_name));
     EXPECT_CALL(*(ptr_mock_request), get_header_value(StrEq("x-amz-tagging")))
         .WillOnce(Return(""));
-
     // Owned and deleted by shared_ptr in S3PutObjectAction
     bucket_meta_factory =
         std::make_shared<MockS3BucketMetadataFactory>(ptr_mock_request);


### PR DESCRIPTION
This change also has other fixes e.g.:
1. Get Object api changes to read several objects created as part of multipart redesign.
    These code change are ported from FaultTolerance branch, with some changes.
2. Changes in implementation files related to Multipart functionality, other than Complete multipart API file

Signed-off-by: Dattaprasad <dattaprasad.govekar@seagate.com>