### PR TITLE
[EOS-23164] : [Multipart Restructure] S3 multipart upload (Redesign) results in metadata "size" with value 0

### DIFF
--- a/server/s3_object_metadata.cc
+++ b/server/s3_object_metadata.cc
@@ -225,6 +225,8 @@ S3ObjectMetadata::S3ObjectMetadata(
     mote_kv_writer_factory = std::make_shared<S3MotrKVSWriterFactory>();
   }
   obj_type = S3ObjectMetadataType::simple;
+  // This will be initially object size, in case of object fragment this will be
+  // fragment size.
   primary_obj_size = request->get_content_length();
   initialize(is_multipart, upload_id);
 }

--- a/server/s3_object_metadata.cc
+++ b/server/s3_object_metadata.cc
@@ -225,7 +225,7 @@ S3ObjectMetadata::S3ObjectMetadata(
     mote_kv_writer_factory = std::make_shared<S3MotrKVSWriterFactory>();
   }
   obj_type = S3ObjectMetadataType::simple;
-  primary_obj_size = 0;
+  primary_obj_size = request->get_content_length();
   initialize(is_multipart, upload_id);
 }
 


### PR DESCRIPTION
Signed-off-by: Pranav Diliprao Pawar <pranav.pawar@seagate.com>

# Problem Statement
- object upload has "size" and its value as 0, it needs to be set to the content length, in case of fragmentation it will be different

# Design
-  Changed primary_obj_size from 0 to content_length.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
