### PR TITLE
EOS-21167 :Add validation of lustre rpm before reconfiguring lnet during execution of init.sh

### DIFF
--- a/scripts/env/common/configure_lnet.sh
+++ b/scripts/env/common/configure_lnet.sh
@@ -26,7 +26,8 @@ validte_configure_lnet() {
   else
     echo "Lnet is down."
     echo "configuring lnet"
-    echo "options lnet networks=tcp(eth0) config_on_load=1" > '/etc/modprobe.d/lnet.conf'
+    iface=$(ip route | grep default | awk 'NR==1{print $5}')
+    echo "options lnet networks=tcp($iface) config_on_load=1" > '/etc/modprobe.d/lnet.conf'
     service lnet restart
     # it has been observed that the lnet does not get restart in first go
     # so for safer side restarting again and then verify
@@ -40,10 +41,11 @@ validte_configure_lnet() {
     fi
   fi
 }
-
 ###############################
 ### Main script starts here ###
 ###############################
 
 # validate and configure lnet
-validte_configure_lnet
+  if rpm -q 'kmod-lustre-client' ; then
+    validte_configure_lnet
+  fi


### PR DESCRIPTION
Tested below scenarios , working fine .

Case 1: When lustre rpm is not present in VM.
[root@cortxhost common]# ./configure_lnet.sh
package kmod-lustre-client is not installed
[root@cortxhost common]#

Case 2: When lustre rpm is present and Lnet is not configured in VM.
[root@cortxhost common]# ./configure_lnet.sh
kmod-lustre-client-2.12.5-99.el7.x86_64
Lnet is down.
configuring lnet
Redirecting to /bin/systemctl restart lnet.service
Redirecting to /bin/systemctl restart lnet.service
Lnet is up and running
[root@cortxhost common]# lctl list_nids
10.230.241.171@tcp
[root@cortxhost common]#

Case 3: When lustre rpm is present and Lnet is pre-configured in VM.
[root@cortxhost common]# ./configure_lnet.sh
kmod-lustre-client-2.12.5-99.el7.x86_64
Lnet is up and running
[root@cortxhost common]#

Signed-off-by: Nilesh Govande <nilesh.govande@seagate.com>