### PR TITLE
HAproxy should read config path from confstore.

### DIFF
--- a/scripts/provisioning/s3_haproxy_config.py
+++ b/scripts/provisioning/s3_haproxy_config.py
@@ -20,7 +20,6 @@
 
 import os
 import sys
-import shutil
 import socket
 import logging
 import urllib.parse

--- a/scripts/provisioning/s3_haproxy_config.py
+++ b/scripts/provisioning/s3_haproxy_config.py
@@ -155,6 +155,10 @@ class S3HaproxyConfig:
 
     return self.get_config_with_defaults('CONFIG>CONFSTORE_BASE_CONFIG_PATH')
 
+  def get_confkey(self, key: str):
+    assert self.local_confstore != None
+    return self.local_confstore.get_config(key)
+
   def get_config_with_defaults(self, key: str):
     confkey = self.local_confstore.get_config(key)
     if "machine-id" in confkey:
@@ -207,8 +211,7 @@ class S3HaproxyConfig:
     s3authbendport = self.get_s3auth_backend_port()
 
     config_file = os.path.join(baseconfig_path, 's3/haproxy.cfg')
-    errors_path = os.path.join(baseconfig_path, 'haproxy/errors/')
-    errors_file = os.path.join(errors_path, '503.http')
+    errors_file = self.get_confkey("S3_HAPROXY_ERROR_CONFIG_FILE")
     global_text = '''global
     log         127.0.0.1 local2
     log stdout format raw local0
@@ -370,11 +373,6 @@ backend s3-auth
     pem_dir = os.path.dirname(sslcertpath)
     if not os.path.exists(pem_dir):
         os.makedirs(pem_dir)
-    if not os.path.exists(errors_path):
-        os.makedirs(errors_path)
-
-    #Run config commands
-    shutil.copy('/opt/seagate/cortx/s3/install/haproxy/503.http', errors_path)
 
   def configure_haproxy_legacy(self):
     """Main Processing function."""

--- a/scripts/provisioning/s3_haproxy_config.py
+++ b/scripts/provisioning/s3_haproxy_config.py
@@ -207,6 +207,8 @@ class S3HaproxyConfig:
     s3authbendport = self.get_s3auth_backend_port()
 
     config_file = os.path.join(baseconfig_path, 's3/haproxy.cfg')
+    errors_path = os.path.join(baseconfig_path, 'haproxy/errors/')
+    errors_file = os.path.join(errors_path, '503.http')
     global_text = '''global
     log         127.0.0.1 local2
     log stdout format raw local0
@@ -268,7 +270,7 @@ defaults
     option http-server-close
     option forwardfor       except 127.0.0.0/8
     option                  redispatch
-    errorfile               503 /etc/haproxy/errors/503.http
+    errorfile               503 %s
     retries                 3
     timeout http-request    10s
     timeout queue           10s
@@ -325,7 +327,7 @@ backend s3-auth
 '''
     config_handle = open(config_file, "w+")
     config_handle.write(global_text)
-    config_handle.write(default_text)
+    config_handle.write(default_text % errors_file)
     config_handle.write(frontend_s3main_text)
     config_handle.write(
          "   bind 0.0.0.0:%s\n"
@@ -368,7 +370,6 @@ backend s3-auth
     pem_dir = os.path.dirname(sslcertpath)
     if not os.path.exists(pem_dir):
         os.makedirs(pem_dir)
-    errors_path = os.path.join(baseconfig_path, 'haproxy/errors/')
     if not os.path.exists(errors_path):
         os.makedirs(errors_path)
 

--- a/scripts/provisioning/s3_prov_config.yaml
+++ b/scripts/provisioning/s3_prov_config.yaml
@@ -140,14 +140,13 @@ LDAP_MDB_LOCATION: "/var/lib/ldap"
 VALIDATION_PREREQ_FILE: "/opt/seagate/cortx/s3/mini-prov/s3setup_prereqs.json"
 TMP_DIR: "/etc/cortx/s3/tmp"
 
-CONFSTORE_SITE_COUNT_KEY: "cluster>cluster-id>site_count"
-
 # S3 config files
 S3_CONFIG_FILE: "/opt/seagate/cortx/s3/conf/s3config.yaml"
 S3_AUTHSERVER_CONFIG_FILE: "/opt/seagate/cortx/auth/resources/authserver.properties"
 S3_KEYSTORE_CONFIG_FILE: "/opt/seagate/cortx/auth/resources/keystore.properties"
 S3_BGDELETE_CONFIG_FILE: "/opt/seagate/cortx/s3/s3backgrounddelete/config.yaml"
 S3_CLUSTER_CONFIG_FILE: "/opt/seagate/cortx/s3/s3backgrounddelete/s3_cluster.yaml"
+S3_HAPROXY_ERROR_CONFIG_FILE: "/opt/seagate/cortx/s3/install/haproxy/503.http"
 
 # S3 sample config files
 S3_CONFIG_SAMPLE_FILE: "/opt/seagate/cortx/s3/conf/s3config.yaml.sample"

--- a/scripts/provisioning/s3_prov_config.yaml
+++ b/scripts/provisioning/s3_prov_config.yaml
@@ -66,7 +66,7 @@ CONFIG:
   CONFSTORE_S3_CLUSTER_ID: "cluster>id" #M (Usedby: None)
   CONFSTORE_STORAGE_SET_COUNT_KEY: "cluster>storage_set_count" #M (Usedby: s3_deployment)
   CONFSTORE_STORAGE_SET_SERVER_NODES_KEY: "cluster>storage_set[storage-set-count]>nodes"  #M (Usedby: s3_deployment)
-  CONFSTORE_BASE_CONFIG_PATH: "cortx>software>storage>config"  #M (Usedby: s3_deployment)
+  CONFSTORE_BASE_CONFIG_PATH: "cortx>software>storage>config"  #O default - /etc/cortx (Usedby: s3_deployment)
 
 
   ##################################################################################################
@@ -119,6 +119,7 @@ DEFAULT_CONFIG:
   CONFSTORE_S3_BGDELETE_SCHEDULER_SCHEDULE_INTERVAL: 1200
   CONFSTORE_S3_BGDELETE_MAX_KEYS: 1000
 
+  CONFSTORE_BASE_CONFIG_PATH: "/etc/cortx"
   CONFSTORE_S3_SECURITY_CERTIFICATE: "/etc/ssl/stx/stx.pem"
   CONFSTORE_S3_OPENLDAP_BASE_DN: "dc=seagate,dc=com"
 

--- a/scripts/provisioning/setupcmd.py
+++ b/scripts/provisioning/setupcmd.py
@@ -280,7 +280,6 @@ class SetupCmd(object):
     # The s3 prov config file has below pairs :
     # "Key Constant" : "Actual Key"
     # Example of "Key Constant" :
-    #   CONFSTORE_SITE_COUNT_KEY
     #   PREPARE
     #   CONFIG>CONFSTORE_LDAPADMIN_USER_KEY
     #   INIT


### PR DESCRIPTION
# Problem Statement
- HAproxy should read config path from confstore, remove hard-coding.

# Design
-  HAproxy should read config path from confstore, remove hard-coding.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
