### PR TITLE
[Backup - Do Not Merge] EOS-22134:Auth: adding new uidNo attribute to s3 account

### DIFF
--- a/auth/server/src/main/java/com/seagates3/controller/AccountController.java
+++ b/auth/server/src/main/java/com/seagates3/controller/AccountController.java
@@ -254,14 +254,13 @@ public class AccountController extends AbstractController {
    private
     String generateUniqueUidNo() throws DataAccessException {
       Account account;
-      String uidNo;
+      String accountUidNo;
       for (int i = 0; i < 5; i++) {
-        uidNo = KeyGenUtil.createAccountuidNo();
-        // TODO add ldap call to check if this id is unique or not
-        account = accountDao.findByCanonicalID(uidNo);
+        accountUidNo = KeyGenUtil.createAccountuidNo();
+        account = accountDao.findByUidNo(accountUidNo);
 
         if (!account.exists()) {
-          return uidNo;
+          return accountUidNo;
         }
       }
       return null;

--- a/auth/server/src/main/java/com/seagates3/dao/AccountDAO.java
+++ b/auth/server/src/main/java/com/seagates3/dao/AccountDAO.java
@@ -40,9 +40,16 @@ public interface AccountDAO {
     *  @throws DataAccessException
     */
    public Account findByCanonicalID(String canonicalID) throws DataAccessException;
+
+    /* @param uidNo of Account.
+    *  @return Account
+    *  @throws DataAccessException
+    */
+   public
+    Account findByUidNo(String uidNo) throws DataAccessException;
     /*
-     * Get account details from the database.
-     */
+      * Get account details from the database.
+      */
     public Account find(String name) throws DataAccessException;
 
     /*

--- a/auth/server/src/main/java/com/seagates3/dao/ldap/AccountImpl.java
+++ b/auth/server/src/main/java/com/seagates3/dao/ldap/AccountImpl.java
@@ -265,8 +265,6 @@ public class AccountImpl implements AccountDAO {
                               .getStringValue());
           account.setId(
               entry.getAttribute(LDAPUtils.ACCOUNT_ID).getStringValue());
-          account.setUidNo(
-              entry.getAttribute(LDAPUtils.ACCOUNT_UID_NO).getStringValue());
         }
         catch (LDAPException ex) {
           LOGGER.error("Failed to find account details." +

--- a/auth/server/src/main/java/com/seagates3/dao/ldap/AccountImpl.java
+++ b/auth/server/src/main/java/com/seagates3/dao/ldap/AccountImpl.java
@@ -20,11 +20,6 @@
 
 package com.seagates3.dao.ldap;
 
-import java.util.ArrayList;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.novell.ldap.LDAPAttribute;
 import com.novell.ldap.LDAPAttributeSet;
 import com.novell.ldap.LDAPConnection;
@@ -36,6 +31,10 @@ import com.seagates3.dao.AccountDAO;
 import com.seagates3.exception.DataAccessException;
 import com.seagates3.fi.FaultPoints;
 import com.seagates3.model.Account;
+import java.util.ArrayList;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AccountImpl implements AccountDAO {
 
@@ -46,8 +45,8 @@ public class AccountImpl implements AccountDAO {
     public Account findByID(String accountID) throws DataAccessException {
         Account account = new Account();
 
-        String[] attrs = {LDAPUtils.ORGANIZATIONAL_NAME,
-                          LDAPUtils.CANONICAL_ID};
+        String[] attrs = {LDAPUtils.ORGANIZATIONAL_NAME, LDAPUtils.CANONICAL_ID,
+                          LDAPUtils.ACCOUNT_UID_NO};
         String filter = String.format("(&(%s=%s)(%s=%s))",
                 LDAPUtils.ACCOUNT_ID, accountID, LDAPUtils.OBJECT_CLASS,
                 LDAPUtils.ACCOUNT_OBJECT_CLASS);
@@ -74,6 +73,8 @@ public class AccountImpl implements AccountDAO {
                 account.setCanonicalId(
                     entry.getAttribute(LDAPUtils.CANONICAL_ID)
                         .getStringValue());
+                account.setUidNo(entry.getAttribute(LDAPUtils.ACCOUNT_UID_NO)
+                                     .getStringValue());
             } catch (LDAPException ex) {
                 LOGGER.error("Failed to find account details."
                         + "of account id: " + accountID);
@@ -89,7 +90,8 @@ public class AccountImpl implements AccountDAO {
         throws DataAccessException {
         Account account = new Account();
 
-        String[] attrs = {LDAPUtils.ORGANIZATIONAL_NAME, LDAPUtils.ACCOUNT_ID};
+        String[] attrs = {LDAPUtils.ORGANIZATIONAL_NAME, LDAPUtils.ACCOUNT_ID,
+                          LDAPUtils.ACCOUNT_UID_NO};
         String filter = String.format("(&(%s=%s)(%s=%s))",
                 LDAPUtils.CANONICAL_ID, canonicalID, LDAPUtils.OBJECT_CLASS,
                 LDAPUtils.ACCOUNT_OBJECT_CLASS);
@@ -115,6 +117,8 @@ public class AccountImpl implements AccountDAO {
                         .getStringValue());
                 account.setId(
                     entry.getAttribute(LDAPUtils.ACCOUNT_ID).getStringValue());
+                account.setUidNo(entry.getAttribute(LDAPUtils.ACCOUNT_UID_NO)
+                                     .getStringValue());
             } catch (LDAPException ex) {
                 LOGGER.error("Failed to find account details."
                         + "of canonical id: " + canonicalID);
@@ -141,7 +145,8 @@ public class AccountImpl implements AccountDAO {
         String[] attrs = {
             LDAPUtils.ACCOUNT_ID,          LDAPUtils.CANONICAL_ID,
             LDAPUtils.PASSWORD,            LDAPUtils.PASSWORD_RESET_REQUIRED,
-            LDAPUtils.PROFILE_CREATE_DATE, LDAPUtils.EMAIL};
+            LDAPUtils.PROFILE_CREATE_DATE, LDAPUtils.EMAIL,
+            LDAPUtils.ACCOUNT_UID_NO};
         String filter = String.format("(&(%s=%s)(%s=%s))",
                 LDAPUtils.ORGANIZATIONAL_NAME, name, LDAPUtils.OBJECT_CLASS,
                 LDAPUtils.ACCOUNT_OBJECT_CLASS);
@@ -209,6 +214,8 @@ public class AccountImpl implements AccountDAO {
                 catch (Exception e) {
                   LOGGER.debug("profileCreateDate value not found in ldap");
                 }
+                account.setUidNo(entry.getAttribute(LDAPUtils.ACCOUNT_UID_NO)
+                                     .getStringValue());
           }
         }
         catch (LDAPException ex) {
@@ -224,7 +231,7 @@ public class AccountImpl implements AccountDAO {
     /*
      * fetch all accounts from database
      */
-    public Account[] findAll() throws DataAccessException {
+    @Override public Account[] findAll() throws DataAccessException {
        ArrayList<Account> accounts = new ArrayList<Account>();
         Account account;
         LDAPSearchResults ldapResults;
@@ -241,7 +248,8 @@ public class AccountImpl implements AccountDAO {
         String accountFilter = String.format("(%s=%s)", LDAPUtils.OBJECT_CLASS,
                                              LDAPUtils.ACCOUNT_OBJECT_CLASS);
         String[] attr = {LDAPUtils.ORGANIZATIONAL_NAME, LDAPUtils.ACCOUNT_ID,
-                         LDAPUtils.EMAIL,               LDAPUtils.CANONICAL_ID};
+                         LDAPUtils.EMAIL,               LDAPUtils.CANONICAL_ID,
+                         LDAPUtils.ACCOUNT_UID_NO};
 
         LOGGER.debug("Searching baseDn: " + baseDn + " account filter: " +
                      accountFilter);
@@ -286,6 +294,8 @@ public class AccountImpl implements AccountDAO {
             account.setCanonicalId(
                 ldapEntry.getAttribute(LDAPUtils.CANONICAL_ID)
                     .getStringValue());
+            account.setUidNo(ldapEntry.getAttribute(LDAPUtils.ACCOUNT_UID_NO)
+                                 .getStringValue());
             accounts.add(account);
             ++resultCount;
             if (resultCount >= maxAllowedLdapResults) {
@@ -327,6 +337,8 @@ public class AccountImpl implements AccountDAO {
             new LDAPAttribute(LDAPUtils.EMAIL, account.getEmail()));
         attributeSet.add(new LDAPAttribute(LDAPUtils.CANONICAL_ID,
                 account.getCanonicalId()));
+        attributeSet.add(
+            new LDAPAttribute(LDAPUtils.ACCOUNT_UID_NO, account.getUidNo()));
 
         LOGGER.debug("Saving account dn: " + dn);
 
@@ -369,8 +381,8 @@ public class AccountImpl implements AccountDAO {
      * The dn format: ou=<ou>,o=<account
      *name>,ou=accounts,dc=s3,dc=seagate,dc=com
      */
-   public
-    void deleteOu(Account account, String ou) throws DataAccessException {
+    @Override public void deleteOu(Account account,
+                                   String ou) throws DataAccessException {
       String dn = String.format(
           "%s=%s,%s=%s,%s=%s,%s", LDAPUtils.ORGANIZATIONAL_UNIT_NAME, ou,
           LDAPUtils.ORGANIZATIONAL_NAME, account.getName(),
@@ -506,8 +518,9 @@ public class AccountImpl implements AccountDAO {
       Account account = new Account();
       account.setEmail(emailAddress);
 
-      String[] attrs = {LDAPUtils.ORGANIZATIONAL_NAME, LDAPUtils.ACCOUNT_ID,
-                        LDAPUtils.CANONICAL_ID};
+      String[] attrs = {
+          LDAPUtils.ORGANIZATIONAL_NAME, LDAPUtils.ACCOUNT_ID,
+          LDAPUtils.CANONICAL_ID,        LDAPUtils.ACCOUNT_UID_NO};
       String filter =
           String.format("(&(%s=%s)(%s=%s))", LDAPUtils.EMAIL, emailAddress,
                         LDAPUtils.OBJECT_CLASS, LDAPUtils.ACCOUNT_OBJECT_CLASS);
@@ -534,6 +547,8 @@ public class AccountImpl implements AccountDAO {
                 entry.getAttribute(LDAPUtils.ACCOUNT_ID).getStringValue());
             account.setCanonicalId(
                 entry.getAttribute(LDAPUtils.CANONICAL_ID).getStringValue());
+            account.setUidNo(
+                entry.getAttribute(LDAPUtils.ACCOUNT_UID_NO).getStringValue());
           }
           catch (LDAPException ex) {
             LOGGER.error("Failed to find account details." +
@@ -551,8 +566,8 @@ public class AccountImpl implements AccountDAO {
      * Delete account entry silently from ldap.
      * if we get connection error then retry once.
      */
-   public
-    void ldap_delete_account(Account account) throws DataAccessException {
+    @Override public void ldap_delete_account(Account account)
+        throws DataAccessException {
       String dn =
           String.format("%s=%s,%s=accounts,%s", LDAPUtils.ORGANIZATIONAL_NAME,
                         account.getName(), LDAPUtils.ORGANIZATIONAL_UNIT_NAME,

--- a/auth/server/src/main/java/com/seagates3/dao/ldap/LDAPUtils.java
+++ b/auth/server/src/main/java/com/seagates3/dao/ldap/LDAPUtils.java
@@ -20,19 +20,19 @@
 
 package com.seagates3.dao.ldap;
 
-import java.util.ArrayList;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.novell.ldap.LDAPConnection;
 import com.novell.ldap.LDAPEntry;
 import com.novell.ldap.LDAPException;
 import com.novell.ldap.LDAPModification;
-import com.novell.ldap.LDAPSearchResults;
 import com.novell.ldap.LDAPSearchConstraints;
+import com.novell.ldap.LDAPSearchResults;
 import com.seagates3.authserver.AuthServerConfig;
 import com.seagates3.fi.FaultPoints;
 import com.seagates3.util.IEMUtil;
+import java.util.ArrayList;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public
 class LDAPUtils {
@@ -46,6 +46,8 @@ class LDAPUtils {
     public static final String ACCOUNT_OBJECT_CLASS = "account";
     public static final String ACCOUNT_OU = "accounts";
     public static final String CANONICAL_ID = "canonicalId";
+    public
+     static final String ACCOUNT_UID_NO = "uidNo";
     public static final String CERTIFICATE = "cacertificate;binary";
     public static final String COMMON_NAME = "cn";
     public static final String CREATE_TIMESTAMP = "createtimestamp";

--- a/auth/server/src/main/java/com/seagates3/model/Account.java
+++ b/auth/server/src/main/java/com/seagates3/model/Account.java
@@ -32,6 +32,8 @@ public class Account {
      String profileCreateDate;
     private
      String pwdResetRequired;
+    private
+     String uidNo;
 
     public String getId() {
         return id;
@@ -88,4 +90,10 @@ public class Account {
 
     public
      String getPwdResetRequired() { return pwdResetRequired; }
+
+    public
+     String getUidNo() { return uidNo; }
+
+    public
+     void setUidNo(String uidNo) { this.uidNo = uidNo; }
 }

--- a/auth/server/src/main/java/com/seagates3/util/KeyGenUtil.java
+++ b/auth/server/src/main/java/com/seagates3/util/KeyGenUtil.java
@@ -20,12 +20,12 @@
 
 package com.seagates3.util;
 
+import com.seagates3.authserver.AuthServerConstants;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.Random;
-import com.seagates3.authserver.AuthServerConstants;
 
 public class KeyGenUtil {
 
@@ -201,5 +201,21 @@ public class KeyGenUtil {
       long min = 100000000000L;
       long account_id = min + (long)(Math.random() * ((max - min) + 1));
       return String.valueOf(account_id);
+    }
+
+    /**
+     * Generate a new uidNo for account.
+     * uidNo should be,
+     * 1. Contains digits only
+     * 2. number should be greater than 1000
+     * e.g 2232
+     * @return uidNo
+     */
+   public
+    static String createAccountuidNo() {
+      long max = 9999L;
+      long min = 1000L;
+      long account_uidNo = min + (long)(Math.random() * ((max - min) + 1));
+      return String.valueOf(account_uidNo);
     }
 }

--- a/auth/server/src/test/java/com/seagates3/controller/AccountControllerTest.java
+++ b/auth/server/src/test/java/com/seagates3/controller/AccountControllerTest.java
@@ -121,6 +121,8 @@ import io.netty.handler.codec.http.HttpResponseStatus;
             .when(AuthServerConfig.class, "getS3InternalAccounts");
         PowerMockito.doReturn(1000)
             .when(AuthServerConfig.class, "getMaxAccountLimit");
+        PowerMockito.doReturn("1234")
+            .when(KeyGenUtil.class, "createAccountuidNo");
     }
 
     @Test
@@ -274,6 +276,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
             throws Exception {
         Account account = new Account();
         account.setName("s3test");
+        account.setUidNo("1234");
 
         Mockito.doReturn(account).when(accountDAO).find("s3test");
         Mockito.doReturn(new Account[0]).when(accountDAO).findAll();
@@ -282,6 +285,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
             .save(account);
         Mockito.doReturn(new Account()).when(accountDAO).findByCanonicalID(
             "can1234");
+        Mockito.doReturn(new Account()).when(accountDAO).findByUidNo("1234");
 
         final String expectedResponseBody =
             "<?xml version=\"1.0\" " +
@@ -311,6 +315,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
                 .when(userDAO).save(any(User.class));
         Mockito.doReturn(new Account()).when(accountDAO).findByCanonicalID(
             "can1234");
+        Mockito.doReturn(new Account()).when(accountDAO).findByUidNo("1234");
 
         final String expectedResponseBody =
             "<?xml version=\"1.0\" " +
@@ -343,6 +348,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
             .save(any(AccessKey.class));
         Mockito.doReturn(new Account()).when(accountDAO).findByCanonicalID(
             "can1234");
+        Mockito.doReturn(new Account()).when(accountDAO).findByUidNo("1234");
 
         final String expectedResponseBody =
             "<?xml version=\"1.0\" " +
@@ -381,6 +387,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
             any(String.class), any(String.class), any(String.class));
         Mockito.doReturn(new Account()).when(accountDAO).findByCanonicalID(
             "can1234");
+        Mockito.doReturn(new Account()).when(accountDAO).findByUidNo("1234");
 
         final String expectedResponseBody =
             "<?xml version=\"1.0\" " +
@@ -458,6 +465,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
           any(String.class), any(String.class), any(String.class));
       Mockito.doReturn(new Account()).when(accountDAO).findByCanonicalID(
           "can1234");
+      Mockito.doReturn(new Account()).when(accountDAO).findByUidNo("1234");
 
       final String expectedResponseBody =
           "<?xml version=\"1.0\" " + "encoding=\"UTF-8\" standalone=\"no\"?>" +

--- a/auth/server/src/test/java/com/seagates3/dao/ldap/AccountImplTest.java
+++ b/auth/server/src/test/java/com/seagates3/dao/ldap/AccountImplTest.java
@@ -481,6 +481,46 @@ import com.seagates3.model.Account;
         accountImpl.findByCanonicalID("C12345");
     }
 
+    @Test public void FindAccountByUidNo_AccountExists_ReturnAccountObject()
+        throws Exception {
+      Account expectedAccount = new Account();
+      expectedAccount.setName("s3test");
+      expectedAccount.setId("98765test");
+      expectedAccount.setCanonicalId("C12345");
+      expectedAccount.setEmail("test@seagate.com");
+      expectedAccount.setUidNo("1234");
+
+      String[] attrs = {LDAPUtils.ORGANIZATIONAL_NAME, LDAPUtils.ACCOUNT_ID};
+      String filter =
+          String.format("(&(%s=%s)(%s=%s))", LDAPUtils.ACCOUNT_UID_NO, "1234",
+                        LDAPUtils.OBJECT_CLASS, LDAPUtils.ACCOUNT_OBJECT_CLASS);
+
+      PowerMockito.doReturn(ldapResults)
+          .when(LDAPUtils.class, "search", BASE_DN, 2, filter, attrs);
+
+      Mockito.when(ldapResults.hasMore()).thenReturn(Boolean.TRUE);
+
+      Account account = accountImpl.findByUidNo("1234");
+      Assert.assertThat(account, new ReflectionEquals(account));
+    }
+
+    @Test(
+        expected =
+            DataAccessException
+                .class) public void FindAccountByUidNo_ShouldThrowLDAPException()
+        throws Exception {
+      String[] attrs = {LDAPUtils.ORGANIZATIONAL_NAME, LDAPUtils.ACCOUNT_ID,
+                        LDAPUtils.ACCOUNT_UID_NO};
+      String filter =
+          String.format("(&(%s=%s)(%s=%s))", LDAPUtils.ACCOUNT_UID_NO, "1234",
+                        LDAPUtils.OBJECT_CLASS, LDAPUtils.ACCOUNT_OBJECT_CLASS);
+
+      PowerMockito.doThrow(new LDAPException())
+          .when(LDAPUtils.class, "search", BASE_DN, 2, filter, attrs);
+
+      accountImpl.findByUidNo("1234");
+    }
+
     @Test
     public void DeleteAccount_DeleteAccountSuccessful()
             throws DataAccessException, LDAPException {

--- a/s3backgrounddelete/s3backgrounddelete/config/s3_background_delete_config.yaml.sample
+++ b/s3backgrounddelete/s3backgrounddelete/config/s3_background_delete_config.yaml.sample
@@ -75,5 +75,6 @@ background_delete_account:
    canonical_id: "C67891"                                     #BG delete account canonical id
    mail: "s3-background-delete-svc@seagate.com"               #BG delete account mail
    s3_user_id: "450"                                          #BG delete account user id
+   uidNo: "1230"                                              #BG delete account uidNo
    const_cipher_secret_str: "s3backgroundsecretkey"           #BG delete account secret key
    const_cipher_access_str: "s3backgroundaccesskey"           #BG delete account access key

--- a/s3backgrounddelete/s3backgrounddelete/config/s3_cluster_unsafe_attributes.yaml
+++ b/s3backgrounddelete/s3backgrounddelete/config/s3_cluster_unsafe_attributes.yaml
@@ -29,5 +29,6 @@ background_delete_account:
    canonical_id: "dummy123"
    mail: "dummy@dummy.com"
    s3_user_id: "dummy123"
+   uidNo: "dummy1230"
    const_cipher_secret_str: "dummy"
    const_cipher_access_str: "dummy"

--- a/scripts/ldap/cn={1}s3user.ldif
+++ b/scripts/ldap/cn={1}s3user.ldif
@@ -81,7 +81,7 @@ olcAttributeTypes: {24}( 1.3.6.1.4.99999.2.3.25 NAME 'profileCreateDate' DES
  C 'Login profile create Timestamp' SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 )
 olcAttributeTypes: {25}( 1.3.6.1.4.99999.2.3.26 NAME 'arn' DESC 'Resource Name
  s' EQUALITY caseExactMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
-olcAttributeTypes: {26}( 1.3.6.1.4.99999.2.3.26 NAME 'uidNo' DESC 'S3 Accoun
+olcAttributeTypes: {26}( 1.3.6.1.4.99999.2.3.27 NAME 'uidNo' DESC 'S3 Accoun
  t unique ID' EQUALITY caseExactMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 olcObjectClasses: {0}( 1.3.6.1.4.99999.2.4.1 NAME 'Account' DESC 'S3 Account'
  SUP top STRUCTURAL MUST ( o $ accountId $ mail $ canonicalId ) MAY ( userPass

--- a/scripts/ldap/cn={1}s3user.ldif
+++ b/scripts/ldap/cn={1}s3user.ldif
@@ -81,9 +81,11 @@ olcAttributeTypes: {24}( 1.3.6.1.4.99999.2.3.25 NAME 'profileCreateDate' DES
  C 'Login profile create Timestamp' SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 )
 olcAttributeTypes: {25}( 1.3.6.1.4.99999.2.3.26 NAME 'arn' DESC 'Resource Name
  s' EQUALITY caseExactMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: {26}( 1.3.6.1.4.99999.2.3.26 NAME 'uidNo' DESC 'S3 Accoun
+ t unique ID' EQUALITY caseExactMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 olcObjectClasses: {0}( 1.3.6.1.4.99999.2.4.1 NAME 'Account' DESC 'S3 Account'
  SUP top STRUCTURAL MUST ( o $ accountId $ mail $ canonicalId ) MAY ( userPass
- word $ profileCreateDate ) )
+ word $ profileCreateDate $ uidNo ) )
 olcObjectClasses: {1}( 1.3.6.1.4.99999.2.4.2 NAME 'iamUser' DESC 'S3 User' SUP
   top STRUCTURAL MUST ( cn $ s3userId ) MAY ( userPassword $ path $ inlinePoli
  cy $ policyId $ profileCreateDate $ arn ) )

--- a/scripts/ldap/create_account_using_cipher.py
+++ b/scripts/ldap/create_account_using_cipher.py
@@ -31,7 +31,7 @@ from s3confstore.cortx_s3_confstore import S3CortxConfStore
 # supported ldap action and input params dict
 opfileconfstore = S3CortxConfStore('yaml:///opt/seagate/cortx/s3/s3backgrounddelete/config.yaml', 'read_bg_delete_config_idx')
 
-param_list = ['account_name', 'account_id', 'canonical_id', 'mail', 's3_user_id', 'const_cipher_secret_str', 'const_cipher_access_str']
+param_list = ['account_name', 'account_id', 'canonical_id', 'mail', 's3_user_id', 'uidNo', 'const_cipher_secret_str', 'const_cipher_access_str']
 bgdelete_acc_input_params_dict = {}
 for param in param_list:
     key = 'background_delete_account' + '>' + param

--- a/scripts/ldap/create_replication_account.ldif
+++ b/scripts/ldap/create_replication_account.ldif
@@ -22,3 +22,4 @@ accountid: 78981
 objectclass: Account
 mail: replication-account@seagate.com
 canonicalId: C78981
+uidNo: 1235

--- a/scripts/ldap/ldapaccountaction.py
+++ b/scripts/ldap/ldapaccountaction.py
@@ -101,6 +101,7 @@ class LdapAccountAction:
     attrs['accountid'] = [input_params['account_id'].encode('utf-8')]
     attrs['mail'] = [input_params['mail'].encode('utf-8')]
     attrs['canonicalId'] = [input_params['canonical_id'].encode('utf-8')]
+    attrs['uidNo'] = [input_params['uidNo'].encode('utf-8')]
 
     dn = dn.format(input_params['account_name'])
 

--- a/scripts/ldap/s3user.schema
+++ b/scripts/ldap/s3user.schema
@@ -139,11 +139,17 @@ attributetype (1.3.6.1.4.99999.2.3.24
   EQUALITY caseExactMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 
+attributetype ( 1.3.6.1.4.99999.2.3.25
+  NAME 'uidNo'
+  DESC 'unique ID of S3 Account'
+  EQUALITY caseExactMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
 objectclass ( 1.3.6.1.4.99999.2.4.1 NAME 'Account'
   DESC 'S3 Account'
   SUP top STRUCTURAL
   MUST ( o $ accountId $ mail $ canonicalId )
-  MAY ( userPassword ) )
+  MAY ( userPassword  $ uidNo ) )
 
 objectclass ( 1.3.6.1.4.99999.2.4.2 NAME 'iamUser'
   DESC 'S3 User'

--- a/scripts/ldap/test_data.ldif
+++ b/scripts/ldap/test_data.ldif
@@ -22,6 +22,7 @@ accountid: 1234567
 objectclass: Account
 mail: s3_test3@seagate.com
 canonicalId: C1234567
+uidNo: 12345
 
 dn: ou=users,o=s3_test3,ou=accounts,dc=s3,dc=seagate,dc=com
 ou: users

--- a/scripts/ldap/test_data.ldif
+++ b/scripts/ldap/test_data.ldif
@@ -22,7 +22,7 @@ accountid: 1234567
 objectclass: Account
 mail: s3_test3@seagate.com
 canonicalId: C1234567
-uidNo: 12345
+uidNo: 1234
 
 dn: ou=users,o=s3_test3,ou=accounts,dc=s3,dc=seagate,dc=com
 ou: users

--- a/scripts/provisioning/setupcmd.py
+++ b/scripts/provisioning/setupcmd.py
@@ -584,7 +584,7 @@ class SetupCmd(object):
     """To get the config parameters required in init and reset phase."""
     opfileconfstore = S3CortxConfStore(f'yaml://{self.BG_delete_config_file}', 'read_bg_delete_config_idx')
 
-    param_list = ['account_name', 'account_id', 'canonical_id', 'mail', 's3_user_id', 'const_cipher_secret_str', 'const_cipher_access_str']
+    param_list = ['account_name', 'account_id', 'canonical_id', 'mail', 's3_user_id', 'uidNo', 'const_cipher_secret_str', 'const_cipher_access_str']
     bgdelete_acc_input_params_dict = {}
     for param in param_list:
         key = 'background_delete_account' + '>' + param

--- a/st/clitests/s3_background_delete_config_test.yaml
+++ b/st/clitests/s3_background_delete_config_test.yaml
@@ -73,5 +73,6 @@ background_delete_account:
    canonical_id: "C67891"                                     #BG delete account canonical id
    mail: "s3-background-delete-svc@seagate.com"               #BG delete account mail
    s3_user_id: "450"                                          #BG delete account user id
+   uidNo: "1230"                                              #BG delete account uidNo
    const_cipher_secret_str: "s3backgroundsecretkey"           #BG delete account secret key
    const_cipher_access_str: "s3backgroundaccesskey"           #BG delete account access key

--- a/st/clitests/test_data/create_test_data.ldif
+++ b/st/clitests/test_data/create_test_data.ldif
@@ -35,6 +35,7 @@ accountid: 12345
 objectclass: Account
 mail: test@seagate.com
 canonicalId: C12345
+uidNo: 1322
 
 dn: ou=users,o=s3_test,ou=accounts,dc=s3,dc=seagate,dc=com
 ou: users


### PR DESCRIPTION
This change is required to enable cortx PAM module.
For more reference pls check below confluence page 
https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/512033346/PAM+authentication+integration+with+s3+openLDAP+server
JIRA : https://jts.seagate.com/browse/EOS-22134
Specifications for uidNo value:
 1) Value should be numeric
 2) Value range : 1000-9999

ldap schema example :
![image](https://user-images.githubusercontent.com/65209830/126508499-cc978628-9b86-4ff2-81c8-4ddeb952c773.png)


Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>