### PR TITLE
EOS-22190: Avoid lookup in Motr for S3 global indices

### DIFF
--- a/server/s3server.cc
+++ b/server/s3server.cc
@@ -552,7 +552,8 @@ int create_global_index(struct s3_motr_idx_layout &idx_lo,
 
   for (; --n_retry > 0; ::sleep(1)) {  // suspend current thread for 1 second
     struct m0_op *cr_op = nullptr;
-
+    // Pass M0_ENF_META to avoid lookup by Motr
+    idx.in_entity.en_flags |= M0_ENF_META;
     m0_entity_create(NULL, &idx.in_entity, &cr_op);
     m0_op_launch(&cr_op, 1);
 
@@ -597,14 +598,12 @@ int create_global_index(struct s3_motr_idx_layout &idx_lo,
     s3_iem(LOG_ALERT, S3_IEM_MOTR_CONN_FAIL, S3_IEM_MOTR_CONN_FAIL_STR,
            S3_IEM_MOTR_CONN_FAIL_JSON);
   } else {
-    // Store pv id and layout type only if flag 'M0_ENF_META' is set.
-    if (idx.in_entity.en_flags & M0_ENF_META) {
-      idx_lo.pver = idx.in_attr.idx_pver;
-      idx_lo.layout_type = idx.in_attr.idx_layout_type;
-    } else {
-      idx_lo.pver.f_container = idx_lo.pver.f_key = 0;
-      idx_lo.layout_type = 0;
-    }
+    idx_lo.pver = idx.in_attr.idx_pver;
+    idx_lo.layout_type = idx.in_attr.idx_layout_type;
+    s3_log(S3_LOG_INFO, "Global index details",
+           "Index OID: %08zx-%08zx PV Id: %08zx-%08zx Layout_type: 0x%x",
+           idx_lo.oid.u_hi, idx_lo.oid.u_lo, idx_lo.pver.f_container,
+           idx_lo.pver.f_key, idx_lo.layout_type);
   }
   return rc;
 }


### PR DESCRIPTION
- Pass M0_ENF_META to S3 global indices
Also, store pv_id and layout_type values returned by Motr, w/out any condition check of whether ENF flag was set are not before invoking m0_entity_create.

Note: During dev testing, it was found that after setting M0_ENF_META in <idx.in_entity.en_flags, just before invoking m0_entity_create(), the flag is found to be getting reset to 0 after index create operation. So, removed condition check in code.

Signed-off-by: Dattaprasad <dattaprasad.govekar@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
