### PR TITLE
[EOS-23455] S3 Background to delete stale kvs entries and Parallel uploads

### DIFF
--- a/server/s3_abort_multipart_action.cc
+++ b/server/s3_abort_multipart_action.cc
@@ -293,15 +293,17 @@ void S3AbortMultipartAction::add_parts_oids_to_probable_dead_oid_list() {
     s3_log(S3_LOG_DEBUG, request_id,
            "Adding part probable del rec with key [%s]\n",
            part_oid_str.c_str());
+    unsigned int part_no = stoi(part_metadata->get_part_number());
     // TODO -- Verify whether background delete process it appropriately
     probable_del_rec.reset(new S3ProbableDeleteRecord(
         part_oid_str, {0ULL, 0ULL}, part_metadata->get_part_number(),
         part_metadata->get_oid(), part_metadata->get_layout_id(),
         part_metadata->get_pvid_str(),
-        part_metadata->get_part_index_layout().oid,
-        bucket_metadata->get_objects_version_list_index_layout().oid, "",
+        part_metadata->get_part_index_layout().oid, {0ULL, 0ULL}, "",
         false /* force_delete */, true,
-        part_metadata->get_part_index_layout().oid));
+        part_metadata->get_part_index_layout().oid, 1, part_no, {0ULL, 0ULL},
+        "",
+        object_multipart_metadata->get_oid() /* parent oid of multipart */));
     probable_oid_list[probable_del_rec->get_key()] =
         probable_del_rec->to_json();
     probable_del_rec_list.push_back(std::move(probable_del_rec));

--- a/server/s3_common.h
+++ b/server/s3_common.h
@@ -59,6 +59,8 @@ const char xml_spaces[] = "        ";
 #define MINIMUM_ALLOWED_PART_SIZE 5242880
 // 5368709120 -- 5GB
 #define MAXIMUM_ALLOWED_PART_SIZE 5368709120
+// Maximum size of object allowed is 5TB
+#define MAXIMUM_ALLOWED_OBJECT_SIZE 5497558138880
 // Minmimum part number for multipart operations
 #define MINIMUM_PART_NUMBER 1
 // Maxmimum part number for multipart operations

