### PR TITLE
EOS-23335: Truncate slapd log file instead of removing it

### DIFF
--- a/scripts/provisioning/cleanupcmd.py
+++ b/scripts/provisioning/cleanupcmd.py
@@ -137,8 +137,9 @@ class CleanupCmd(SetupCmd):
       self.logger.info("truncate slapd log file started")
       slapd_log="/var/log/slapd.log"
       if os.path.isfile(slapd_log):
-        fo = open(slapd_log, "rw+")
-        fo.truncate()
+        fslapd = open(slapd_log, "w")
+        fslapd.truncate()
+        fslapd.close()
         self.logger.info("truncate slapd log file completed")
 
       #delete deployment log

--- a/scripts/provisioning/cleanupcmd.py
+++ b/scripts/provisioning/cleanupcmd.py
@@ -133,12 +133,13 @@ class CleanupCmd(SetupCmd):
       self.delete_ldap_config()
       self.logger.info("delete ldap config and schemas completed")
 
-      # delete slapd logs
-      self.logger.info("delete slapd log file started")
+      # truncate slapd logs
+      self.logger.info("truncate slapd log file started")
       slapd_log="/var/log/slapd.log"
       if os.path.isfile(slapd_log):
-        os.remove(slapd_log)
-        self.logger.info("delete slapd log file completed")
+        fo = open(slapd_log, "rw+")
+        fo.truncate()
+        self.logger.info("truncate slapd log file completed")
 
       #delete deployment log
       if pre_factory == True:

--- a/scripts/provisioning/resetcmd.py
+++ b/scripts/provisioning/resetcmd.py
@@ -19,6 +19,7 @@
 #
 
 import sys
+import os
 import time
 import re
 from s3msgbus.cortx_s3_msgbus import S3CortxMsgBus
@@ -27,7 +28,7 @@ from s3backgrounddelete.cortx_s3_constants import MESSAGE_BUS
 from setupcmd import SetupCmd
 from ldapaccountaction import LdapAccountAction
 
-services_list = ["haproxy", "s3backgroundproducer", "s3backgroundconsumer", "s3server@*", "s3authserver", "slapd"]
+services_list = ["haproxy", "s3backgroundproducer", "s3backgroundconsumer", "s3server@*", "s3authserver"]
 
 class ResetCmd(SetupCmd):
   """Reset Setup Cmd."""
@@ -107,8 +108,7 @@ class ResetCmd(SetupCmd):
       self.DeleteDirContents(logDir, skipDirs)
 
     logFiles = ["/var/log/haproxy.log",
-                "/var/log/haproxy-status.log",
-                "/var/log/slapd.log"]
+                "/var/log/haproxy-status.log"]
     for logFile in logFiles:
       self.DeleteFile(logFile)
 
@@ -117,6 +117,15 @@ class ResetCmd(SetupCmd):
                       '/var/log/crash':'core-s3server.*.gz'}
     for path in logRegexPath:
       self.DeleteFileOrDirWithRegex(path, logRegexPath[path])
+
+    # truncate slapd logs
+    self.logger.info("truncate slapd log file started")
+    slapd_log="/var/log/slapd.log"
+    if os.path.isfile(slapd_log):
+      fo = open(slapd_log, "rw+")
+      fo.truncate()
+      self.logger.info("truncate slapd log file completed")
+
 
   def purge_messages(self, producer_id: str, msg_type: str, delivery_mechanism: str, sleep_time: int):
     """purge messages on message bus."""

--- a/scripts/provisioning/resetcmd.py
+++ b/scripts/provisioning/resetcmd.py
@@ -122,8 +122,9 @@ class ResetCmd(SetupCmd):
     self.logger.info("truncate slapd log file started")
     slapd_log="/var/log/slapd.log"
     if os.path.isfile(slapd_log):
-      fo = open(slapd_log, "rw+")
-      fo.truncate()
+      fslapd = open(slapd_log, "w")
+      fslapd.truncate()
+      fslapd.close()
       self.logger.info("truncate slapd log file completed")
 
 


### PR DESCRIPTION
# Problem Statement
- Cluster is not starting after reset phase

# Design
- removed the slapd shutdown from the reset phase
- truncate slapd log file instead of removing from reset and cleanup phase 
- added validation in start and stop services

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
