### PR TITLE
EOS-22342: Fix redirection in haproxy entry point script

### DIFF
--- a/scripts/provisioning/s3_start
+++ b/scripts/provisioning/s3_start
@@ -76,7 +76,7 @@ def main():
     elif args.service == 'haproxy':
       # TODO: logging path has to come from conf store -- to be fixed during
       # end-to-end logging integration.
-      os.system("/usr/sbin/haproxy -Ws -f /etc/cortx/s3/haproxy.cfg -p /run/haproxy.pid 2>&1 1>/var/log/cortx/s3/haproxy.log")
+      os.system("/usr/sbin/haproxy -Ws -f /etc/cortx/s3/haproxy.cfg -p /run/haproxy.pid 1>/var/log/cortx/s3/haproxy.log 2>&1")
     else:
       logger.error(f"Invalid argument {args.service}")
   except Exception as e:


### PR DESCRIPTION
Signed-off-by: Ivan Tishchenko <ivan.tishchenko@seagate.com>

# Problem Statement
- Linux stream redirection was put in incorrect order, and so STDERR was actually being printed out to console for haproxy entry point script.

# Design
- Fix the order.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
