### PR TITLE
Minor logging changes in case of memory crunch

### DIFF
--- a/server/s3_evbuffer_wrapper.cc
+++ b/server/s3_evbuffer_wrapper.cc
@@ -47,8 +47,23 @@ int S3Evbuffer::init() {
         evbuffer_reserve_space(p_evbuf, buffer_unit_sz, &vec[i], 1);
     if (no_of_extends < 0) {
       s3_log(S3_LOG_ERROR, request_id,
-             "evbuffer_reserve_space failed, no_of_extends = %d\n",
-             no_of_extends);
+             "evbuffer_reserve_space failed, i = %zu buffer_unit_sz = %zu "
+             "no_of_extends = %d\n",
+             i, buffer_unit_sz, no_of_extends);
+      struct pool_info poolinfo;
+      int rc = event_mempool_getinfo(&poolinfo);
+      if (rc != 0) {
+        s3_log(S3_LOG_FATAL, "", "Issue with memory pool!\n");
+      } else {
+        s3_log(S3_LOG_ERROR, "",
+               "mempool info during init failure : mempool_item_size = %zu "
+               "free_bufs_in_pool = %d "
+               "number_of_bufs_shared = %d "
+               "total_bufs_allocated_by_pool = %d\n",
+               poolinfo.mempool_item_size, poolinfo.free_bufs_in_pool,
+               poolinfo.number_of_bufs_shared,
+               poolinfo.total_bufs_allocated_by_pool);
+      }
       return no_of_extends;
     }
     if (evbuffer_commit_space(p_evbuf, &vec[i], 1) < 0) {

--- a/server/s3_motr_reader.cc
+++ b/server/s3_motr_reader.cc
@@ -239,7 +239,7 @@ bool S3MotrReader::read_object() {
     // out-of-memory
     state = S3MotrReaderOpState::ooo;
     s3_log(S3_LOG_ERROR, request_id,
-           "Motr API failed: openobj(oid: ("
+           "S3 API failed: openobj(oid: ("
            "%" SCNx64 " : %" SCNx64 "), out-of-memory)\n",
            oid.u_hi, oid.u_lo);
     return false;


### PR DESCRIPTION
Add mempool logging in case of libevent call failure
due to memory crunch

Signed-off-by: Rajesh Nambiar <rajesh.nambiar@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
