### PR TITLE
EOS-23614 : Code changes for s3 single entry script with call to s3authserver script

### DIFF
--- a/installhelper.sh
+++ b/installhelper.sh
@@ -123,6 +123,7 @@ cp scripts/provisioning/templates/s3.cleanup.tmpl.1-node.sample $S3_INSTALL_LOCA
 
 # Copy the provisioning python scripts
 cp scripts/provisioning/s3_setup $S3_INSTALL_LOCATION/bin
+cp scripts/provisioning/s3_start $S3_INSTALL_LOCATION/bin
 cp scripts/provisioning/postinstallcmd.py $S3_INSTALL_LOCATION/bin
 cp scripts/provisioning/configcmd.py $S3_INSTALL_LOCATION/bin
 cp scripts/provisioning/initcmd.py $S3_INSTALL_LOCATION/bin

--- a/rpms/s3/s3rpm.spec
+++ b/rpms/s3/s3rpm.spec
@@ -421,6 +421,7 @@ echo "[cortx-s3server-rpm] INFO: S3 RPM Clean section completed"
 /opt/seagate/cortx/s3/bin/merge.py
 /opt/seagate/cortx/s3/bin/s3_haproxy_config.py
 %attr(755, root, root) /opt/seagate/cortx/s3/bin/s3_setup
+%attr(755, root, root) /opt/seagate/cortx/s3/bin/s3_start
 %attr(755, root, root) /opt/seagate/cortx/s3/s3backgrounddelete/s3backgroundconsumer
 %attr(755, root, root) /opt/seagate/cortx/s3/s3backgrounddelete/s3backgroundproducer
 /etc/rsyslog.d/rsyslog-tcp-audit.conf

--- a/scripts/provisioning/s3_start
+++ b/scripts/provisioning/s3_start
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import sys
+import argparse
+import traceback
+import errno
+import logging
+import os
+import socket
+from logging import handlers
+
+#Logger details
+s3_single_entry_logger_name = \
+    "s3-deployment-logger-" + "[" + str(socket.gethostname()) + "]"
+s3_single_entry_log_file = \
+    "/var/log/seagate/s3/s3deployment/s3_single_entry.log"
+s3_single_entry_log_directory = "/var/log/seagate/s3/s3deployment/"
+s3_single_entry_log_format = \
+    "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+def main():
+
+  parser = argparse.ArgumentParser("S3server single entry command")
+  parser.add_argument("--service", required=True)
+
+  args = parser.parse_args()
+
+  create_logger_directory()
+  logger = create_logger()
+
+  try:
+    if args.service == 's3server':
+      # Action
+    elif args.service == 's3authserver':
+      os.system("sh /opt/seagate/cortx/auth/startauth.sh")
+    elif args.service == 's3bgproducer':
+      # Action
+    elif args.service == 's3bgconsumer':
+      # Action
+  except Exception as e:
+    logger.error(f"{str(e)}")
+    logger.error(f"{traceback.format_exc()}")
+    return errno.EINVAL
+
+  return 0
+
+def create_logger():
+    """Create logger, file handler, console handler and formatter."""
+    # create logger with "S3 deployment logger"
+    logger = logging.getLogger(s3_single_entry_logger_name)
+    logger.setLevel(logging.DEBUG)
+    # maxBytes 5242880 will allow base file s3_single_entry.log to rotate 
+    # after every 5MB. With a backupCount of 5, files will be generated 
+    # like s3_single_entry.log, s3_single_entry.log.1 and up to s3.log.5.
+    # The file being written to is always s3_single_entry.log.
+    fhandler = logging.handlers.RotatingFileHandler(s3_single_entry_log_file, \
+                                                    mode='a',\
+                                                    maxBytes = 5242880,\
+                                                    backupCount = 5,\
+                                                    encoding=None, delay=False)
+    fhandler.setLevel(logging.DEBUG)
+
+    # create console handler with a higher log level
+    chandler = logging.StreamHandler(sys.stdout)
+    chandler.setLevel(logging.DEBUG)
+
+    formatter = logging.Formatter(s3_single_entry_log_format)
+
+    # create formatter and add it to the handlers
+    fhandler.setFormatter(formatter)
+    chandler.setFormatter(formatter)
+
+    # add the handlers to the logger
+    logger.addHandler(fhandler)
+    logger.addHandler(chandler)
+
+    return logger
+
+def create_logger_directory():
+    """Create log directory if not exsists."""
+    _logger_directory = os.path.join(s3_single_entry_log_directory)
+    if not os.path.isdir(_logger_directory):
+        try:
+            os.mkdir(_logger_directory)
+        except BaseException:
+            raise Exception(f"{_logger_directory} Could not be created")
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/scripts/provisioning/s3_start
+++ b/scripts/provisioning/s3_start
@@ -29,7 +29,7 @@ from logging import handlers
 
 #Logger details
 s3_single_entry_logger_name = \
-    "s3-deployment-logger-" + "[" + str(socket.gethostname()) + "]"
+    "s3-single_entry-logger-" + "[" + str(socket.gethostname()) + "]"
 s3_single_entry_log_file = \
     "/var/log/seagate/s3/s3deployment/s3_single_entry.log"
 s3_single_entry_log_directory = "/var/log/seagate/s3/s3deployment/"
@@ -48,13 +48,18 @@ def main():
 
   try:
     if args.service == 's3server':
-      # Action
+      # Add action and remove pass
+      pass
     elif args.service == 's3authserver':
       os.system("sh /opt/seagate/cortx/auth/startauth.sh")
     elif args.service == 's3bgproducer':
-      # Action
+      # Add action and remove pass
+      pass
     elif args.service == 's3bgconsumer':
-      # Action
+      # Add action and remove pass
+      pass
+    else:
+      logger.error(f"Invalid argument {args.service}")
   except Exception as e:
     logger.error(f"{str(e)}")
     logger.error(f"{traceback.format_exc()}")
@@ -99,7 +104,7 @@ def create_logger_directory():
     _logger_directory = os.path.join(s3_single_entry_log_directory)
     if not os.path.isdir(_logger_directory):
         try:
-            os.mkdir(_logger_directory)
+            os.makedirs(_logger_directory)
         except BaseException:
             raise Exception(f"{_logger_directory} Could not be created")
 


### PR DESCRIPTION
Signed-off-by: Mohammed Shahid <mohammed.shahid@seagate.com>

# Problem Statement
- Create a single entry script s3_start to support argument: --service [ s3server | s3authserver | s3bgproducer | s3bgconsumer ]

# Design
-  Create basic structure for allowing all service provisioning separately.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide
