### PR TITLE
EOS-21164: All Motr object operations must supply PVID & LID

### DIFF
--- a/server/s3_motr_kvs_writer.cc
+++ b/server/s3_motr_kvs_writer.cc
@@ -138,7 +138,13 @@ void S3MotrKVSWriter::create_index_with_oid(
 
   s3_motr_api->motr_idx_init(idx_ctx->idx, &motr_uber_realm, &idx_oid);
   idx_ctx->n_initialized_contexts = 1;
-
+  // Caller(S3) will save pv id and other attributes retuned by entity create
+  // API
+  // Note:
+  // M0_ENF_META flag is not passed during S3 global index creation. As a
+  // result, Motr fallback to older model of storing pv id
+  // and other attributes for S3 global indices.
+  idx_ctx->idx[0].in_entity.en_flags |= M0_ENF_META;
   int rc = s3_motr_api->motr_entity_create(&(idx_ctx->idx[0].in_entity),
                                            &(idx_op_ctx->ops[0]));
   if (rc != 0) {

--- a/server/s3_motr_writer.h
+++ b/server/s3_motr_writer.h
@@ -208,7 +208,7 @@ class S3MotrWiter {
   virtual void delete_object(std::function<void(void)> on_success,
                              std::function<void(void)> on_failed,
                              const struct m0_uint128& object_id, int layoutid,
-                             const struct m0_fid& pv_id = {});  // BG delete
+                             const struct m0_fid& pv_id);  // BG delete
 
   virtual void delete_objects(std::vector<struct m0_uint128> oids,
                               std::vector<int> layoutids,

--- a/server/s3_object_metadata.h
+++ b/server/s3_object_metadata.h
@@ -240,7 +240,7 @@ class S3ObjectMetadata : private S3ObjectMetadataCopyable {
   std::string& get_encoded_object_acl();
   std::string get_acl_as_xml();
 
-  struct m0_fid get_pvid() const;
+  virtual struct m0_fid get_pvid() const;
   void set_pvid(const struct m0_fid* p_pvid);
 
   const std::string& get_pvid_str() const { return pvid_str; }

--- a/server/s3_post_complete_action.cc
+++ b/server/s3_post_complete_action.cc
@@ -233,6 +233,7 @@ void S3PostCompleteAction::fetch_multipart_info_success() {
   old_layout_id = multipart_metadata->get_old_layout_id();
   new_object_oid = multipart_metadata->get_oid();
   layout_id = multipart_metadata->get_layout_id();
+  new_pvid = multipart_metadata->get_pvid();
 
   if (old_object_oid.u_hi != 0ULL || old_object_oid.u_lo != 0ULL) {
     old_oid_str = S3M0Uint128Helper::to_string(old_object_oid);
@@ -492,6 +493,7 @@ void S3PostCompleteAction::add_object_oid_to_probable_dead_oid_list() {
 
   new_object_metadata->set_oid(new_object_oid);
   new_object_metadata->set_layout_id(layout_id);
+  new_object_metadata->set_pvid(&new_pvid);
   // Generate version id for the new obj as it will become live to s3 clients.
   new_object_metadata->regenerate_version_id();
 
@@ -936,7 +938,7 @@ void S3PostCompleteAction::delete_old_object() {
       std::bind(&S3PostCompleteAction::remove_old_object_version_metadata,
                 this),
       std::bind(&S3PostCompleteAction::next, this), old_object_oid,
-      old_layout_id, multipart_metadata->get_pvid());
+      old_layout_id, object_metadata->get_pvid());
 
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
@@ -1007,7 +1009,8 @@ void S3PostCompleteAction::delete_new_object() {
   }
   motr_writer->delete_object(
       std::bind(&S3PostCompleteAction::remove_new_oid_probable_record, this),
-      std::bind(&S3PostCompleteAction::next, this), new_object_oid, layout_id);
+      std::bind(&S3PostCompleteAction::next, this), new_object_oid, layout_id,
+      multipart_metadata->get_pvid());
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 

--- a/server/s3_post_complete_action.h
+++ b/server/s3_post_complete_action.h
@@ -81,6 +81,7 @@ class S3PostCompleteAction : public S3ObjectAction {
   struct m0_uint128 old_object_oid;
   int old_layout_id;
   struct m0_uint128 new_object_oid;
+  struct m0_fid new_pvid;
   int layout_id;
 
   // Probable delete record for old object OID in case of overwrite

--- a/server/s3_put_chunk_upload_object_action.cc
+++ b/server/s3_put_chunk_upload_object_action.cc
@@ -364,6 +364,7 @@ void S3PutChunkUploadObjectAction::create_object_successful() {
   new_object_metadata->regenerate_version_id();
   new_object_metadata->set_oid(motr_writer->get_oid());
   new_object_metadata->set_layout_id(layout_id);
+  new_object_metadata->set_pvid(motr_writer->get_ppvid());
 
   add_object_oid_to_probable_dead_oid_list();
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
@@ -663,7 +664,6 @@ void S3PutChunkUploadObjectAction::save_metadata() {
   new_object_metadata->set_content_type(request->get_content_type());
   new_object_metadata->set_md5(motr_writer->get_content_md5());
   new_object_metadata->set_tags(new_object_tags_map);
-  new_object_metadata->set_pvid(motr_writer->get_ppvid());
 
   for (auto it : request->get_in_headers_copy()) {
     if (it.first.find("x-amz-meta-") != std::string::npos) {
@@ -1025,7 +1025,7 @@ void S3PutChunkUploadObjectAction::delete_new_object() {
       std::bind(&S3PutChunkUploadObjectAction::remove_new_oid_probable_record,
                 this),
       std::bind(&S3PutChunkUploadObjectAction::next, this), new_object_oid,
-      layout_id);
+      layout_id, new_object_metadata->get_pvid());
 
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }

--- a/server/s3_put_object_action.cc
+++ b/server/s3_put_object_action.cc
@@ -936,7 +936,8 @@ void S3PutObjectAction::delete_new_object() {
 
   motr_writer->delete_object(
       std::bind(&S3PutObjectAction::remove_new_oid_probable_record, this),
-      std::bind(&S3PutObjectAction::next, this), new_object_oid, layout_id);
+      std::bind(&S3PutObjectAction::next, this), new_object_oid, layout_id,
+      new_object_metadata->get_pvid());
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 

--- a/server/s3_put_object_action_base.cc
+++ b/server/s3_put_object_action_base.cc
@@ -262,6 +262,7 @@ void S3PutObjectActionBase::create_object_successful() {
   new_object_metadata->regenerate_version_id();
   new_object_metadata->set_oid(motr_writer->get_oid());
   new_object_metadata->set_layout_id(layout_id);
+  new_object_metadata->set_pvid(motr_writer->get_ppvid());
 
   add_object_oid_to_probable_dead_oid_list();
   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
@@ -564,7 +565,8 @@ void S3PutObjectActionBase::delete_new_object() {
 
   motr_writer->delete_object(
       std::bind(&S3PutObjectActionBase::remove_new_oid_probable_record, this),
-      std::bind(&S3PutObjectActionBase::next, this), new_object_oid, layout_id);
+      std::bind(&S3PutObjectActionBase::next, this), new_object_oid, layout_id,
+      new_object_metadata->get_pvid());
 
   s3_log(S3_LOG_DEBUG, "", "Exiting\n");
 }

--- a/server/s3server.cc
+++ b/server/s3server.cc
@@ -597,8 +597,14 @@ int create_global_index(struct s3_motr_idx_layout &idx_lo,
     s3_iem(LOG_ALERT, S3_IEM_MOTR_CONN_FAIL, S3_IEM_MOTR_CONN_FAIL_STR,
            S3_IEM_MOTR_CONN_FAIL_JSON);
   } else {
-    idx_lo.pver = idx.in_attr.idx_pver;
-    idx_lo.layout_type = idx.in_attr.idx_layout_type;
+    // Store pv id and layout type only if flag 'M0_ENF_META' is set.
+    if (idx.in_entity.en_flags & M0_ENF_META) {
+      idx_lo.pver = idx.in_attr.idx_pver;
+      idx_lo.layout_type = idx.in_attr.idx_layout_type;
+    } else {
+      idx_lo.pver.f_container = idx_lo.pver.f_key = 0;
+      idx_lo.layout_type = 0;
+    }
   }
   return rc;
 }

--- a/third_party/build_motr.sh
+++ b/third_party/build_motr.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -xe
 # Script to build motr.
 # github repo: https://github.com/Seagate/cortx-motr
-# branch: master commit: 70701eea1dd1e20fd7c6bdc5bdd1203795d09958
+# branch: master commit: 2ca587c61fdbd2b2b71c79ab0ebd8761e496f3ab
 
 cd motr
 # Uncomment following line to compile motr with both KVS and Cassandra

--- a/ut/mock_s3_object_metadata.h
+++ b/ut/mock_s3_object_metadata.h
@@ -41,6 +41,7 @@ class MockS3ObjectMetadata : public S3ObjectMetadata {
   MOCK_METHOD0(get_version_key_in_index, std::string());
   MOCK_METHOD0(get_oid, struct m0_uint128());
   MOCK_METHOD0(get_layout_id, int());
+  MOCK_METHOD0(get_pvid, struct m0_fid());
   MOCK_METHOD1(set_oid, void(struct m0_uint128));
   MOCK_METHOD1(set_md5, void(std::string));
   MOCK_METHOD0(reset_date_time_to_current, void());

--- a/ut/mock_s3_object_multipart_metadata.h
+++ b/ut/mock_s3_object_multipart_metadata.h
@@ -46,6 +46,7 @@ class MockS3ObjectMultipartMetadata : public S3ObjectMetadata {
   MOCK_METHOD0(get_part_one_size, size_t());
   MOCK_METHOD1(set_part_one_size, void(size_t part_size));
   MOCK_METHOD0(get_layout_id, int());
+  MOCK_METHOD0(get_pvid, struct m0_fid());
   MOCK_METHOD2(load, void(std::function<void(void)> on_success,
                           std::function<void(void)> on_failed));
   MOCK_METHOD2(save, void(std::function<void(void)> on_success,

--- a/ut/s3_motr_writer_test.cc
+++ b/ut/s3_motr_writer_test.cc
@@ -259,7 +259,7 @@ TEST_F(S3MotrWiterTest, DeleteObjectSuccessfulTest) {
   motr_writer_ptr->delete_object(
       std::bind(&S3CallBack::on_success, &S3MotrWiter_callbackobj),
       std::bind(&S3CallBack::on_failed, &S3MotrWiter_callbackobj), obj_oid,
-      layout_id);
+      layout_id, pv_id);
 
   EXPECT_TRUE(S3MotrWiter_callbackobj.success_called);
   EXPECT_FALSE(S3MotrWiter_callbackobj.fail_called);
@@ -285,7 +285,7 @@ TEST_F(S3MotrWiterTest, DeleteObjectFailedTest) {
   motr_writer_ptr->delete_object(
       std::bind(&S3CallBack::on_success, &S3MotrWiter_callbackobj),
       std::bind(&S3CallBack::on_failed, &S3MotrWiter_callbackobj), obj_oid,
-      layout_id);
+      layout_id, pv_id);
 
   EXPECT_FALSE(S3MotrWiter_callbackobj.success_called);
   EXPECT_TRUE(S3MotrWiter_callbackobj.fail_called);

--- a/ut/s3_post_complete_action_test.cc
+++ b/ut/s3_post_complete_action_test.cc
@@ -659,7 +659,9 @@ TEST_F(S3PostCompleteActionTest, SendResponseToClientSuccess) {
 TEST_F(S3PostCompleteActionTest, DeleteNewObject) {
   CREATE_WRITER_OBJ;
   CREATE_MP_METADATA_OBJ;
-
+  struct m0_fid pv_id = {0x7810203002040bfe, 0x19be102030405060};
+  EXPECT_CALL(*(object_mp_meta_factory->mock_object_mp_metadata), get_pvid())
+      .WillRepeatedly(Return(pv_id));
   action_under_test_ptr->new_object_oid = oid;
   action_under_test_ptr->layout_id = layout_id;
   action_under_test_ptr->set_abort_multipart(true);
@@ -673,15 +675,18 @@ TEST_F(S3PostCompleteActionTest, DeleteNewObject) {
 TEST_F(S3PostCompleteActionTest, DeleteOldObject) {
   CREATE_WRITER_OBJ;
   CREATE_MP_METADATA_OBJ;
+  CREATE_METADATA_OBJ;
 
   S3Option::get_instance()->set_s3server_obj_delayed_del_enabled(false);
 
   m0_uint128 old_object_oid = {0x1ffff, 0x1ffff};
   int old_layout_id = 2;
+  struct m0_fid pv_id = {0x7810203002040bfe, 0x19be102030405060};
   action_under_test_ptr->old_object_oid = old_object_oid;
   action_under_test_ptr->old_layout_id = old_layout_id;
   action_under_test_ptr->set_abort_multipart(true);
-
+  EXPECT_CALL(*(object_meta_factory->mock_object_metadata), get_pvid())
+      .WillRepeatedly(Return(pv_id));
   EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
               delete_object(_, _, _, old_layout_id, _)).Times(AtLeast(1));
 
@@ -696,10 +701,13 @@ TEST_F(S3PostCompleteActionTest, DelayedDeleteOldObject) {
 
   m0_uint128 old_object_oid = {0x1ffff, 0x1ffff};
   int old_layout_id = 2;
+  struct m0_fid pv_id = {0x7810203002040bfe, 0x19be102030405060};
   action_under_test_ptr->old_object_oid = old_object_oid;
   action_under_test_ptr->old_layout_id = old_layout_id;
   action_under_test_ptr->set_abort_multipart(true);
 
+  EXPECT_CALL(*(object_meta_factory->mock_object_metadata), get_pvid())
+      .WillRepeatedly(Return(pv_id));
   EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
               delete_object(_, _, _, old_layout_id, _)).Times(0);
 
@@ -740,6 +748,7 @@ TEST_F(S3PostCompleteActionTest, StartCleanupAbortedSinceValidationFailed) {
   std::string object_name = "abcd";
   std::string version_key_in_index = "abcd/v1";
   int layout_id = 9;
+  struct m0_fid pv_id = {0x7810203002040bfe, 0x19be102030405060};
   struct m0_uint128 object_list_indx_oid = {0x11ffff, 0x1ffff};
   struct m0_uint128 objects_version_list_index_oid = {0x1ff1ff, 0x1ffff};
   struct m0_uint128 oid = {0x1ffff, 0x1ffff};
@@ -753,6 +762,8 @@ TEST_F(S3PostCompleteActionTest, StartCleanupAbortedSinceValidationFailed) {
           object_list_indx_oid, objects_version_list_index_oid,
           version_key_in_index, false /* force_delete */));
   action_under_test_ptr->set_abort_multipart(true);
+  EXPECT_CALL(*(object_mp_meta_factory->mock_object_mp_metadata), get_pvid())
+      .WillRepeatedly(Return(pv_id));
   EXPECT_CALL(*(motr_kvs_writer_factory->mock_motr_kvs_writer),
               put_keyval(_, _, _, _, _))
       .Times(1)
@@ -764,7 +775,8 @@ TEST_F(S3PostCompleteActionTest, StartCleanupAbortedSinceValidationFailed) {
       .Times(1)
       .WillRepeatedly(
            Invoke(this, &S3PostCompleteActionTest::dummy_delete_object));
-
+  action_under_test_ptr->multipart_metadata =
+      object_mp_meta_factory->mock_object_mp_metadata;
   action_under_test_ptr->startcleanup();
   EXPECT_EQ(false, action_under_test_ptr->is_error_state());
   EXPECT_EQ(2, action_under_test_ptr->number_of_tasks());

--- a/ut/s3_post_multipartobject_action_test.cc
+++ b/ut/s3_post_multipartobject_action_test.cc
@@ -328,9 +328,14 @@ TEST_F(S3PostMultipartObjectTest, CreateNewOid) {
 }
 
 TEST_F(S3PostMultipartObjectTest, RollbackCreate) {
+  struct m0_fid pv_id = {0x7810203002040bfe, 0x19be102030405060};
+  action_under_test->object_multipart_metadata =
+      object_mp_meta_factory->mock_object_mp_metadata;
   action_under_test->motr_writer = motr_writer_factory->mock_motr_writer;
   EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
               delete_object(_, _, _, _, _)).Times(1);
+  EXPECT_CALL(*(object_mp_meta_factory->mock_object_mp_metadata), get_pvid())
+      .WillRepeatedly(Return(pv_id));
   action_under_test->rollback_create();
 }
 

--- a/ut/s3_put_chunk_upload_object_action_test.cc
+++ b/ut/s3_put_chunk_upload_object_action_test.cc
@@ -696,9 +696,12 @@ TEST_F(S3PutChunkUploadObjectActionTestNoAuth, DelayedDeleteOldObject) {
 
   m0_uint128 old_object_oid = {0x1ffff, 0x1ffff};
   int old_layout_id = 2;
+  struct m0_fid pv_id = {0x7810203002040bfe, 0x19be102030405060};
   action_under_test->old_object_oid = old_object_oid;
   action_under_test->old_layout_id = old_layout_id;
 
+  EXPECT_CALL(*(object_meta_factory->mock_object_metadata), get_pvid())
+      .WillRepeatedly(Return(pv_id));
   EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
               delete_object(_, _, _, old_layout_id, _)).Times(0);
 

--- a/ut/s3_put_object_action_test.cc
+++ b/ut/s3_put_object_action_test.cc
@@ -776,11 +776,15 @@ TEST_F(S3PutObjectActionTest, DelayedDeleteOldObject) {
 
   m0_uint128 old_object_oid = {0x1ffff, 0x1ffff};
   int old_layout_id = 2;
+  struct m0_fid pv_id = {0x7810203002040bfe, 0x19be102030405060};
+
   action_under_test->old_object_oid = old_object_oid;
   action_under_test->old_layout_id = old_layout_id;
 
   EXPECT_CALL(*(motr_writer_factory->mock_motr_writer),
               delete_object(_, _, _, old_layout_id, _)).Times(0);
+  EXPECT_CALL(*(object_meta_factory->mock_object_metadata), get_pvid())
+      .WillRepeatedly(Return(pv_id));
 
   action_under_test->clear_tasks();
   ACTION_TASK_ADD_OBJPTR(action_under_test,


### PR DESCRIPTION
 - S3server changes
 - S3ut changes
 - M0_ENF_META
 - Motr version raised to 2ca587c61fdbd2b2b71c79ab0ebd8761e496f3ab

Signed-off-by: Dattaprasad <dattaprasad.govekar@seagate.com>