### PR TITLE
EOS-24139: Use addb ID generation API from motr

### DIFF
--- a/server/request_object.cc
+++ b/server/request_object.cc
@@ -37,8 +37,6 @@
 
 extern S3Option* g_option_instance;
 
-uint64_t RequestObject::addb_request_id_gc = S3_ADDB_FIRST_GENERIC_REQUESTS_ID;
-
 // evhttp Helpers
 /* evhtp_kvs_iterator */
 extern "C" int consume_header(evhtp_kv_t* kvobj, void* arg) {
@@ -132,15 +130,7 @@ RequestObject::RequestObject(
       is_chunked_upload(false),
       in_headers_copied(false),
       in_query_params_copied(false),
-      // FIXME:
-      // For the time being, we are generating ADDB request IDs as a simple
-      // sequence starting from 1 and then simply increasing (1,2,3,...).   It
-      // works for now, while ADDB logs are only used for debugging (since
-      // we don't need to mix ADDB logs for different s3 server instances).  If
-      // and when ADDB will be used in production, we will need to generate
-      // proper globally unique IDs here.  Specifically, we'll need to address
-      // uniqueness across all instances of S3 Server.
-      addb_request_id(++addb_request_id_gc),
+      addb_request_id(m0_dummy_id_generate()),
       reply_buffer(NULL),
       used_mempool_buffer_count(0) {
 

--- a/server/request_object.h
+++ b/server/request_object.h
@@ -352,8 +352,6 @@ class RequestObject {
   }
   // See detailed comment in Action::addb_request_id.
   const uint64_t addb_request_id;
-  // Helper counter for assigning unique addb_request_id's for each request.
-  static uint64_t addb_request_id_gc;
 
   // Response Helpers
  private:

--- a/server/s3_addb.h
+++ b/server/s3_addb.h
@@ -49,11 +49,6 @@
 // Depends on s3_log.
 int s3_addb_init();
 
-// Used for s3starup calls without any request-objects.
-#define S3_ADDB_STARTUP_REQUESTS_ID 1
-// Default addb beginning request id.
-#define S3_ADDB_FIRST_GENERIC_REQUESTS_ID 2
-
 // Macro to create ADDB log entry.
 //
 // addb_action_type_id parameter must be a value from enum S3AddbActionTypeId.

--- a/server/s3_motr_kvs_writer.cc
+++ b/server/s3_motr_kvs_writer.cc
@@ -665,7 +665,7 @@ int S3MotrKVSWriter::put_keyval_impl(
   }
 
   s3_motr_api->motr_op_launch(
-      (is_async ? request->addb_request_id : S3_ADDB_STARTUP_REQUESTS_ID),
+      (is_async ? request->addb_request_id : m0_dummy_id_generate()),
       &(idx_op_ctx->ops[0]), 1, MotrOpType::putkv);
   global_motr_idx_ops_list.insert(idx_op_ctx);
   if (!is_async) {


### PR DESCRIPTION
EOS-24139: Use addb ID generation API from motr, instead of incremental counter

# Problem Statement
- Current code to generate ADDB uses incremental counter -- this is recently creating problems for PerfLine team, they asked to use API generator API from Motr.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
