### PR TITLE
EOS-25162: Fix for GET failure post copy operation

### DIFF
--- a/server/s3_copy_object_action.cc
+++ b/server/s3_copy_object_action.cc
@@ -406,6 +406,8 @@ void S3CopyObjectAction::save_metadata() {
       additional_object_metadata->get_number_of_fragments());
   new_object_metadata->set_primary_obj_size(
       additional_object_metadata->get_primary_obj_size());
+  new_object_metadata->set_layout_id(
+      additional_object_metadata->get_layout_id());
 
   // put source object tags on new object
   s3_log(S3_LOG_DEBUG, stripped_request_id,

--- a/server/s3_object_metadata.h
+++ b/server/s3_object_metadata.h
@@ -466,6 +466,7 @@ class S3ObjectExtendedMetadata : private S3ObjectMetadataCopyable {
   std::string bucket_name;
   std::string object_name;
   std::string last_object;
+  std::string prefix_of_unique_object;
   std::string version_id;
   struct s3_motr_idx_layout extended_list_index_layout = {};
   std::shared_ptr<S3MotrKVSReader> motr_kv_reader;

--- a/server/s3_put_object_action_base.cc
+++ b/server/s3_put_object_action_base.cc
@@ -315,7 +315,7 @@ void S3PutObjectActionBase::create_part_fragment_successful() {
   s3_put_action_state = S3PutObjectActionState::newObjOidCreated;
 
   // New Object or overwrite, create new metadata and release old.
-  if (index == 0) {
+  if (new_object_metadata == nullptr) {
     new_object_metadata = object_metadata_factory->create_object_metadata_obj(
         request, bucket_metadata->get_object_list_index_layout(),
         bucket_metadata->get_objects_version_list_index_layout());
@@ -329,7 +329,7 @@ void S3PutObjectActionBase::create_part_fragment_successful() {
           object_metadata_factory->create_object_ext_metadata_obj(
               request, object_metadata->get_bucket_name(),
               object_metadata->get_object_name(),
-              object_metadata->get_obj_version_key(), 0, 0,
+              new_object_metadata->get_obj_version_key(), 0, 0,
               bucket_metadata->get_extended_metadata_index_layout());
 
       new_object_metadata->set_extended_object_metadata(
@@ -352,7 +352,9 @@ void S3PutObjectActionBase::create_part_fragment_successful() {
            sizeof(struct m0_fid));
     new_part_frag_ctx.versionID = new_object_metadata->get_obj_version_key();
     new_part_frag_ctx.item_size = part_fragment_context_list[index].item_size;
-    if (index == 0) {
+
+    // Get max part size of all parts
+    if (max_part_size == 0) {
       max_part_size = new_part_frag_ctx.item_size;
     } else {
       if (new_part_frag_ctx.item_size > max_part_size) {


### PR DESCRIPTION
Fix to GET failure post copy operation -- fix to
metadata udring copy operation, fix to prefix
during post completion.

Signed-off-by: Rajesh Nambiar <rajesh.nambiar@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added (Some UTs and STs already added, some will be added in a separate ticket http://eos-jenkins.colo.seagate.com/job/S3server/job/S3Server-PreMerge-Test/281/console)
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
