### PR TITLE
EOS-21416: Removed workaround used for iterating all keys using get_all_keys()

### DIFF
--- a/s3cortxutils/s3confstore/s3confstore/cortx_s3_confstore.py
+++ b/s3cortxutils/s3confstore/s3confstore/cortx_s3_confstore.py
@@ -42,7 +42,7 @@ class S3CortxConfStore:
   def load_config(index: str = "default_s3confstore_index", config: str = ""):
     """Load Config into confstore."""
     # TODO recurse flag will be deprecated in future.
-    Conf.load(index, config, recurse = False)
+    Conf.load(index, config, recurse = True)
 
   def get_config(self, key: str):
     """Get the key's config from confstore."""
@@ -60,7 +60,7 @@ class S3CortxConfStore:
     # TODO recurse flag will be deprecated in future.
     # Do changes in all places wherever its applicable
     # refer validate_config_files() and phase_keys_validate() in setupcmd.py
-    return Conf.get_keys(self.default_index, recurse = False)
+    return Conf.get_keys(self.default_index, recurse = True)
 
   def delete_key(self, key: str, save: bool = False):
     """Deletes the specified key."""
@@ -77,7 +77,7 @@ class S3CortxConfStore:
     # TODO recurse flag will be deprecated in future.
     # Do changes in all places wherever its applicable
     # refer upgrade_config() in merge.py
-    Conf.copy(source_index, self.default_index, keys_to_include, recurse = False)
+    Conf.copy(source_index, self.default_index, keys_to_include, recurse = True)
 
   def save_config(self):
     """Saves to config file."""

--- a/scripts/provisioning/setupcmd.py
+++ b/scripts/provisioning/setupcmd.py
@@ -330,7 +330,7 @@ class SetupCmd(object):
     try:
       # Extract keys from yardstick file for current phase considering inheritance
       yardstick_list = self.extract_yardstick_list(phase_name)
-
+      self.logger.info(f"yardstick_list -> {yardstick_list}")
       # Set argument file confstore
       argument_file_confstore = S3CortxConfStore(arg_file, 'argument_file_index')
       # Extract keys from argument file

--- a/scripts/provisioning/setupcmd.py
+++ b/scripts/provisioning/setupcmd.py
@@ -277,7 +277,7 @@ class SetupCmd(object):
       "PREPARE" : ["POST_INSTALL", "PREPARE"],
       "CONFIG" : ["POST_INSTALL", "PREPARE", "CONFIG"],
       "INIT" : ["POST_INSTALL", "PREPARE", "CONFIG", "INIT"],
-      "RESET": ["reset"],
+      "RESET": ["RESET"],
       "CLEANUP": ["CLEANUP"],
       "TEST" : ["TEST"]}
 

--- a/scripts/provisioning/setupcmd.py
+++ b/scripts/provisioning/setupcmd.py
@@ -340,21 +340,6 @@ class SetupCmd(object):
       argument_file_confstore = S3CortxConfStore(arg_file, 'argument_file_index')
       # Extract keys from argument file
       arg_keys_list = argument_file_confstore.get_all_keys()
-      # Since get_all_keys misses out listing entries inside
-      # an array, the below code is required to fetch such
-      # array entries. The result will be stored in a full
-      # list which will be complete and will be used to verify
-      # keys required for each phase.
-      full_arg_keys_list = []
-      for key in arg_keys_list:
-        if ((key.find('[') != -1) and (key.find(']') != -1)):
-          storage_set = self.get_confvalue(key)
-          base_key = key
-          for set_key in storage_set:
-            key = base_key + ">" + set_key
-            full_arg_keys_list.append(key)
-        else:
-          full_arg_keys_list.append(key)
 
       # Below algorithm uses tokenization
       # of both yardstick and argument key
@@ -373,7 +358,7 @@ class SetupCmd(object):
       for key_yard in yardstick_list:
         key_yard_token_list = re.split('>|\[|\]',key_yard)
         key_match_found = False
-        for key_arg in full_arg_keys_list:
+        for key_arg in arg_keys_list:
           if key_match_found is False:
             key_arg_token_list = re.split('>|\[|\]',key_arg)
             if len(key_yard_token_list) == len(key_arg_token_list):

--- a/scripts/provisioning/setupcmd.py
+++ b/scripts/provisioning/setupcmd.py
@@ -20,7 +20,6 @@
 
 import sys
 import os
-import re
 import shutil
 import glob
 import socket
@@ -347,15 +346,14 @@ class SetupCmd(object):
     # (B) both the key-tokens from key_arg
     #     and key_yard are the same.
     for key_yard in yardstick_list:
-      key_yard = key_yard.replace("machine-id", machine_id_val) \
-      .replace("cluster-id", cluster_id_val)
-
+      if "machine-id" in key_yard:
+        key_yard = key_yard.replace("machine-id", machine_id_val)
+      if "cluster-id" in key_yard:
+        key_yard = key_yard.replace("cluster-id", cluster_id_val)
       if "server_nodes" in key_yard:
         index = 0
-        while index <  storage_set_val:
-          key_yard_server_nodes = self.get_confvalue(key_yard.replace("machine-id", machine_id_val) \
-          .replace("cluster-id", cluster_id_val) \
-          .replace("storage-set-count", str(index)))
+        while index < storage_set_val:
+          key_yard_server_nodes = self.get_confvalue(key_yard.replace("storage-set-count", str(index)))
           if key_yard_server_nodes is None:
             raise Exception("Validation for server_nodes failed")
           index += 1

--- a/scripts/swupdate/merge.py
+++ b/scripts/swupdate/merge.py
@@ -104,15 +104,6 @@ def upgrade_config(configFile:str, oldSampleFile:str, newSampleFile:str, unsafeA
     cs_conf_file = S3CortxConfStore(config=conf_file, index=conf_file)
     conf_file_keys = cs_conf_file.get_all_keys()
 
-    # Handle the special scenario where we have array in the config file
-    # 1)search for keys with [] in config
-    # 2)delete these keys/values in config
-    for key in conf_new_sample_keys:
-        if ((key.find('[') != -1) and (key.find(']') != -1)):
-            # deleting key[0]..[n] has issues in confstore deletes
-            # so deleting the root key which will deletes all the child entires
-            cs_conf_file.delete_key(key[:key.find('[')], True)
-
     # deleted keys dont go away in already loaded index.
     # so we load at another index and re-populate conf_file_keys again.
     conf_file_keys_after_delete = S3CortxConfStore(config=conf_file, index=conf_file+"after_delete")

--- a/scripts/swupdate/merge.py
+++ b/scripts/swupdate/merge.py
@@ -104,11 +104,6 @@ def upgrade_config(configFile:str, oldSampleFile:str, newSampleFile:str, unsafeA
     cs_conf_file = S3CortxConfStore(config=conf_file, index=conf_file)
     conf_file_keys = cs_conf_file.get_all_keys()
 
-    # deleted keys dont go away in already loaded index.
-    # so we load at another index and re-populate conf_file_keys again.
-    conf_file_keys_after_delete = S3CortxConfStore(config=conf_file, index=conf_file+"after_delete")
-    conf_file_keys = conf_file_keys_after_delete.get_all_keys()
-
     #logic to determine which keys to merge.
     keys_to_overwrite = []
     for key in conf_new_sample_keys:


### PR DESCRIPTION
# Change Summary
## Problem Statement/Description
_[EOS-21416](https://jts.seagate.com/browse/EOS-21416):_
_Removed workaround used for iterating all keys using get_all_keys()_

## Solution Overview
- Removed the workaround from get_all_keys()

