### PR TITLE
EOS-22090: System tests fails with timeout when run with valgrind

### DIFF
--- a/auth-utils/jclient/src/main/java/com/seagates3/javaclient/ClientConfig.java
+++ b/auth-utils/jclient/src/main/java/com/seagates3/javaclient/ClientConfig.java
@@ -40,7 +40,11 @@ public class ClientConfig {
     public static ClientConfiguration getClientConfiguration() {
         ClientConfiguration config = new ClientConfiguration();
         config.setProtocol(Protocol.HTTP);
-
+        config.setMaxErrorRetry(2);
+        config.setConnectionTimeout(72000000);
+        config.setSocketTimeout(72000000);
+        config.setRequestTimeout(72000000);
+        config.setClientExecutionTimeout(72000000);
         return config;
     }
 

--- a/st/clitests/jcloud_spec.py
+++ b/st/clitests/jcloud_spec.py
@@ -31,9 +31,9 @@ from s3client_config import S3ClientConfig
 # Helps debugging
 # Config.log_enabled = True
 # Config.dummy_run = True
-# Config.client_execution_timeout = 300 * 1000
-# Config.request_timeout = 300 * 1000
-# Config.socket_timeout = 300 * 1000
+Config.client_execution_timeout = 300 * 1000 * 240
+Config.request_timeout = 300 * 1000 * 240
+Config.socket_timeout = 300 * 1000 * 240
 
 # Set time_readable_format to False if you want to display the time in milli seconds.
 # Config.time_readable_format = False


### PR DESCRIPTION
When STs are run with valgrind, jcloud and jclient tests fails
due to timeout, runing with valgrind results in more time
for request processing

Signed-off-by: Rajesh Nambiar <rajesh.nambiar@seagate.com>