### PR TITLE
EOS-23396: Machine ID and BGDelete account changes

### DIFF
--- a/s3cortxutils/s3confstore/s3confstore/cortx_s3_confstore.py
+++ b/s3cortxutils/s3confstore/s3confstore/cortx_s3_confstore.py
@@ -83,6 +83,10 @@ class S3CortxConfStore:
     """Saves to config file."""
     Conf.save(self.default_index)
 
+  def get_machine_id(self):
+    """Get machine id from the constore"""
+    return Conf.machine_id
+
   @staticmethod
   def validate_configfile(configfile: str):
     """Validate the 'configfile' url, if its a valid file and of supported format."""

--- a/scripts/provisioning/configcmd.py
+++ b/scripts/provisioning/configcmd.py
@@ -33,6 +33,7 @@ from s3msgbus.cortx_s3_msgbus import S3CortxMsgBus
 from s3backgrounddelete.cortx_s3_config import CORTXS3Config
 from s3backgrounddelete.cortx_s3_constants import MESSAGE_BUS
 from s3_haproxy_config import S3HaproxyConfig
+from ldapaccountaction import LdapAccountAction
 
 class ConfigCmd(SetupCmd):
   """Config Setup Cmd."""
@@ -96,6 +97,11 @@ class ConfigCmd(SetupCmd):
                           bgdeleteconfig.get_msgbus_topic(),
                           self.get_msgbus_partition_count())
         self.logger.info('Create topic completed')
+
+      # create background delete account
+      self.logger.info("create background delete account started")
+      self.create_bgdelete_account()
+      self.logger.info("create background delete account completed")
     except Exception as e:
       raise S3PROVError(f'process() failed with exception: {e}')
 
@@ -289,3 +295,16 @@ class ConfigCmd(SetupCmd):
       s3configfileconfstore = S3CortxConfStore(f'yaml://{s3configfile}', 'write_s3_motr_max_unit_idx')
       s3configfileconfstore.set_config(motr_max_units_per_request_key, int(motr_max_units_per_request), True)
       self.logger.info(f'Key {motr_max_units_per_request_key} updated successfully in {s3configfile}')
+
+  def create_bgdelete_account(self):
+    """ create bgdelete account."""
+    try:
+      # Create background delete account
+      bgdelete_acc_input_params_dict = self.get_config_param_for_BG_delete_account()
+      LdapAccountAction(self.ldap_user, self.ldap_passwd).create_account(bgdelete_acc_input_params_dict)
+    except Exception as e:
+      if "Already exists" not in str(e):
+        self.logger.error(f'Failed to create backgrounddelete service account, error: {e}')
+        raise(e)
+      else:
+        self.logger.warning("backgrounddelete service account already exist")

--- a/scripts/provisioning/initcmd.py
+++ b/scripts/provisioning/initcmd.py
@@ -21,7 +21,6 @@
 import sys
 
 from setupcmd import SetupCmd
-from ldapaccountaction import LdapAccountAction
 
 class InitCmd(SetupCmd):
   """Init Setup Cmd."""
@@ -44,15 +43,3 @@ class InitCmd(SetupCmd):
     self.validate_config_files(self.name)
     self.logger.info("validations completed")
 
-    try:
-      # Create background delete account
-      self.logger.info("create background delete account started")
-      bgdelete_acc_input_params_dict = self.get_config_param_for_BG_delete_account()
-      LdapAccountAction(self.ldap_user, self.ldap_passwd).create_account(bgdelete_acc_input_params_dict)
-    except Exception as e:
-      if "Already exists" not in str(e):
-        self.logger.error(f'Failed to create backgrounddelete service account, error: {e}')
-        raise(e)
-      else:
-        self.logger.warning("backgrounddelete service account already exist")
-    self.logger.info("create background delete account completed")

--- a/scripts/provisioning/s3_haproxy_config.py
+++ b/scripts/provisioning/s3_haproxy_config.py
@@ -49,15 +49,14 @@ class S3HaproxyConfig:
       # add the handlers to the logger
       self.logger.addHandler(chandler)
 
-    # Read machine-id of current node
-    with open('/etc/machine-id', 'r') as mcid_file:
-      self.machine_id = mcid_file.read().strip()
-
     if not confstore.strip():
       self.logger.error(f'config url:[{confstore}] must be a valid url path')
       raise Exception('empty config URL path')
 
     self.provisioner_confstore = S3CortxConfStore(confstore, 'haproxy_config_index')
+
+    # Get machine-id of current node from constore
+    self.machine_id = provisioner_confstore.get_machine_id()
 
   def get_publicip(self):
     assert self.provisioner_confstore != None

