### PR TITLE
[EOS-24264]: Config path changed to /etc/cortx for auth and s3 in startup script (PVC support)

### DIFF
--- a/scripts/provisioning/s3_start
+++ b/scripts/provisioning/s3_start
@@ -44,7 +44,7 @@ def main():
   as a argument.
 
   """
-  s3config_path = "/opt/seagate/cortx/s3/conf/s3config.yaml"
+  s3config_path = "/etc/cortx/s3/conf/s3config.yaml"
   parser = argparse.ArgumentParser("S3server single entry command")
   parser.add_argument("--service", required=True)
   parser.add_argument("--index", required=False)
@@ -67,7 +67,7 @@ def main():
       os.system(f"sh /opt/seagate/cortx/s3/s3startsystem.sh -F {Fid} -P {fid_path} -C {s3config_path} -d")
       pass
     elif args.service == 's3authserver':
-      os.system("sh /opt/seagate/cortx/auth/startauth.sh /opt/seagate/cortx")
+      os.system("sh /opt/seagate/cortx/auth/startauth.sh /etc/cortx")
     elif args.service == 's3bgproducer':
       os.system("sh /opt/seagate/cortx/s3/s3backgrounddelete/starts3backgroundproducer.sh")
     elif args.service == 's3bgconsumer':


### PR DESCRIPTION
Signed-off-by: Saumitra Kulkarni <saumitra.kulkarni@seagate.com>
# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
