### PR TITLE
[EOS-18251] Use Bazel 4.1.0 explicitly. 

### DIFF
--- a/rpms/s3/s3rpm.spec
+++ b/rpms/s3/s3rpm.spec
@@ -67,7 +67,7 @@ URL:        https://github.com/Seagate/cortx-s3server
 Source:     %{name}-%{version}-%{_s3_git_ver}.tar.gz
 
 BuildRequires: automake
-BuildRequires: bazel
+BuildRequires: bazel >= 4.1.0
 BuildRequires: cmake >= 2.8.12
 BuildRequires: libtool
 %if %{with cortx_motr}


### PR DESCRIPTION
Use bazel 4.1.0 explicitly so that it gets installed/updated even if an older version is already installed. 

Test log 
```
00:01:42.506  + yum-builddep -y /tmp/workspace/GitHub-custom-ci-builds/centos-7.8/s3-custom-build/rpms/s3/s3rpm.spec
00:01:42.506  Loaded plugins: fastestmirror, ovl, priorities
00:01:42.764  Enabling base-source repository
00:01:42.764  Enabling extras-source repository
00:01:42.764  Loading mirror speeds from cached hostfile
00:01:45.294  Loading mirror speeds from cached hostfile
00:01:45.552  Getting requirements for /tmp/workspace/GitHub-custom-ci-builds/centos-7.8/s3-custom-build/rpms/s3/s3rpm.spec
00:01:45.553   --> Already installed : automake-1.13.4-3.el7.noarch
00:01:45.553   --> bazel-4.1.0-1.el7.x86_64
00:01:46.487   --> Already installed : cmake-2.8.12.2-2.el7.x86_64
00:01:46.487   --> Already installed : libtool-2.4.2-22.el7_3.x86_64
00:01:46.487   --> Already installed : cortx-motr-2.0.0-0_git51c256cf_3.10.0_1127.el7.x86_64
00:01:46.487   --> Already installed : cortx-motr-devel-2.0.0-0_git51c256cf_3.10.0_1127.el7.x86_64
00:01:46.487   --> Already installed : 1:openssl-1.0.2k-19.el7.x86_64
00:01:46.487   --> Already installed : 1:openssl-devel-1.0.2k-19.el7.x86_64
00:01:46.487   --> Already installed : 1:java-1.8.0-openjdk-1.8.0.242.b08-1.el7.x86_64
00:01:46.487   --> Already installed : 1:java-1.8.0-openjdk-devel-1.8.0.242.b08-1.el7.x86_64
00:01:46.487   --> Already installed : maven-3.0.5-17.el7.noarch
00:01:46.487   --> Already installed : unzip-6.0-21.el7.x86_64
00:01:46.487   --> Already installed : clang-3.4.2-9.el7.x86_64
00:01:46.487   --> Already installed : zlib-devel-1.2.7-18.el7.x86_64
00:01:46.487   --> Already installed : libxml2-2.9.1-6.el7.4.x86_64
00:01:46.487   --> Already installed : libxml2-devel-2.9.1-6.el7.4.x86_64
00:01:46.487   --> Already installed : libyaml-0.1.4-11.el7_0.x86_64
00:01:46.487   --> Already installed : libyaml-devel-0.1.4-11.el7_0.x86_64
00:01:46.487   --> Already installed : 1:yaml-cpp-0.5.1-2.el7.x86_64
00:01:46.487   --> Already installed : 1:yaml-cpp-devel-0.5.1-2.el7.x86_64
00:01:46.487   --> Already installed : gflags-2.1.1-6.el7.x86_64
00:01:46.487   --> Already installed : gflags-devel-2.1.1-6.el7.x86_64
00:01:46.487   --> Already installed : glog-0.3.3-8.el7.x86_64
00:01:46.487   --> Already installed : glog-devel-0.3.3-8.el7.x86_64
00:01:46.487   --> Already installed : gtest-1.10.0-1.el7.x86_64
00:01:46.487   --> Already installed : gtest-devel-1.10.0-1.el7.x86_64
00:01:46.487   --> Already installed : git-1.8.3.1-21.el7_7.x86_64
00:01:46.487   --> Already installed : git-clang-format-6.0-1.el7.x86_64
00:01:46.487   --> Already installed : log4cxx_cortx-0.10.0-1.x86_64
00:01:46.487   --> Already installed : log4cxx_cortx-devel-0.10.0-1.x86_64
00:01:46.487   --> Already installed : hiredis-0.12.1-2.el7.x86_64
00:01:46.488   --> Already installed : hiredis-devel-0.12.1-2.el7.x86_64
00:01:46.488   --> Already installed : python3-rpm-macros-3-32.el7.noarch
00:01:46.488   --> Already installed : python3-3.6.8-13.el7.x86_64
00:01:46.488   --> Already installed : python3-devel-3.6.8-13.el7.x86_64
00:01:46.488   --> Already installed : python3-setuptools-39.2.0-10.el7.noarch
00:01:46.488   --> Already installed : 1:python36-dateutil-2.4.2-5.el7.noarch
00:01:46.488   --> Already installed : python36-PyYAML-3.13-1.el7.x86_64
00:01:46.488   --> Already installed : python36-pika-0.10.0-10.el7.noarch
00:01:46.488   --> Already installed : python2-keyring-5.0-4.el7.noarch
00:01:46.488   --> Already installed : python2-futures-3.1.1-5.el7.noarch
00:01:46.488  --> Running transaction check
00:01:46.488  ---> Package bazel.x86_64 0:0.13.0-1.el7 will be updated
00:01:46.488  ---> Package bazel.x86_64 0:4.1.0-1.el7 will be an update
00:01:47.054  --> Finished Dependency Resolution
00:01:47.054  
00:01:47.054  Dependencies Resolved
00:01:47.054  
00:01:47.054  ================================================================================
00:01:47.054   Package       Arch           Version               Repository             Size
00:01:47.054  ================================================================================
00:01:47.054  Updating:
00:01:47.054   bazel         x86_64         4.1.0-1.el7           cortx-uploads          26 M
00:01:47.054  
00:01:47.054  Transaction Summary
00:01:47.054  ================================================================================
00:01:47.054  Upgrade  1 Package
00:01:47.054  
00:01:47.054  Total download size: 26 M
00:01:47.054  Downloading packages:
00:01:47.054  No Presto metadata available for cortx-uploads
00:01:47.312  Running transaction check
00:01:47.570  Running transaction test
00:01:47.570  Transaction test succeeded
00:01:47.570  Running transaction
00:01:48.137    Updating   : bazel-4.1.0-1.el7.x86_64                                     1/2 
00:01:48.137    Cleanup    : bazel-0.13.0-1.el7.x86_64                                    2/2 
00:01:48.137    Verifying  : bazel-4.1.0-1.el7.x86_64                                     1/2 
00:01:48.395    Verifying  : bazel-0.13.0-1.el7.x86_64                                    2/2 
00:01:48.395  
00:01:48.395  Updated:
00:01:48.395    bazel.x86_64 0:4.1.0-1.el7                                                    
00:01:48.395  
00:01:48.395  Complete!
```