### PR TITLE
EOS-24974: Fix auth base config path in startauth.sh argument

### DIFF
--- a/auth/server/s3authserver.service
+++ b/auth/server/s3authserver.service
@@ -24,7 +24,7 @@ Requires=slapd.service
 
 [Service]
 Type=simple
-ExecStart=/opt/seagate/cortx/auth/startauth.sh "/etc/cortx"
+ExecStart=/opt/seagate/cortx/auth/startauth.sh "/etc/cortx/s3"
 ExecStop=/bin/kill -TERM $MAINPID
 TimeoutSec=300
 

--- a/scripts/provisioning/s3_start
+++ b/scripts/provisioning/s3_start
@@ -66,7 +66,7 @@ def main():
       Fid = get_fid(fid_path)
       os.system(f"sh /opt/seagate/cortx/s3/s3startsystem.sh -F {Fid} -P {fid_path} -C {s3config_path} -d")
     elif args.service == 's3authserver':
-      os.system("sh /opt/seagate/cortx/auth/startauth.sh /etc/cortx")
+      os.system("sh /opt/seagate/cortx/auth/startauth.sh /etc/cortx/s3")
     elif args.service == 's3bgproducer':
       os.system("sh /opt/seagate/cortx/s3/s3backgrounddelete/starts3backgroundproducer.sh")
     elif args.service == 's3bgconsumer':


### PR DESCRIPTION
Signed-off-by: Ivan Tishchenko <ivan.tishchenko@seagate.com>

# Problem Statement
- s3_start script is not able to start auth server
- reason: wrong config base path: /etc/cortx, but expected is /etc/cortx/s3

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
