### PR TITLE
EOS-21423: Fixed systemd service files for all S3 services

### DIFF
--- a/rpms/s3/s3rpm.spec
+++ b/rpms/s3/s3rpm.spec
@@ -483,7 +483,6 @@ elif [ $1 == 2 ];then
     echo "[cortx-s3server-rpm] INFO: S3 RPM Post Upgrade section completed"
 fi
 systemctl daemon-reload
-systemctl enable s3authserver
 systemctl restart rsyslog
 openssl_version=`rpm -q --queryformat '%{VERSION}' openssl`
 if [ "$openssl_version" != "1.0.2k" ] && [ "$openssl_version" != "1.1.1" ]; then

--- a/scripts/provisioning/configcmd.py
+++ b/scripts/provisioning/configcmd.py
@@ -22,7 +22,6 @@ import sys
 import os
 import errno
 import shutil
-import configparser
 from pathlib import Path
 from  ast import literal_eval
 
@@ -64,12 +63,6 @@ class ConfigCmd(SetupCmd):
       services_list = ["haproxy", "s3backgroundproducer", "s3backgroundconsumer", "s3server@*", "s3authserver"]
       self.disable_services(services_list)
       self.logger.info('Disable services on reboot completed')
-
-      # provisioner is creating override.conf file for haproxy in which 
-      # restart should be 'no' as it is managed by HA
-      self.logger.info('Set haproxy restart to NO started')
-      self.set_haproxy_restart_to_no()
-      self.logger.info('Set haproxy restart to NO completed')
 
       self.logger.info('create auth jks password started')
       self.create_auth_jks_password()
@@ -254,14 +247,3 @@ class ConfigCmd(SetupCmd):
     else:
       self.logger.warning(f'warning of create_auth_jks_password.sh: {stderr}')
       self.logger.info(' Successfully set auth JKS keystore password.')
-
-  def set_haproxy_restart_to_no(self):
-    """Set restart to 'no' in /etc/systemd/system/haproxy.service.d/override.conf"""
-    overridefilepath = "/etc/systemd/system/haproxy.service.d/override.conf"
-    if os.path.isfile(overridefilepath):
-      self.logger.info(f"file {overridefilepath} exist")
-      config = configparser.ConfigParser()
-      config.read(overridefilepath)
-      config.set("Service", "Restart", "no")
-      with open(overridefilepath, 'w') as configfile:
-          config.write(configfile)

--- a/scripts/provisioning/setupcmd.py
+++ b/scripts/provisioning/setupcmd.py
@@ -429,6 +429,16 @@ class SetupCmd(object):
       if res_rc != 0:
         raise Exception(f"{cmd} failed with err: {res_err}, out: {res_op}, ret: {res_rc}")
 
+  def disable_services(self, s3services_list):
+    """Disable services specified as parameter."""
+    for service_name in s3services_list:
+      cmd = ['/bin/systemctl', 'disable', f'{service_name}']
+      handler = SimpleProcess(cmd)
+      self.logger.info(f"Disabling {service_name}")
+      res_op, res_err, res_rc = handler.run()
+      if res_rc != 0:
+        raise Exception(f"{cmd} failed with err: {res_err}, out: {res_op}, ret: {res_rc}")
+
   def delete_mdb_files(self):
     """Deletes ldap mdb files."""
     for files in os.listdir(self.ldap_mdb_folder):

--- a/system/s3server@.service
+++ b/system/s3server@.service
@@ -19,10 +19,6 @@
 
 [Unit]
 Description=Motr-S3 Core instance Server
-Requires=haproxy.service
-After=haproxy.service
-Requires=s3authserver.service
-After=s3authserver.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
# Change Summary
## Problem Statement/Description
_[EOS-21429](https://jts.seagate.com/browse/EOS-21429):_
_Fixed systemd service files for all S3 services_

## Solution Overview
- s3authserver
    - systemctl disable s3authserver (remove from spec file)
    - systemctl disable haproxy in conf phase
- haproxy
    - systemctl disable haproxy in conf phase
    - /etc/systemd/system/haproxy.service.d/override.conf
        - restart=no
- s3server
    - haproxy and authserver dependencies remove (required and after)
    - systemctl disable haproxy in conf phase
   