--- a/server/s3_common_utilities.cc
+++ b/server/s3_common_utilities.cc
@@ -139,14 +139,22 @@ void size_based_bucketing_of_objects(std::string &oid_str,
   // 50MB < size <= 1GB                           'F'
   // 10KB < size <= 50MB                          'G'
   // 1KB < size <= 10KB                           'H'
-  // size <= 1KB                                  'I'
+  // 0 < size <= 1KB                              'I'
+  // size = 0                                     'J'
+
+  // Note: size = 0 is added for dummy object in case of multipart parent object
 
   // NOTE : chars A/B/C have been left out for objects bigger than 100GB
   // Listing of keys in motr happens in lexicographic order, hence bigger object
   // will get listed first.
 
   switch (object_size_for_bucketing) {
-    case 0 ... 1024:  // less than or equal to 1KB
+    case 0:
+      marker = 'J';  // Multipart parent object (a dummy object oid)
+      oid_str.insert(0, marker);
+      break;
+
+    case 1 ... 1024:  // greater than 0 and less than equal to 1KB
       marker = 'I';
       oid_str.insert(0, marker);
       break;

--- a/server/s3_probable_delete_record.cc
+++ b/server/s3_probable_delete_record.cc
@@ -36,7 +36,7 @@ S3ProbableDeleteRecord::S3ProbableDeleteRecord(
     struct m0_uint128 objs_version_list_idx_oid, std::string ver_key_in_index,
     bool force_del, bool is_multipart, struct m0_uint128 part_list_oid,
     unsigned int frg, unsigned int prt, struct m0_uint128 extended_idx,
-    std::string ext_version_id)
+    std::string ext_version_id, struct m0_uint128 parent_oid)
     : record_key(rec_key),
       old_object_oid(old_oid),
       object_key_in_index(obj_key_in_index),
@@ -52,7 +52,8 @@ S3ProbableDeleteRecord::S3ProbableDeleteRecord(
       fragment(frg),
       part(prt),
       extended_md_idx_oid(extended_idx),
-      ext_version_id(ext_version_id) {
+      ext_version_id(ext_version_id),
+      mp_parent_oid(parent_oid) {
   // Assertions
   s3_log(S3_LOG_DEBUG, "", "object_key_in_index = %s\n",
          object_key_in_index.c_str());
@@ -103,7 +104,6 @@ std::string S3ProbableDeleteRecord::to_json() {
     root["is_multipart"] = "true";
     root["part_list_idx_oid"] = S3M0Uint128Helper::to_string(part_list_idx_oid);
     root["version_key_in_index"] = version_key_in_index;
-    root["ext_version_id"] = ext_version_id;
   } else {
     root["is_multipart"] = "false";
     root["version_key_in_index"] = version_key_in_index;
@@ -117,7 +117,9 @@ std::string S3ProbableDeleteRecord::to_json() {
     root["part"] = part;
   }
   if (fragment || part) {
-    // Add extended metadata(a.k.a fragment) index index oid
+    root["ext_version_id"] = ext_version_id;
+    root["parent_oid"] = S3M0Uint128Helper::to_string(mp_parent_oid);
+    // Add extended metadata(a.k.a fragment) index oid
     root["extended_md_idx_oid"] =
         S3M0Uint128Helper::to_string(extended_md_idx_oid);
   }

--- a/server/s3_probable_delete_record.h
+++ b/server/s3_probable_delete_record.h
@@ -55,6 +55,10 @@ class S3ProbableDeleteRecord {
   struct m0_uint128 extended_md_idx_oid;
 
   std::string ext_version_id;
+  // Parent dummy oid of multipart object
+  // This is provided for every part entry into probable delete list index
+  // to help S3 BD in leak determination when force_delete is false.
+  struct m0_uint128 mp_parent_oid;
 
  public:
   S3ProbableDeleteRecord(
@@ -65,7 +69,8 @@ class S3ProbableDeleteRecord {
       bool force_del = false, bool is_multipart = false,
       struct m0_uint128 part_list_oid = {0ULL, 0ULL}, unsigned int frg = 0,
       unsigned int prt = 0, struct m0_uint128 extended_idx = {0ULL, 0ULL},
-      std::string ext_version_id = {});
+      std::string ext_version_id = {},
+      struct m0_uint128 parent_oid = {0ULL, 0ULL});
   virtual ~S3ProbableDeleteRecord() {}
 
   virtual const std::string& get_key() const { return record_key; }

--- a/server/s3_put_multiobject_action.cc
+++ b/server/s3_put_multiobject_action.cc
@@ -699,7 +699,7 @@ void S3PutMultiObjectAction::add_object_oid_to_probable_dead_oid_list() {
       bucket_metadata->get_multipart_index_layout().oid,
       bucket_metadata->get_objects_version_list_index_layout().oid, "",
       false /* force_delete */, true,
-      part_metadata->get_part_index_layout().oid, 0,
+      part_metadata->get_part_index_layout().oid, 1,
       strtoul(part_metadata->get_part_number().c_str(), NULL, 0),
       bucket_metadata->get_extended_metadata_index_layout().oid));
   // store new oid, key = newoid

--- a/st/clitests/aws_iam_credential_file
+++ b/st/clitests/aws_iam_credential_file
@@ -1,5 +1,3 @@
 [default]
-aws_access_key_id = G6OFkXkYTyS_YRmxenLbBg
-aws_secret_access_key = KPykpvZqBQFysZ8vkmGwrPLXyafnOJ52n/qpRVOF
-
-
+aws_access_key_id = AKIAenS4eZxmQGCMpmUE_k_VFg
+aws_secret_access_key = 5mFDCF4SbUkTc6nz2ovelgpdDGAniCwKyg52SqJ3

--- a/st/clitests/runallsystest.sh
+++ b/st/clitests/runallsystest.sh
@@ -81,8 +81,8 @@ sed -i "s/password :.*/password : $ldap_root_pwd/g" test_data/ldap_config.yaml
 #Using Python 3.6 version for Running System Tests
 PythonV="python3.6"
 
-#echo "`date -u`: Running backgrounddelete_spec.py"
-#$PythonV backgrounddelete_spec.py
+echo "`date -u`: Running backgrounddelete_spec.py"
+$PythonV backgrounddelete_spec.py
 
 echo "`date -u`: Running auth_spec.py..."
 $PythonV auth_spec.py

--- a/ut/s3_common_utilities_test.cc
+++ b/ut/s3_common_utilities_test.cc
@@ -291,6 +291,10 @@ TEST_F(S3CommonUtilitiesTest, SizeBucketingOfObjects) {
 
   std::string original_string = "XYZ";
   S3CommonUtilities::size_based_bucketing_of_objects(original_string, 0);
+  EXPECT_EQ("JXYZ", original_string);
+
+  original_string = "XYZ";
+  S3CommonUtilities::size_based_bucketing_of_objects(original_string, 10);
   EXPECT_EQ("IXYZ", original_string);
 
   original_string = "XYZ";


### PR DESCRIPTION
Signed-off-by: Dattaprasad Govekar <dattaprasad.govekar@seagate.com>

# Problem statement 
- S3 BD to delete stale KVS entries during multipart operation and parallel upload

# Design
-  During S3 multipart object delete and S3 multipart complete, S3 server, after adding part entries to probable delete list index, would add additional entry for the parent(dummy) multipart object. This would help S3 BD to delete version entry associated with it once all parts are processed. As it is a dummy object, its size is considered 0. A prefix 'J' is added to oid. This prefix 'J' indicates it is dummy multipart object and S3 BD would delete stale version entry.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
