### PR TITLE
EOS-21402:S3:Send complete error msg to client

### DIFF
--- a/scripts/kafka/message_bus.conf
+++ b/scripts/kafka/message_bus.conf
@@ -1,11 +1,17 @@
 {
-   "message_broker":{
-      "type":"kafka",
-      "cluster":[
-         {
-            "server":"localhost",
-            "port":"9092"
-         }
-      ]
-   }
+  "message_broker": {
+    "type": "kafka",
+    "cluster": [
+      {
+        "server": "localhost",
+        "port": "9092"
+      }
+    ],
+    "message_bus": {
+      "recv_message_timeout": 2,
+      "controller_socket_timeout": 15000,
+      "send_message_timeout": 5000
+    }
+  }
 }
+

--- a/server/s3_action_base.cc
+++ b/server/s3_action_base.cc
@@ -78,6 +78,7 @@ void S3Action::check_authorization_failed() {
   s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   if (request->client_connected()) {
     std::string error_code = auth_client->get_error_code();
+    std::string error_message = auth_client->get_error_message();
     if (error_code == "InvalidAccessKeyId") {
       s3_stats_inc("authorization_failed_invalid_accesskey_count");
     } else if (error_code == "SignatureDoesNotMatch") {
@@ -96,7 +97,7 @@ void S3Action::check_authorization_failed() {
     }
     s3_log(S3_LOG_ERROR, request_id, "Authorization failure: %s\n",
            error_code.c_str());
-    request->respond_error(error_code);
+    request->respond_error(error_code, {}, error_message);
   }
   done();
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);


### PR DESCRIPTION

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>

# Problem Statement
- When we send copy-object request without authorization header, Error message was not in sync with aws s3.
- Aws error message : "Anonymous users cannot copy objects. Please authenticate"
- Cortx s3 error message : "Access Denied"

# Design
-  fixed s3server code and added error message
# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide

#**Testing output**:
 
![image](https://user-images.githubusercontent.com/65209830/129135692-2e53ccbc-d721-4940-955e-89cd498f16dc.png)