--- a/scripts/provisioning/s3_haproxy_config.py
+++ b/scripts/provisioning/s3_haproxy_config.py
@@ -56,7 +56,8 @@ class S3HaproxyConfig:
     self.provisioner_confstore = S3CortxConfStore(confstore, 'haproxy_config_index')
 
     # Get machine-id of current node from constore
-    self.machine_id = provisioner_confstore.get_machine_id()
+    self.machine_id = self.provisioner_confstore.get_machine_id()
+    self.logger.info(f'Machine id : {self.machine_id}')
 
   def get_publicip(self):
     assert self.provisioner_confstore != None

--- a/scripts/provisioning/s3setup_prereqs.json
+++ b/scripts/provisioning/s3setup_prereqs.json
@@ -3,7 +3,6 @@
     "rpms": ["symas-openldap", "symas-openldap-servers", "symas-openldap-clients", "haproxy", "cortx-motr", "python36-ldap"],
     "pip3s": ["s3confstore", "cryptography", "s3cipher"],
     "files": [
-      "file:/etc/machine-id",
       "file:/etc/haproxy/haproxy.cfg",
       "file:/etc/ssl/stx/stx.pem",
       "file:/opt/seagate/cortx/s3/install/haproxy/503.http",
@@ -22,7 +21,6 @@
     "pip3s": ["s3confstore", "cryptography", "s3cipher"],
     "services": ["sshd", "haproxy", "slapd", "rsyslog"],
     "files": [
-      "file:/etc/machine-id",
       "file:/etc/haproxy/haproxy.cfg",
       "file:/etc/ssl/stx/stx.pem",
       "file:/opt/seagate/cortx/s3/install/haproxy/503.http",
@@ -41,7 +39,6 @@
     "pip3s": ["s3confstore", "cryptography", "s3cipher"],
     "services": ["sshd", "haproxy", "slapd", "rsyslog"],
     "files": [
-      "file:/etc/machine-id",
       "file:/etc/haproxy/haproxy.cfg",
       "file:/etc/ssl/stx/stx.pem",
       "file:/opt/seagate/cortx/s3/install/haproxy/503.http",

--- a/scripts/provisioning/setupcmd.py
+++ b/scripts/provisioning/setupcmd.py
@@ -66,7 +66,7 @@ class SetupCmd(object):
   ha_service_map = {}
 
   def __init__(self,config: str):
-        """Constructor."""
+    """Constructor."""
     self.endpoint = None
     self._url = None
     self._provisioner_confstore = None

--- a/scripts/provisioning/setupcmd.py
+++ b/scripts/provisioning/setupcmd.py
@@ -92,7 +92,8 @@ class SetupCmd(object):
     self._provisioner_confstore = S3CortxConfStore(self._url, 'setup_prov_index')
 
     # Get machine-id of current node from constore
-    self.machine_id = provisioner_confstore.get_machine_id()
+    self.machine_id = self._provisioner_confstore.get_machine_id()
+    self.logger.info(f'Machine id : {self.machine_id}')
 
     self.cluster_id = self.get_confvalue(self.get_confkey(
       'CONFIG>CONFSTORE_CLUSTER_ID_KEY').replace("machine-id", self.machine_id))

--- a/scripts/provisioning/setupcmd.py
+++ b/scripts/provisioning/setupcmd.py
@@ -66,7 +66,7 @@ class SetupCmd(object):
   ha_service_map = {}
 
   def __init__(self,config: str):
-    """Constructor."""
+        """Constructor."""
     self.endpoint = None
     self._url = None
     self._provisioner_confstore = None
@@ -91,9 +91,8 @@ class SetupCmd(object):
     self._url = config
     self._provisioner_confstore = S3CortxConfStore(self._url, 'setup_prov_index')
 
-    # machine_id will be used to read confstore keys
-    with open('/etc/machine-id') as f:
-      self.machine_id = f.read().strip()
+    # Get machine-id of current node from constore
+    self.machine_id = provisioner_confstore.get_machine_id()
 
     self.cluster_id = self.get_confvalue(self.get_confkey(
       'CONFIG>CONFSTORE_CLUSTER_ID_KEY').replace("machine-id", self.machine_id))


### PR DESCRIPTION
# Problem Statement
- Machine id should be get from the confstore instead of /etc/machine-id
- Create BG delete account should be moved to config phase.

# Design
- Machine id get from the confstore instead of /etc/machine-id
- Create BG delete account moved to config phase.
- 
# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
