### PR TITLE
update s3server guide with corrections

### DIFF
--- a/docs/CORTX-S3 Server Quick Start Guide.md
+++ b/docs/CORTX-S3 Server Quick Start Guide.md
@@ -49,7 +49,7 @@ This guide provides a step-by-step walkthrough for getting you CORTX-S3 Server r
         * `$ yum install -y epel-release`
     * Ansible: Install ansible if not there already `$ yum install -y ansible`
     * ipaddress: Install ipaddress if not there already `$ pip3 install ipaddress`
-    * Make sure that PATH variable has `/root/local/bin`,`/usr/local/sbin`,`/usr/sbin`,`/usr/bin` directories 
+    * Make sure that PATH variable has `/root/local/bin`,`/usr/local/sbin`,`/usr/sbin`,`/usr/bin`, `/usr/local/bin` directories 
     
 6. You will need to set your hostname to something other than localhost `hostnamectl set-hostname --static --transient --pretty <new-name>`. Try `sudo' if the command fails
 
@@ -105,7 +105,7 @@ You'll need to clone the S3 Server Repository from the main branch. To clone the
 
 ```shell
 
-$ git clone --recursive git@github.com:Seagate/cortx-s3server.git -b main
+$ git clone --recursive https://github.com/Seagate/cortx-s3server.git -b main
 $ cd cortx-s3server
 $ git submodule update --init --recursive && git status
 ```
@@ -140,6 +140,8 @@ At some point during the execution of the `init.sh` script, it will prompt for t
 Refer to the image below to view the output of a successful `$ init.sh -a` run, where the `failed` field value should be zero.
 
 ![Successful run](../images/init_script_output.png)
+
+If you encounter `failed=1` that is caused by Motr dependency conflicts (such as gcc or python3 version conflict), you can install Motr dependencies first (in cortx-motr, run `scripts/install-build-deps`), before follow this guide. Refer to [Motr guide](https://github.com/Seagate/cortx-motr/blob/main/doc/Quick-Start-Guide.rst)
 
 If you still see errors or a failed status, please [reach out to us for support](https://github.com/Seagate/cortx/blob/main/SUPPORT.md)
 
@@ -367,6 +369,7 @@ Refer to our [CORTX Contribution Guide](https://github.com/Seagate/cortx/blob/ma
 Please refer to the [Support](https://github.com/Seagate/cortx/blob/main/SUPPORT.md) section to reach out to us with your questions, contributions, and feedback.
 
 Tested by:
+- Aug 1, 2021: Bo Wei (bo.b.wei@seagate.com) on Windows laptop running Oracle VirtualBox (Centos 7.8).
 - July 30, 2021: Kapil Jinna (kapil.jinna@seagate.com) on G2 cloud VM (Centos 7.8)
 - June 11, 2021: Kapil Jinna (kapil.jinna@seagate.com) on Vsphere cloud VM (Centos 7.8)
 - May 09, 2021: Kapil Jinna (kapil.jinna@seagate.com) on SSC cloud VM (Centos 7.8)


### PR DESCRIPTION
1. githubrelease is installed in /usr/local/bin. Need to add this to PATH to avoid error when run `./init.sh -a`.
2. Change git clone to use the HTTPS web URL. The benefit is that no need to generate SSH public key.
3. Add note to avoid Motr dependency conflict. For example, python may install a newer gcc version and conflict with Motr requirement, and cause './init.sh -a' failure.


-----
[View rendered docs/CORTX-S3 Server Quick Start Guide.md](https://github.com/wb-droid/cortx-s3server/blob/main/docs/CORTX-S3 Server Quick Start Guide.md)