### PR TITLE
EOS-25051:S3:add MOTR_INIT_MAX_ALLOWED_TIME as config paramter to s3config file instead of hardcoded value

### DIFF
--- a/s3config-test.yaml
+++ b/s3config-test.yaml
@@ -120,6 +120,7 @@ S3_MOTR_CONFIG:                                     # Section for S3 Motr
    S3_MOTR_FIRST_READ_SIZE: 4                         # Num of units of First Read Request to MOTR
    S3_MOTR_SLEEP_DURING_RECONNECT: 4                 # Time in seconds
    S3_MOTR_RECONNECT_RETRY_COUNT: 15                 # No of times s3 will try to retry connection to motr.
+   S3_MOTR_INIT_MAX_TIMEOUT: 120                      # Motr init retry interval.
 S3_THIRDPARTY_CONFIG:
    S3_LIBEVENT_POOL_BUFFER_SIZE: 16384                   # Pool buffer size
                                                         # For S3_MOTR_UNIT_SIZE of size 1MB, it is recommended to have S3_LIBEVENT_POOL_BUFFER_SIZE of size 16384

--- a/s3config.release.yaml.sample
+++ b/s3config.release.yaml.sample
@@ -120,6 +120,7 @@ S3_MOTR_CONFIG:                                     # Section for S3 Motr
    S3_MOTR_FIRST_READ_SIZE: 4                         # Size in MB of the First Read Request to MOTR
    S3_MOTR_SLEEP_DURING_RECONNECT: 4                 # Time in seconds
    S3_MOTR_RECONNECT_RETRY_COUNT: 15                 # No of times s3 will try to retry connection to motr.
+   S3_MOTR_INIT_MAX_TIMEOUT: 120                      # Motr init retry interval.
 S3_THIRDPARTY_CONFIG:
    S3_LIBEVENT_POOL_BUFFER_SIZE: 16384                  # Pool buffer size, in case of S3_MOTR_UNIT_SIZE of size 1MB, it is recommended to have S3_LIBEVENT_POOL_BUFFER_SIZE of size 16384
    S3_LIBEVENT_MAX_READ_SIZE: 16384                     # Maximum read in a single read operation, as per libevent documentation in code, user should not try to read more than this value

--- a/s3config.yaml.sample
+++ b/s3config.yaml.sample
@@ -120,6 +120,7 @@ S3_MOTR_CONFIG:                                     # Section for S3 Motr
    S3_MOTR_FIRST_READ_SIZE: 4                        # Size in MB of the First Read Request to MOTR
    S3_MOTR_SLEEP_DURING_RECONNECT: 4                 # Time in seconds
    S3_MOTR_RECONNECT_RETRY_COUNT: 15                 # No of times s3 will try to retry connection to motr.
+   S3_MOTR_INIT_MAX_TIMEOUT: 120                      # Motr init retry interval.
 S3_THIRDPARTY_CONFIG:
    S3_LIBEVENT_POOL_BUFFER_SIZE: 16384                  # Pool buffer size, in case of S3_MOTR_UNIT_SIZE of size 1MB, it is recommended to have S3_LIBEVENT_POOL_BUFFER_SIZE of size 16384
    S3_LIBEVENT_MAX_READ_SIZE: 16384                     # Maximum read in a single read operation, as per libevent documentation in code, user should not try to read more than this value

--- a/scripts/provisioning/s3_start
+++ b/scripts/provisioning/s3_start
@@ -25,6 +25,7 @@ import errno
 import logging
 import os
 import socket
+import time
 from logging import handlers
 
 #Logger details
@@ -64,7 +65,12 @@ def main():
         raise Exception("provide instance id")
       fid_path = "/etc/cortx/s3/s3server-" + args.index
       Fid = get_fid(fid_path)
-      os.system(f"sh /opt/seagate/cortx/s3/s3startsystem.sh -F {Fid} -P {fid_path} -C {s3config_path} -d")
+      i = 0
+      while i < 10:
+        # Start S3 Server
+        os.system(f"sh /opt/seagate/cortx/s3/s3startsystem.sh -F {Fid} -P {fid_path} -C {s3config_path} -d")
+        i += 1
+        time.sleep(60)
       pass
     elif args.service == 's3authserver':
       os.system("sh /opt/seagate/cortx/auth/startauth.sh /opt/seagate/cortx")

--- a/server/s3_option.cc
+++ b/server/s3_option.cc
@@ -331,6 +331,9 @@ bool S3Option::load_section(std::string section_name,
       motr_reconnect_sleep_time =
           s3_option_node["S3_MOTR_SLEEP_DURING_RECONNECT"].as<unsigned int>();
       ;
+      motr_init_max_timeout =
+          s3_option_node["S3_MOTR_INIT_MAX_TIMEOUT"].as<unsigned int>();
+      ;
 
       std::string motr_read_pool_initial_buffer_count_str;
       std::string motr_read_pool_expandable_count_str;
@@ -1514,4 +1517,8 @@ unsigned int S3Option::get_motr_reconnect_retry_count() {
 
 unsigned int S3Option::get_motr_reconnect_sleep_time() {
   return motr_reconnect_sleep_time;
+}
+
+unsigned int S3Option::get_motr_init_max_timeout() {
+  return motr_init_max_timeout;
 }

--- a/server/s3_option.h
+++ b/server/s3_option.h
@@ -150,6 +150,7 @@ class S3Option {
   unsigned int motr_first_obj_read_size;
   unsigned int motr_reconnect_retry_count;
   unsigned int motr_reconnect_sleep_time;
+  unsigned int motr_init_max_timeout;
 
   unsigned bucket_metadata_cache_max_size;
   unsigned bucket_metadata_cache_expire_sec;
@@ -456,6 +457,7 @@ class S3Option {
   unsigned int get_motr_first_read_size();
   unsigned int get_motr_reconnect_sleep_time();
   unsigned int get_motr_reconnect_retry_count();
+  unsigned int get_motr_init_max_timeout();
 
   size_t get_libevent_pool_initial_size();
   size_t get_libevent_pool_expandable_size();

--- a/server/s3server.cc
+++ b/server/s3server.cc
@@ -60,7 +60,6 @@
 #define MIN_RESERVE_SIZE 32768
 
 #define WEBSTORE "/home/seagate/webstore"
-#define MOTR_INIT_MAX_ALLOWED_TIME 120
 
 /* Program options */
 #include <unistd.h>
@@ -972,7 +971,7 @@ int main(int argc, char **argv) {
 
     struct timeval tv;
     tv.tv_usec = 0;
-    tv.tv_sec = MOTR_INIT_MAX_ALLOWED_TIME;
+    tv.tv_sec = g_option_instance->get_motr_init_max_timeout();
 
     struct event *timer_event =
         event_new(global_evbase_handle, -1, 0, s3_motr_init_timeout_cb, NULL);


### PR DESCRIPTION
Handling motr hang issue by increasing MOTR_INIT_MAX_ALLOWED_TIME value from 15 -> 120
Note : **this is done in main branch** 

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
