### PR TITLE
EOS-24396: Fixed the opeldap schema as per new constore changes

### DIFF
--- a/scripts/provisioning/configcmd.py
+++ b/scripts/provisioning/configcmd.py
@@ -234,32 +234,27 @@ class ConfigCmd(SetupCmd):
 
   def configure_s3_schema(self):
     self.logger.info('openldap s3 configuration started')
-    storage_set_count = self.get_confvalue(self.get_confkey(
-        'CONFIG>CONFSTORE_STORAGE_SET_COUNT_KEY').replace("cluster-id", self.cluster_id))
-    index = 0
-    while index < int(storage_set_count):
-      server_nodes_list_key = self.get_confkey('CONFIG>CONFSTORE_S3_OPENLDAP_SERVERS')
-      server_nodes_list = self.get_confvalue(server_nodes_list_key)
-      if type(server_nodes_list) is str:
-        # list is stored as string in the confstore file
-        server_nodes_list = literal_eval(server_nodes_list)
-      for node_machine_id in server_nodes_list:
-          cmd = ['/opt/seagate/cortx/s3/install/ldap/s3_setup_ldap.sh',
-                 '--hostname',
-                 f'{node_machine_id}',
-                 '--ldapadminpasswd',
-                 f'{self.ldap_passwd}',
-                 '--rootdnpasswd',
-                 f'{self.rootdn_passwd}']
-          handler = SimpleProcess(cmd)
-          stdout, stderr, retcode = handler.run()
-          self.logger.info(f'output of setup_ldap.sh: {stdout}')
-          if retcode != 0:
-            self.logger.error(f'error of setup_ldap.sh: {stderr} {node_machine_id}')
-            raise S3PROVError(f"{cmd} failed with err: {stderr}, out: {stdout}, ret: {retcode}")
-          else:
-            self.logger.warning(f'warning of setup_ldap.sh: {stderr} {node_machine_id}')
-      index += 1
+    server_nodes_list_key = self.get_confkey('CONFIG>CONFSTORE_S3_OPENLDAP_SERVERS')
+    server_nodes_list = self.get_confvalue(server_nodes_list_key)
+    if type(server_nodes_list) is str:
+      # list is stored as string in the confstore file
+      server_nodes_list = literal_eval(server_nodes_list)
+    for node_machine_id in server_nodes_list:
+        cmd = ['/opt/seagate/cortx/s3/install/ldap/s3_setup_ldap.sh',
+                '--hostname',
+                f'{node_machine_id}',
+                '--ldapadminpasswd',
+                f'{self.ldap_passwd}',
+                '--rootdnpasswd',
+                f'{self.rootdn_passwd}']
+        handler = SimpleProcess(cmd)
+        stdout, stderr, retcode = handler.run()
+        self.logger.info(f'output of setup_ldap.sh: {stdout}')
+        if retcode != 0:
+          self.logger.error(f'error of setup_ldap.sh: {stderr} {node_machine_id}')
+          raise S3PROVError(f"{cmd} failed with err: {stderr}, out: {stdout}, ret: {retcode}")
+        else:
+          self.logger.warning(f'warning of setup_ldap.sh: {stderr} {node_machine_id}')
 
   def create_topic(self, admin_id: str, topic_name:str, partitions: int):
     """create topic for background delete services."""


### PR DESCRIPTION
# Problem Statement
- Storage set count is removed from the confstore. 
- Openldap is still using storage set count

# Solution
Fixed the opeldap schema as per new constore changes

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
