### PR TITLE
[EOS-23091] PUT Refactoring changes.

### DIFF
--- a/server/s3_md5_hash.cc
+++ b/server/s3_md5_hash.cc
@@ -164,6 +164,9 @@ int MD5hash::Finalize() {
     return 0;
   }
   pi_bufvec.ov_vec.v_nr = 0;
+  // Function gets called in send_response_to_s3_client
+  // at this point i feel this is moot, since we have
+  // already written data to motr.
   if (!is_initialized) {
     status = s3_motr_api->motr_client_calculate_pi(
         (struct m0_generic_pi *)&s3_md5_inc_digest_pi, NULL, &pi_bufvec,

--- a/server/s3_motr_context.cc
+++ b/server/s3_motr_context.cc
@@ -283,7 +283,6 @@ int free_basic_rw_op_ctx(struct s3_motr_rw_op_context *ctx) {
   m0_indexvec_free(ctx->ext);
   free(ctx->ext);
   free(ctx->data);
-  m0_bufvec_free(ctx->attr);
   // reset v_nr, as we dont want to free ov_buf[*] in m0_bufvec_free()
   // s3_bufvec_free_aligned(ctx->data..) has freed it
   ctx->pi_bufvec->ov_vec.v_nr = 0;

--- a/server/s3_motr_writer.cc
+++ b/server/s3_motr_writer.cc
@@ -797,7 +797,7 @@ void S3MotrWiter::calc_pi_info(
              rc);
       // Should we stop here? what should we do?
     }
-    assert(rc != 0);
+    assert(rc == 0);
   } else {
     if (!(s3_checksum_flag & S3_SEED_UNIT) && is_s3_write_di_check_enabled) {
       s3_checksum_flag |= S3_SEED_UNIT;
@@ -812,7 +812,7 @@ void S3MotrWiter::calc_pi_info(
              rc);
       // Should we stop here? what should we do?
     }
-    assert(rc != 0);
+    assert(rc == 0);
   }
 
   if (!is_called_for_unaligned_buffers) {

--- a/server/s3_motr_writer.cc
+++ b/server/s3_motr_writer.cc
@@ -867,42 +867,45 @@ void S3MotrWiter::set_up_motr_data_buffers(struct s3_motr_rw_op_context *rw_ctx,
   s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   size_in_current_write = 0;
 
-  // Buffer index within given write command 
-  // For example say 5.3M write  - it will range from 0 to 64*5 +3 -1 assuming 16K write buffer size
+  // Buffer index within given write command
+  // For example say 5.3M write  - it will range from 0 to 64*5 +3 -1 assuming
+  // 16K write buffer size
   // Updated at every write buffer processing.
   size_t buf_idx = 0;
 
-  // Same as buf_idx - Difference is - it is updated only at motr size boundry 
+  // Same as buf_idx - Difference is - it is updated only at motr size boundry
   // (interval of 64 in above example)
   // It acts as marker for unaligned block.
   size_t unaligned_buf_idx_offset = 0;
 
   // Index of attr/PI info.
-  // For example say 5.3M write  - it will range from 0 to 5 (0 to 4 for 0 to 5M and 5 value for last 0.3M )
+  // For example say 5.3M write  - it will range from 0 to 5 (0 to 4 for 0 to 5M
+  // and 5 value for last 0.3M )
   // Updated at every checksum calculation.
   size_t chksum_buf_idx = 0;
 
   bool calculated_chksum_at_unit_boundary = false;
-  
-  // Byte offset of the last write (Before this write). 
+
+  // Byte offset of the last write (Before this write).
   // This will be progressed for current write as well in this function
   size_t saved_last_index = last_index;
 
-  //This is first write of a part 
+  // This is first write of a part
   bool initial_buffers_part_write = is_first_write_part_segment;
 
-  // It is buffer index within given given motr unit. 
-  // For every 1M write in process this will range from 0 to 63 assuming 16K write buffer size
+  // It is buffer index within given given motr unit.
+  // For every 1M write in process this will range from 0 to 63 assuming 16K
+  // write buffer size
   // and will be reset to 0 at motr unit boundry.
   // It will have < 63 value for last unaligned portion (if any)
   size_t starting_checksum_buf_idx = 0;
 
-  //Valid data length in buffer (<=16k)
+  // Valid data length in buffer (<=16k)
   size_t len_in_buf = 0;
 
   size_t number_of_unit_unaligned = 0;
   size_t last_data_buf_indx_for_pi = 0;
-	
+
   int s3_checksum_flag = 0;
 
   while (!buffer_sequence.empty()) {
@@ -913,19 +916,21 @@ void S3MotrWiter::set_up_motr_data_buffers(struct s3_motr_rw_op_context *rw_ctx,
     s3_log(S3_LOG_DEBUG, request_id, "To Motr: len(%zu) at last_index(%zu)\n",
            len_in_buf, (size_t)last_index);
 
-	// Append  One Read buffer (typically 16k) to motr data structures in rw_ctx
-	// Increment starting_checksum_buf_idx and buf_idx
+    // Append  One Read buffer (typically 16k) to motr data structures in rw_ctx
+    // Increment starting_checksum_buf_idx and buf_idx
     add_buffer_to_motr_structures(rw_ctx, ptr_n_len.first, buf_idx,
                                   starting_checksum_buf_idx, false);
 
     size_in_current_write += len_in_buf;
-	
-	// At motr unit boundry calculate PI info
-	// if 5.3Mb write payload (for a part or object) and 16k is write buffer size & 1M is motr unit size;
-	// Checksum will be called at every 1M offset interval (so 1M and 2M 3M... to write to motr 
-	// as well as for ETAG)
-	// We will fall through for last 0.3M
-  
+
+    // At motr unit boundry calculate PI info
+    // if 5.3Mb write payload (for a part or object) and 16k is write buffer
+    // size & 1M is motr unit size;
+    // Checksum will be called at every 1M offset interval (so 1M and 2M 3M...
+    // to write to motr
+    // as well as for ETAG)
+    // We will fall through for last 0.3M
+
     if (size_in_current_write % motr_unit_size == 0) {
       calc_pi_info(rw_ctx, saved_last_index, initial_buffers_part_write,
                    s3_checksum_flag, chksum_buf_idx, unaligned_buf_idx_offset,
@@ -936,23 +941,24 @@ void S3MotrWiter::set_up_motr_data_buffers(struct s3_motr_rw_op_context *rw_ctx,
     buffer_sequence.pop_front();
   }
 
-  // Number of unaligned write buffers calculated here for checksum / PI calculation.
+  // Number of unaligned write buffers calculated here for checksum / PI
+  // calculation.
   number_of_unit_unaligned = buf_idx - unaligned_buf_idx_offset;
   if (number_of_unit_unaligned != 0) {
     last_data_buf_indx_for_pi = starting_checksum_buf_idx - 1;
   }
 
   // Save current running checksum, as this will change after padding
-  // and its checksum calculation and we need 
+  // and its checksum calculation and we need
   // this twice (once for ETAG and once for writing to motr)
   if (s3_md5crypt->is_checksum_saved()) {
     s3_md5crypt->save_motr_unit_checksum_for_unaligned_bufs(
         (unsigned char *)s3_md5crypt->get_prev_write_checksum());
   }
 
-  // Placeholder buffer allocation for padding 	
+  // Placeholder buffer allocation for padding
   find_and_allocate_placeholder_for_data_alignment(buf_idx, motr_buf_count);
-  
+
   // Perform padding using above placeholder buffer
   align_data_to_motr_unit_size(rw_ctx, buf_idx, motr_buf_count,
                                starting_checksum_buf_idx);

--- a/server/s3_motr_writer.h
+++ b/server/s3_motr_writer.h
@@ -231,6 +231,25 @@ class S3MotrWiter {
   void set_up_motr_data_buffers(struct s3_motr_rw_op_context* rw_ctx,
                                 S3BufferSequence buffer_sequence,
                                 size_t motr_buf_count);
+  void align_data_to_motr_unit_size(struct s3_motr_rw_op_context *rw_ctx,
+                                    size_t &buf_idx, size_t &motr_buf_count,
+                                    size_t &starting_checksum_buf_idx);
+  void find_and_allocate_placeholder_for_data_alignment(size_t &buf_idx,
+                                                        size_t &motr_buf_count);
+  void calc_pi_info(struct s3_motr_rw_op_context *rw_ctx,
+                    size_t &saved_last_index, bool &initial_buffers_part_write,
+                    int &s3_checksum_flag, size_t &chksum_buf_idx,
+                    size_t &unaligned_buf_idx_offset, size_t &buf_idx,
+                    size_t &starting_checksum_buf_idx,
+                    bool &calculated_chksum_at_unit_boundary,
+                    bool reset_initial_buffers,
+                    bool is_called_for_unaligned_buffers,
+                    bool is_finalize_call);
+  void add_buffer_to_motr_structures(struct s3_motr_rw_op_context *rw_ctx,
+                                     void *pbuffer, size_t &buf_idx,
+                                     size_t &starting_checksum_buf_idx,
+                                     bool is_this_alignment_buffer);
+
   struct m0_fid* get_ppvid() const;
 
   // For Testing purpose


### PR DESCRIPTION
<details>
  <summary>Testing Done</summary>

> [root@ssc-vm-1453 testfiles]# s3cmd mb s3://seagatebucket
> motr[10641]:  a9f0  ERROR  [cas/service.c:1262:cas_fom_tick]  <! rc=-2
> motr[13646]:  9180  ERROR  [cas/client.c:1172:cas_req_replied_ast]  <! rc=-2
> Bucket 's3://seagatebucket/' created
> [root@ssc-vm-1453 testfiles]# ls
> total 223M
> -rw-r--r-- 1 root root 1.0K Jul 26 03:51 1kfile
> -rw-r--r-- 1 root root 2.0K Jul 26 03:51 2kfile
> -rw-r--r-- 1 root root 4.9K Jul 26 03:52 4kfile_unaligned
> -rw-r--r-- 1 root root 8.0K Jul 26 03:52 8kfile
> -rw-r--r-- 1 root root  16K Jul 26 03:52 16kfile
> -rw-r--r-- 1 root root  18K Jul 26 03:54 16kfile_unaligned
> -rw-r--r-- 1 root root  32K Jul 26 03:55 32kfile
> -rw-r--r-- 1 root root  33K Jul 26 03:55 32kfile_unaligned
> -rw-r--r-- 1 root root  64K Jul 26 03:56 64kfile
> -rw-r--r-- 1 root root  65K Jul 26 03:56 64kfile_unaligned
> -rw-r--r-- 1 root root 128K Jul 26 03:57 128kfile
> -rw-r--r-- 1 root root 129K Jul 26 03:57 128kfile_unaligned
> -rw-r--r-- 1 root root 1.0M Jul 26 03:58 1Mfile
> -rw-r--r-- 1 root root 1.1M Jul 26 03:58 1Mfile_unaligned
> -rw-r--r-- 1 root root  10M Jul 26 03:58 10Mfile
> -rw-r--r-- 1 root root  11M Jul 26 03:59 10Mfile_unaligned
> -rw-r--r-- 1 root root 100M Jul 26 03:59 100Mfile
> -rw-r--r-- 1 root root 101M Jul 26 03:59 100Mfile_unaligned
> [root@ssc-vm-1453 testfiles]# s3cmd put 1kfile s3://seagatebucket --max-retries=0
> upload: '1kfile' -> 's3://seagatebucket/1kfile'  [1 of 1]
>  1024 of 1024   100% in    0s   675.22 kB/smotr[10641]:  d9f0  ERROR  [cas/service.c:1262:cas_fom_tick]  <! rc=-2
> motr[13646]:  a180  ERROR  [cas/client.c:1172:cas_req_replied_ast]  <! rc=-2
>  1024 of 1024   100% in    0s     6.10 kB/s  done
> [root@ssc-vm-1453 testfiles]# s3cmd put 2kfile s3://seagatebucket --max-retries=0
> upload: '2kfile' -> 's3://seagatebucket/2kfile'  [1 of 1]
>  2024 of 2024   100% in    0s    13.90 kB/s  done
> [root@ssc-vm-1453 testfiles]# s3cmd put 4kfile_unaligned s3://seagatebucket --max-retries=0
> upload: '4kfile_unaligned' -> 's3://seagatebucket/4kfile_unaligned'  [1 of 1]
>  5000 of 5000   100% in    0s    27.15 kB/s  done
> [root@ssc-vm-1453 testfiles]# s3cmd put 8kfile s3://seagatebucket --max-retries=0
> upload: '8kfile' -> 's3://seagatebucket/8kfile'  [1 of 1]
>  8192 of 8192   100% in    0s    56.12 kB/s  done
> [root@ssc-vm-1453 testfiles]# s3cmd put 16kfile s3://seagatebucket --max-retries=0
> upload: '16kfile' -> 's3://seagatebucket/16kfile'  [1 of 1]
>  16384 of 16384   100% in    0s   135.98 kB/s  done
> [root@ssc-vm-1453 testfiles]# s3cmd put 16kfile_unaligned s3://seagatebucket --max-retries=0
> upload: '16kfile_unaligned' -> 's3://seagatebucket/16kfile_unaligned'  [1 of 1]
>  18000 of 18000   100% in    0s   115.56 kB/s  done
> [root@ssc-vm-1453 testfiles]# s3cmd put 32kfile s3://seagatebucket --max-retries=0
> upload: '32kfile' -> 's3://seagatebucket/32kfile'  [1 of 1]
>  32768 of 32768   100% in    0s   315.39 kB/s  done
> [root@ssc-vm-1453 testfiles]# s3cmd put 32kfile_unaligned s3://seagatebucket --max-retries=0
> upload: '32kfile_unaligned' -> 's3://seagatebucket/32kfile_unaligned'  [1 of 1]
>  33000 of 33000   100% in    0s   229.47 kB/s  done
> [root@ssc-vm-1453 testfiles]# s3cmd put 64kfile s3://seagatebucket --max-retries=0
> upload: '64kfile' -> 's3://seagatebucket/64kfile'  [1 of 1]
>  65536 of 65536   100% in    0s   467.86 kB/s  done
> [root@ssc-vm-1453 testfiles]# s3cmd put 64kfile_unaligned s3://seagatebucket --max-retries=0
> upload: '64kfile_unaligned' -> 's3://seagatebucket/64kfile_unaligned'  [1 of 1]
>  66000 of 66000   100% in    0s   411.26 kB/s  done
> [root@ssc-vm-1453 testfiles]# s3cmd put 128kfile s3://seagatebucket --max-retries=0
> upload: '128kfile' -> 's3://seagatebucket/128kfile'  [1 of 1]
>  131072 of 131072   100% in    0s  1151.03 kB/s  done
> [root@ssc-vm-1453 testfiles]# s3cmd put 128kfile_unaligned s3://seagatebucket --max-retries=0
> upload: '128kfile_unaligned' -> 's3://seagatebucket/128kfile_unaligned'  [1 of 1]
>  132072 of 132072   100% in    0s   740.98 kB/s  done
> [root@ssc-vm-1453 testfiles]# s3cmd put 1Mfile s3://seagatebucket --max-retries=0
> upload: '1Mfile' -> 's3://seagatebucket/1Mfile'  [1 of 1]
>  1048576 of 1048576   100% in    0s     3.99 MB/s  done
> [root@ssc-vm-1453 testfiles]# s3cmd put 1Mfile_unaligned s3://seagatebucket --max-retries=0
> upload: '1Mfile_unaligned' -> 's3://seagatebucket/1Mfile_unaligned'  [1 of 1]
>  1048600 of 1048600   100% in    0s     3.27 MB/s  done
> [root@ssc-vm-1453 testfiles]# s3cmd put 10Mfile s3://seagatebucket --max-retries=0
> motr[10641]:  19f0  ERROR  [cas/service.c:1262:cas_fom_tick]  <! rc=-2
> motr[13646]:  c180  ERROR  [cas/client.c:1172:cas_req_replied_ast]  <! rc=-2
> upload: '10Mfile' -> 's3://seagatebucket/10Mfile'  [part 1 of 2, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     7.32 MB/s  done
> upload: '10Mfile' -> 's3://seagatebucket/10Mfile'  [part 2 of 2, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     7.56 MB/s  done
> [root@ssc-vm-1453 testfiles]# s3cmd put 10Mfile_unaligned s3://seagatebucket --max-retries=0
> upload: '10Mfile_unaligned' -> 's3://seagatebucket/10Mfile_unaligned'  [part 1 of 3, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     7.12 MB/s  done
> upload: '10Mfile_unaligned' -> 's3://seagatebucket/10Mfile_unaligned'  [part 2 of 3, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.22 MB/s  done
> upload: '10Mfile_unaligned' -> 's3://seagatebucket/10Mfile_unaligned'  [part 3 of 3, 240B] [1 of 1]
>  240 of 240   100% in    0s  1897.94 B/s  done
> [root@ssc-vm-1453 testfiles]# s3cmd put 100Mfile s3://seagatebucket --max-retries=0
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 1 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     7.65 MB/s  done
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 2 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     7.62 MB/s  done
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 3 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     7.92 MB/s  done
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 4 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    1s     4.61 MB/s  done
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 5 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.20 MB/s  done
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 6 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     7.27 MB/s  done
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 7 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     7.74 MB/s  done
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 8 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     5.57 MB/s  done
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 9 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     7.68 MB/s  done
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 10 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.37 MB/s  done
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 11 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.58 MB/s  done
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 12 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.49 MB/s  done
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 13 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.68 MB/s  done
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 14 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.18 MB/s  done
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 15 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.54 MB/s  done
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 16 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.83 MB/s  done
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 17 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.87 MB/s  done
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 18 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.80 MB/s  done
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 19 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.75 MB/s  done
> upload: '100Mfile' -> 's3://seagatebucket/100Mfile'  [part 20 of 20, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.54 MB/s  done
> [root@ssc-vm-1453 testfiles]# s3cmd put 100Mfile_unaligned s3://seagatebucket --max-retries=0
> motr[10648]:  e9f0  ERROR  [cas/service.c:1262:cas_fom_tick]  <! rc=-2
> motr[13646]:   180  ERROR  [cas/client.c:1172:cas_req_replied_ast]  <! rc=-2
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 1 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.00 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 2 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     7.99 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 3 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.24 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 4 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.22 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 5 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.36 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 6 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.93 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 7 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.00 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 8 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.57 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 9 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.33 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 10 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.35 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 11 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.51 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 12 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     6.57 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 13 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     5.89 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 14 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     9.10 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 15 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     9.08 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 16 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.23 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 17 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     5.82 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 18 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.72 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 19 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.77 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 20 of 21, 5MB] [1 of 1]
>  5242880 of 5242880   100% in    0s     8.58 MB/s  done
> upload: '100Mfile_unaligned' -> 's3://seagatebucket/100Mfile_unaligned'  [part 21 of 21, 100B] [1 of 1]
>  100 of 100   100% in    0s   938.79 B/s  done
> [root@ssc-vm-1453 testfiles]# mkdir downloadfiles
> [root@ssc-vm-1453 testfiles]# cd downloadfiles/
> [root@ssc-vm-1453 downloadfiles]# s3cmd ls s3://seagatebucket
> 2021-07-26 10:07 104857600   s3://seagatebucket/100Mfile
> 2021-07-26 10:07 104857700   s3://seagatebucket/100Mfile_unaligned
> 2021-07-26 10:06  10485760   s3://seagatebucket/10Mfile
> 2021-07-26 10:06  10486000   s3://seagatebucket/10Mfile_unaligned
> 2021-07-26 10:05    131072   s3://seagatebucket/128kfile
> 2021-07-26 10:05    132072   s3://seagatebucket/128kfile_unaligned
> 2021-07-26 10:04     16384   s3://seagatebucket/16kfile
> 2021-07-26 10:04     18000   s3://seagatebucket/16kfile_unaligned
> 2021-07-26 10:06   1048576   s3://seagatebucket/1Mfile
> 2021-07-26 10:06   1048600   s3://seagatebucket/1Mfile_unaligned
> 2021-07-26 10:02      1024   s3://seagatebucket/1kfile
> 2021-07-26 10:02      2024   s3://seagatebucket/2kfile
> 2021-07-26 10:04     32768   s3://seagatebucket/32kfile
> 2021-07-26 10:04     33000   s3://seagatebucket/32kfile_unaligned
> 2021-07-26 10:03      5000   s3://seagatebucket/4kfile_unaligned
> 2021-07-26 10:05     65536   s3://seagatebucket/64kfile
> 2021-07-26 10:05     66000   s3://seagatebucket/64kfile_unaligned
> 2021-07-26 10:04      8192   s3://seagatebucket/8kfile
> [root@ssc-vm-1453 downloadfiles]# s3cmd get s3://seagatebucket/100Mfile
> download: 's3://seagatebucket/100Mfile' -> './100Mfile'  [1 of 1]
>  104857600 of 104857600   100% in    1s    50.41 MB/s  done
> [root@ssc-vm-1453 downloadfiles]# s3cmd get s3://seagatebucket/100Mfile_unaligned
> download: 's3://seagatebucket/100Mfile_unaligned' -> './100Mfile_unaligned'  [1 of 1]
>  104857700 of 104857700   100% in    1s    50.65 MB/s  done
> [root@ssc-vm-1453 downloadfiles]# s3cmd get s3://seagatebucket/10Mfile
> download: 's3://seagatebucket/10Mfile' -> './10Mfile'  [1 of 1]
>  10485760 of 10485760   100% in    0s    39.35 MB/s  done
> [root@ssc-vm-1453 downloadfiles]# s3cmd get s3://seagatebucket/10Mfile_unaligned
> download: 's3://seagatebucket/10Mfile_unaligned' -> './10Mfile_unaligned'  [1 of 1]
>  10486000 of 10486000   100% in    0s    44.35 MB/s  done
> [root@ssc-vm-1453 downloadfiles]# s3cmd get s3://seagatebucket/128kfile
> download: 's3://seagatebucket/128kfile' -> './128kfile'  [1 of 1]
>  131072 of 131072   100% in    0s  1663.03 kB/s  done
> [root@ssc-vm-1453 downloadfiles]# s3cmd get s3://seagatebucket/128kfile_unaligned
> download: 's3://seagatebucket/128kfile_unaligned' -> './128kfile_unaligned'  [1 of 1]
>  132072 of 132072   100% in    0s     2.55 MB/s  done
> [root@ssc-vm-1453 downloadfiles]# s3cmd get s3://seagatebucket/64kfile
> download: 's3://seagatebucket/64kfile' -> './64kfile'  [1 of 1]
>  65536 of 65536   100% in    0s   812.52 kB/s  done
> [root@ssc-vm-1453 downloadfiles]# s3cmd get s3://seagatebucket/64kfile_unaligned
> download: 's3://seagatebucket/64kfile_unaligned' -> './64kfile_unaligned'  [1 of 1]
>  66000 of 66000   100% in    0s  1568.09 kB/s  done
> [root@ssc-vm-1453 downloadfiles]# s3cmd get s3://seagatebucket/32kfile
> download: 's3://seagatebucket/32kfile' -> './32kfile'  [1 of 1]
>  32768 of 32768   100% in    0s   844.82 kB/s  done
> [root@ssc-vm-1453 downloadfiles]# s3cmd get s3://seagatebucket/32kfile_unaligned
> download: 's3://seagatebucket/32kfile_unaligned' -> './32kfile_unaligned'  [1 of 1]
>  33000 of 33000   100% in    0s   823.98 kB/s  done
> [root@ssc-vm-1453 downloadfiles]# s3cmd get s3://seagatebucket/16kfile
> download: 's3://seagatebucket/16kfile' -> './16kfile'  [1 of 1]
>  16384 of 16384   100% in    0s   261.03 kB/s  done
> [root@ssc-vm-1453 downloadfiles]# s3cmd get s3://seagatebucket/16kfile_unaligned
> download: 's3://seagatebucket/16kfile_unaligned' -> './16kfile_unaligned'  [1 of 1]
>  18000 of 18000   100% in    0s   389.34 kB/s  done
> [root@ssc-vm-1453 downloadfiles]# s3cmd get s3://seagatebucket/8kfile
> download: 's3://seagatebucket/8kfile' -> './8kfile'  [1 of 1]
>  8192 of 8192   100% in    0s   226.73 kB/s  done
> [root@ssc-vm-1453 downloadfiles]# s3cmd get s3://seagatebucket/4kfile_unaligned
> download: 's3://seagatebucket/4kfile_unaligned' -> './4kfile_unaligned'  [1 of 1]
>  5000 of 5000   100% in    0s   130.40 kB/s  done
> [root@ssc-vm-1453 downloadfiles]# s3cmd get s3://seagatebucket/2kfile
> download: 's3://seagatebucket/2kfile' -> './2kfile'  [1 of 1]
>  2024 of 2024   100% in    0s    43.05 kB/s  done
> [root@ssc-vm-1453 downloadfiles]# s3cmd get s3://seagatebucket/1kfile
> download: 's3://seagatebucket/1kfile' -> './1kfile'  [1 of 1]
>  1024 of 1024   100% in    0s    30.93 kB/s  done
> [root@ssc-vm-1453 downloadfiles]# md5sum *
> 2f282b84e7e608d5852449ed940bfc51  100Mfile
> 3af505a6e9c9b496f0865434b60f9119  100Mfile_unaligned
> f1c9645dbc14efddc7d8a322685f26eb  10Mfile
> c4cb59705ed81082fb13974a405f92c4  10Mfile_unaligned
> 0dfbe8aa4c20b52e1b8bf3cb6cbdf193  128kfile
> 5dfe41acb0f440bc6a73a1e88c68534d  128kfile_unaligned
> ce338fe6899778aacfc28414f2d9498b  16kfile
> 469c7dbcba354a281cbea1f731f301b0  16kfile_unaligned
> 0f343b0931126a20f133d67c2b018a3b  1kfile
> b6d81b360a5672d80c27430f39153e2c  1Mfile
> 0c311baf6be3bf7db23fbc7e5cd75055  1Mfile_unaligned
> 68ccb018145df2abff08bb6040351f01  2kfile
> bb7df04e1b0a2570657527a7e108ae23  32kfile
> d7ea97d313b83e91efbb901cc558bea4  32kfile_unaligned
> 6bf95a48f366bdf8af3a198c7b723c77  4kfile_unaligned
> fcd6bcb56c1689fcef28b57c22475bad  64kfile
> 86021f5bf847aed4117d20694f94d2a4  64kfile_unaligned
> 0829f71740aab1ab98b33eae21dee122  8kfile
> [root@ssc-vm-1453 downloadfiles]# cd ..
> [root@ssc-vm-1453 testfiles]# md5sum *
> 2f282b84e7e608d5852449ed940bfc51  100Mfile
> 3af505a6e9c9b496f0865434b60f9119  100Mfile_unaligned
> f1c9645dbc14efddc7d8a322685f26eb  10Mfile
> c4cb59705ed81082fb13974a405f92c4  10Mfile_unaligned
> 0dfbe8aa4c20b52e1b8bf3cb6cbdf193  128kfile
> 5dfe41acb0f440bc6a73a1e88c68534d  128kfile_unaligned
> ce338fe6899778aacfc28414f2d9498b  16kfile
> 469c7dbcba354a281cbea1f731f301b0  16kfile_unaligned
> 0f343b0931126a20f133d67c2b018a3b  1kfile
> b6d81b360a5672d80c27430f39153e2c  1Mfile
> 0c311baf6be3bf7db23fbc7e5cd75055  1Mfile_unaligned
> 68ccb018145df2abff08bb6040351f01  2kfile
> bb7df04e1b0a2570657527a7e108ae23  32kfile
> d7ea97d313b83e91efbb901cc558bea4  32kfile_unaligned
> 6bf95a48f366bdf8af3a198c7b723c77  4kfile_unaligned
> fcd6bcb56c1689fcef28b57c22475bad  64kfile
> 86021f5bf847aed4117d20694f94d2a4  64kfile_unaligned
> 0829f71740aab1ab98b33eae21dee122  8kfile

</details>