### PR TITLE
EOS-25783: Add options to jenkins-build.sh to speed up s3server rebuild.

### DIFF
--- a/jenkins-build.sh
+++ b/jenkins-build.sh
@@ -20,7 +20,7 @@
 
 
 USAGE="USAGE: bash $(basename "$0") [--use_http_client | --s3server_enable_ssl ]
-                        [--use_ipv6] [--skip_build] [--skip_ut_build]
+                        [--use_ipv6] [--skip_build] [--skip_ut_build] [--no_clean_build] [--build_only_s3server]
                         [--skip_tests] [--skip_ut_run] [--skip_st_run]
                         [--cleanup_only]
                         [--fake_obj] [--fake_kvs | --redis_kvs] [--basic_test_only]
@@ -48,6 +48,10 @@ where:
 --skip_build             Do not run build step
 
 --skip_ut_build          Do not run build step for UTs
+
+--no_clean_build         Do not run clean build.
+
+--build_only_s3server    Only build/rebuild s3server, leave other targest as is.
 
 --skip_tests             Do not run tests, exit before test run
 
@@ -130,6 +134,8 @@ use_ipv6=0
 restart_haproxy=0
 skip_build=0
 skip_ut_build=0
+no_clean_build=0
+build_only_s3server=0
 cleanup_only=0
 skip_tests=0
 skip_ut_run=0
@@ -189,6 +195,12 @@ else
           ;;
       --skip_ut_build ) skip_ut_build=1;
           echo "Skip UTs build step";
+          ;;
+      --no_clean_build ) no_clean_build=1;
+          echo "Do not run clean build";
+          ;;
+      --build_only_s3server ) build_only_s3server=1;
+          echo "Only build/rebuild s3server, leave other targest as is";
           ;;
       --skip_tests ) skip_tests=1;
           echo "Skip test step";
@@ -418,6 +430,18 @@ then
     if [ $skip_tests -ne 0 ]
     then
         extra_opts+=" --no-java-tests"
+    fi
+    if [ $no_clean_build -ne 0 ]
+    then
+        extra_opts+=" --no-clean-build"
+    fi
+    if [ $build_only_s3server -ne 0 ]
+    then
+        extra_opts+=" --no-s3ut-build --no-s3mempoolut-build --no-s3mempoolmgrut-build --no-motrkvscli-build"
+        extra_opts+=" --no-base64-encoder-decoder-build --no-auth-build --no-jclient-build"
+        extra_opts+=" --no-jcloudclient-build --no-java-tests --no-s3addbplugin-build"
+        extra_opts+=" --no-s3confstoretool-build --no-s3background-build --no-s3msgbus-build"
+        extra_opts+=" --no-s3cipher-build --no-s3iamcli-build"
     fi
     ./rebuildall.sh --no-motr-rpm --use-build-cache $valgrind_flag $extra_opts --bazel_cpu_usage_limit $bazel_cpu_limit --bazel_ram_usage_limit $bazel_ram_limit
 fi

--- a/rebuildall.sh
+++ b/rebuildall.sh
@@ -34,8 +34,8 @@ usage() {
   echo '                                       Default is (false) i.e. use motr libs from pre-installed'
   echo '                                       motr rpm location (/usr/lib64)'
   echo '          --use-build-cache          : Use build cache for third_party and motr, Default (false)'
-  echo '                                      If cache is missing, third_party and motr will be rebuilt'
-  echo '                                      Ensuring consistency of cache is responsibility of caller'
+  echo '                                       If cache is missing, third_party and motr will be rebuilt'
+  echo '                                       Ensuring consistency of cache is responsibility of caller'
   echo '          --no-check-code            : Do not check code for formatting style, Default (false)'
   echo '          --no-clean-build           : Do not clean before build, Default (false)'
   echo '                                       Use this option for incremental build.'
@@ -143,7 +143,7 @@ get_motr_pkg_config_rpm() {
 
 # read the options
 OPTS=`getopt -o h --long no-motr-rpm,use-build-cache,no-check-code,no-clean-build,\
-no-s3ut-build,no-s3mempoolut-build,no-s3mempoolmgrut-build,no-s3server-build,\
+no-s3ut-build,no-s3mempoolut-build,no-s3mempoolmgrut-build,no-s3server-build,no-base64-encoder-decoder-build,\
 no-motrkvscli-build,no-s3background-build,no-s3msgbus-build,no-s3cipher-build,no-s3confstoretool-build,\
 no-s3addbplugin-build,no-auth-build,no-jclient-build,no-jcloudclient-build,\
 no-s3iamcli-build,no-java-tests,no-install,just-gen-build-file,valgrind_memcheck,\


### PR DESCRIPTION
With this change, it is now possible to quicker test s3server changes, by running this below command:

```
./jenkins-build.sh --no_clean_build --build_only_s3server --skip_tests
```

This will only build/rebuild s3server, and leave other targets as is.

Signed-off-by: Ivan Tishchenko <ivan.tishchenko@seagate.com>

# Problem Statement
- Even a single file change in s3server would cause rebuild of all other tools as well (Java, kvscli, etc).

# Design
-  Add CLI option to bypass everything but s3server.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
