### PR TITLE
EOS-22342 : Adding haproxy service handler

### DIFF
--- a/scripts/provisioning/s3_start
+++ b/scripts/provisioning/s3_start
@@ -58,6 +58,8 @@ def main():
     elif args.service == 's3bgconsumer':
       # Add action and remove pass
       pass
+    elif args.service == 'haproxy':
+      os.system("/usr/sbin/haproxy -Ws -f /etc/cortx/s3/haproxy.cfg -p /run/haproxy.pid &")
     else:
       logger.error(f"Invalid argument {args.service}")
   except Exception as e:

--- a/scripts/provisioning/s3_start
+++ b/scripts/provisioning/s3_start
@@ -46,6 +46,9 @@ def main():
   create_logger_directory()
   logger = create_logger()
 
+  # TODO: to be removed when end-to-end logging integration is done:
+  os.makedirs("/var/log/cortx/s3", mode=0o755, exist_ok=True)
+
   try:
     if args.service == 's3server':
       # Add action and remove pass
@@ -59,7 +62,9 @@ def main():
       # Add action and remove pass
       pass
     elif args.service == 'haproxy':
-      os.system("/usr/sbin/haproxy -Ws -f /etc/cortx/s3/haproxy.cfg -p /run/haproxy.pid &")
+      # TODO: logging path has to come from conf store -- to be fixed during
+      # end-to-end logging integration.
+      os.system("/usr/sbin/haproxy -Ws -f /etc/cortx/s3/haproxy.cfg -p /run/haproxy.pid 2>&1 1>/var/log/cortx/s3/haproxy.log")
     else:
       logger.error(f"Invalid argument {args.service}")
   except Exception as e:


### PR DESCRIPTION
Adding haproxy service handler and command to start haproxy inside container.

Signed-off-by: Mohammed Shahid <mohammed.shahid@seagate.com>

# Problem Statement
- Add haproxy to single entry-point script

# Design
-  Documented design changes [here](https://seagate-systems.atlassian.net/wiki/spaces/PRIVATECOR/pages/639434861/K8+single+node+deployment+without+systemd+on+VM+Only+for+S3+Internal+Purpose#1.-Configuration-changes-in-containers.)

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide
