### PR TITLE
EOS-25359: Clear bucket metadata object before reloading from Motr.

### DIFF
--- a/server/s3_bucket_metadata.cc
+++ b/server/s3_bucket_metadata.cc
@@ -182,11 +182,13 @@ int S3BucketMetadata::from_json(std::string content) {
   bucket_name = newroot["Bucket-Name"].asString();
 
   Json::Value::Members members = newroot["System-Defined"].getMemberNames();
+  system_defined_attribute.clear();
   for (auto it : members) {
     system_defined_attribute[it.c_str()] =
         newroot["System-Defined"][it].asString();
   }
   members = newroot["User-Defined"].getMemberNames();
+  user_defined_attribute.clear();
   for (auto it : members) {
     user_defined_attribute[it.c_str()] = newroot["User-Defined"][it].asString();
   }
@@ -212,6 +214,7 @@ int S3BucketMetadata::from_json(std::string content) {
   bucket_policy = base64_decode(newroot["Policy"].asString());
 
   members = newroot["User-Defined-Tags"].getMemberNames();
+  bucket_tags.clear();
   for (const auto& tag : members) {
     bucket_tags[tag] = newroot["User-Defined-Tags"][tag].asString();
   }

--- a/server/s3_motr_kvs_reader.cc
+++ b/server/s3_motr_kvs_reader.cc
@@ -26,8 +26,8 @@
 #include "s3_motr_kvs_reader.h"
 #include "s3_motr_rw_common.h"
 #include "s3_option.h"
-#include "s3_uri_to_motr_oid.h"
 #include "s3_stats.h"
+#include "s3_uri_to_motr_oid.h"
 
 extern struct m0_realm motr_uber_realm;
 extern struct m0_container motr_container;
@@ -38,7 +38,6 @@ extern int shutdown_motr_teardown_called;
 S3MotrKVSReader::S3MotrKVSReader(std::shared_ptr<RequestObject> req,
                                  std::shared_ptr<MotrAPI> motr_api)
     : request(std::move(req)) {
-
   request_id = request->get_request_id();
   stripped_request_id = request->get_stripped_request_id();
   s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
@@ -259,12 +258,18 @@ void S3MotrKVSReader::get_keyval_successful() {
     assert(kvs_ctx->keys->ov_buf[i] != NULL);
     key = std::string((char *)kvs_ctx->keys->ov_buf[i],
                       kvs_ctx->keys->ov_vec.v_count[i]);
+    s3_log(S3_LOG_DEBUG, stripped_request_id, "key[%zd] = %s\n", i,
+           key.c_str());
+    s3_log(S3_LOG_DEBUG, stripped_request_id, "rc[%zd] = %d\n", i,
+           (int)kvs_ctx->rcs[i]);
     if (kvs_ctx->rcs[i] == 0) {
       rcs = 0;
       keys_retrieved = true;  // atleast one key successfully retrieved
       if (kvs_ctx->values->ov_buf[i] != NULL) {
         val = std::string((char *)kvs_ctx->values->ov_buf[i],
                           kvs_ctx->values->ov_vec.v_count[i]);
+        s3_log(S3_LOG_DEBUG, stripped_request_id, "value[%zd] = %s\n", i,
+               val.c_str());
       } else {
         val = "";
       }

--- a/server/s3server.cc
+++ b/server/s3server.cc
@@ -112,7 +112,7 @@ std::set<struct s3_motr_obj_context *> global_motr_obj;
 void s3_motr_init_timeout_cb(evutil_socket_t fd, short event, void *arg) {
   // s3_iem(LOG_ALERT, S3_IEM_MOTR_CONN_FAIL, S3_IEM_MOTR_CONN_FAIL_STR,
   //     S3_IEM_MOTR_CONN_FAIL_JSON);
-  s3_log(S3_LOG_FATAL, "", "Motr connection timet out (hang)\n");
+  s3_log(S3_LOG_FATAL, "", "Motr connection timed out (hang?)\n");
   event_base_loopbreak(global_evbase_handle);
   return;
 }


### PR DESCRIPTION
* Clear bucket metadata object before reloading from Motr.
* Fix misprints in log messages.
* Add extra logging for get_keyval.

Signed-off-by: Ivan Tishchenko <ivan.tishchenko@seagate.com>

# Problem Statement
- s3 would sometimes return stale bucket tags, even after bucket MD cache timeout passes.

# Design
- For Bug, Describe the fix here.
- Properly clear cache entry before loading from Motr.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
