### PR TITLE
EOS-25589: Multipart overwrite object with old object with 1000 parts need stage-wise addition of probable entries

### DIFF
--- a/server/s3_post_complete_action.cc
+++ b/server/s3_post_complete_action.cc
@@ -682,7 +682,6 @@ void S3PostCompleteAction::add_part_object_to_probable_dead_oid_list(
           new_obj_pvids.push_back(part_entry[0].PVID);
           new_obj_layout_ids.push_back(part_entry[0].layout_id);
         }
-
       }
     }  // End of For
     // Add one more entry for parent multipart object to erase it
@@ -752,21 +751,14 @@ void S3PostCompleteAction::add_object_oid_to_probable_dead_oid_list() {
     assert(!new_oid_str.empty());
     add_part_object_to_probable_dead_oid_list(new_object_metadata,
                                               new_parts_probable_del_rec_list);
-    std::map<std::string, std::string> kv_list;
     for (auto& probable_rec : new_parts_probable_del_rec_list) {
       kv_list[probable_rec->get_key()] = probable_rec->to_json();
     }
     if (!kv_list.empty()) {
       // S3 Background delete will delete new object parts, when multipart
       // metadata has been deleted
-      motr_kv_writer->put_keyval(
-          global_probable_dead_object_list_index_layout, kv_list,
-          std::bind(&S3PostCompleteAction::
-                         add_object_oid_to_probable_dead_oid_list_success,
-                    this),
-          std::bind(&S3PostCompleteAction::
-                         add_object_oid_to_probable_dead_oid_list_failed,
-                    this));
+      total_keys = kv_list.size();
+      save_probable_list_metadata(kv_list);
     } else {
       next();
     }
@@ -779,7 +771,6 @@ void S3PostCompleteAction::add_object_oid_to_probable_dead_oid_list() {
       assert(!new_oid_str.empty());
       add_part_object_to_probable_dead_oid_list(
           object_metadata, old_parts_probable_del_rec_list, true);
-      std::map<std::string, std::string> kv_list;
       for (auto& probable_rec : old_parts_probable_del_rec_list) {
         kv_list[probable_rec->get_key()] = probable_rec->to_json();
       }
@@ -787,14 +778,8 @@ void S3PostCompleteAction::add_object_oid_to_probable_dead_oid_list() {
         // S3 Background delete will delete old object parts, when current
         // object metadata has
         // moved on
-        motr_kv_writer->put_keyval(
-            global_probable_dead_object_list_index_layout, kv_list,
-            std::bind(&S3PostCompleteAction::
-                           add_object_oid_to_probable_dead_oid_list_success,
-                      this),
-            std::bind(&S3PostCompleteAction::
-                           add_object_oid_to_probable_dead_oid_list_failed,
-                      this));
+        total_keys = kv_list.size();
+        save_probable_list_metadata(kv_list);
       } else {
         next();
       }
@@ -803,6 +788,85 @@ void S3PostCompleteAction::add_object_oid_to_probable_dead_oid_list() {
       next();
     }
   }
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
+
+void S3PostCompleteAction::save_probable_list_metadata(
+    std::map<std::string, std::string>& key_values) {
+  s3_log(S3_LOG_DEBUG, stripped_request_id, "%s Entry\n", __func__);
+  if ((key_values.size() > 0) &&
+      (key_values.size() <= MAX_PUT_MULTIPART_EXTENDED_ENTRIES)) {
+    motr_kv_writer->put_keyval(
+        global_probable_dead_object_list_index_layout, key_values,
+        std::bind(&S3PostCompleteAction::
+                       add_object_oid_to_probable_dead_oid_list_success,
+                  this),
+        std::bind(&S3PostCompleteAction::
+                       add_object_oid_to_probable_dead_oid_list_failed,
+                  this));
+  } else if (key_values.size() > MAX_PUT_MULTIPART_EXTENDED_ENTRIES) {
+    save_partial_probable_list_metadata(key_values);
+  }
+  s3_log(S3_LOG_DEBUG, stripped_request_id, "%s Exit\n", __func__);
+}
+
+void S3PostCompleteAction::save_partial_probable_list_metadata(
+    std::map<std::string, std::string>& key_values) {
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
+  assert(key_values.size());
+  unsigned int kv_to_be_processed = key_values.size() - total_processed_count;
+  unsigned int how_many_kv_to_write =
+      ((kv_to_be_processed - MAX_PUT_MULTIPART_EXTENDED_ENTRIES) >
+       MAX_PUT_MULTIPART_EXTENDED_ENTRIES)
+          ? MAX_PUT_MULTIPART_EXTENDED_ENTRIES
+          : kv_to_be_processed;
+  if (motr_kv_writer == nullptr) {
+    motr_kv_writer =
+        mote_kv_writer_factory->create_motr_kvs_writer(request, s3_motr_api);
+  }
+
+  motr_kv_writer->put_partial_keyval(
+      global_probable_dead_object_list_index_layout, key_values,
+      std::bind(
+          &S3PostCompleteAction::save_partial_probable_list_metadata_successful,
+          this, std::placeholders::_1),
+      std::bind(
+          &S3PostCompleteAction::save_partial_probable_list_metadata_failed,
+          this, std::placeholders::_1),
+      total_processed_count, how_many_kv_to_write);
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
+
+void S3PostCompleteAction::save_partial_probable_list_metadata_successful(
+    unsigned int processed_count) {
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
+  total_processed_count += processed_count;
+  s3_log(S3_LOG_INFO, request_id,
+         "%u probable delete entries saved for Object [%s]. "
+         "total_processed_count[%u]\n",
+         processed_count, object_name.c_str(), total_processed_count);
+  if (total_processed_count < total_keys) {
+    if (request->client_connected() &&
+        request->get_response_started_by_action()) {
+      // send white space to client, if it has already been initiated by action
+      // class
+      request->send_reply_body(xml_spaces, sizeof(xml_spaces) - 1);
+    }
+    save_partial_probable_list_metadata(kv_list);
+  } else {
+    add_object_oid_to_probable_dead_oid_list_success();
+  }
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
+
+void S3PostCompleteAction::save_partial_probable_list_metadata_failed(
+    unsigned int processed_count) {
+  s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
+  s3_log(S3_LOG_ERROR, request_id,
+         "Failed to save %u probbale delete entries for Object [%s] "
+         "total_processed_count[%u]\n",
+         processed_count, object_name.c_str(), total_processed_count);
+  add_object_oid_to_probable_dead_oid_list_failed();
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 

--- a/server/s3_post_complete_action.h
+++ b/server/s3_post_complete_action.h
@@ -106,6 +106,11 @@ class S3PostCompleteAction : public S3ObjectAction {
   std::map<unsigned int, std::string> part_etags;
   std::string generate_etag();
   bool mp_completion_send_space_chk_shutdown();
+  // Following state used during partial put kv
+  // - while adding probbale leak entries for parts
+  unsigned int total_processed_count = 0;
+  unsigned int total_keys = 0;
+  std::map<std::string, std::string> kv_list;
 
  public:
   S3PostCompleteAction(
@@ -164,6 +169,11 @@ class S3PostCompleteAction : public S3ObjectAction {
       const std::shared_ptr<S3ObjectMetadata> &,
       std::vector<std::unique_ptr<S3ProbableDeleteRecord>> &,
       bool is_old_object = false);
+  void save_probable_list_metadata(std::map<std::string, std::string> &);
+  void save_partial_probable_list_metadata(
+      std::map<std::string, std::string> &);
+  void save_partial_probable_list_metadata_successful(unsigned int);
+  void save_partial_probable_list_metadata_failed(unsigned int);
 
   void startcleanup() override;
   void mark_old_oid_for_deletion();


### PR DESCRIPTION
 
Signed-off-by: Dattaprasad Govekar <dattaprasad.govekar@seagate.com>

# Problem Statement
- Problem statement

# Design
-  Addition of old parts to probable leak index is done in stages, sending white space
   to client for every stage.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
