### PR TITLE
avoid the unrelesed lock after the method returns for issue#1037

### DIFF
--- a/mempool/s3_memory_pool.c
+++ b/mempool/s3_memory_pool.c
@@ -540,6 +540,9 @@ int mempool_destroy(MemoryPoolHandle *handle) {
   }
 
   if (*handle == NULL) {
+    if ((pool->flags & ENABLE_LOCKING) != 0) {
+      pthread_mutex_unlock(&pool->lock);
+    }
     return S3_MEMPOOL_INVALID_ARG;
   }
 


### PR DESCRIPTION
Update s3_memory_pool.c. Avoid the unreleased lock pool->lock after the method returns. This patch for issue#1037.