### PR TITLE
[versioning] [EOS-24955] GetObject with version

### DIFF
--- a/server/action_base.cc
+++ b/server/action_base.cc
@@ -89,6 +89,17 @@ void Action::set_s3_error_message(std::string message) {
   s3_error_message = std::move(message);
 }
 
+void Action::set_invalid_argument(std::string arg_name, std::string arg_val) {
+  invalid_arg_name = std::move(arg_name);
+  invalid_arg_value = std::move(arg_val);
+}
+const std::string& Action::get_invalid_argument_name() {
+  return invalid_arg_name;
+}
+const std::string& Action::get_invalid_argument_value() {
+  return invalid_arg_value;
+}
+
 void Action::client_read_error() {
   const std::string& s3_error = base_request->get_s3_client_read_error();
   set_s3_error(s3_error);

--- a/server/action_base.h
+++ b/server/action_base.h
@@ -156,6 +156,9 @@ class Action {
   bool action_uses_cleanup;
   bool cleanup_started;  // action has started cleanup process.
 
+  std::string invalid_arg_name;
+  std::string invalid_arg_value;
+
  public:
   Action(std::shared_ptr<RequestObject> req, bool check_shutdown = true,
          std::shared_ptr<S3AuthClientFactory> auth_factory = nullptr,
@@ -169,6 +172,9 @@ class Action {
   const std::string& get_s3_error_message() const;
   bool is_error_state() const;
   void client_read_error();
+  void set_invalid_argument(std::string arg_name, std::string arg_val);
+  const std::string& get_invalid_argument_name();
+  const std::string& get_invalid_argument_value();
 
  protected:
   void add_task(std::function<void()> task, const char* func_name) {

--- a/server/s3_error_codes.cc
+++ b/server/s3_error_codes.cc
@@ -34,6 +34,11 @@ int S3Error::get_http_status_code() { return details.get_http_status_code(); }
 void S3Error::set_auth_error_message(const std::string& errmsg) {
   auth_error_message = errmsg;
 }
+void S3Error::set_invalid_arg(const std::string& arg_name,
+                              const std::string& arg_val) {
+  invalid_arg_name = arg_name;
+  invalid_arg_value = arg_val;
+}
 
 std::string& S3Error::to_xml(bool no_decl) {
   if (get_http_status_code() == -1) {
@@ -52,6 +57,12 @@ std::string& S3Error::to_xml(bool no_decl) {
   } else {
     xml_message +=
         S3CommonUtilities::format_xml_string("Message", auth_error_message);
+  }
+  if (!invalid_arg_name.empty()) {
+    xml_message +=
+        S3CommonUtilities::format_xml_string("ArgumentName", invalid_arg_name);
+    xml_message += S3CommonUtilities::format_xml_string("ArgumentValue",
+                                                        invalid_arg_value);
   }
   xml_message += S3CommonUtilities::format_xml_string("Resource", resource_key);
   xml_message += S3CommonUtilities::format_xml_string("RequestId", request_id);

--- a/server/s3_error_codes.h
+++ b/server/s3_error_codes.h
@@ -56,6 +56,8 @@ class S3Error {
   S3ErrorDetails& details;
 
   std::string xml_message;
+  std::string invalid_arg_name;
+  std::string invalid_arg_value;
 
  public:
   S3Error(const std::string& error_code, std::string req_id,
@@ -64,6 +66,7 @@ class S3Error {
   int get_http_status_code();
 
   void set_auth_error_message(const std::string&);
+  void set_invalid_arg(const std::string& arg_name, const std::string& arg_val);
 
   std::string& to_xml(bool no_decl = false);
 };

--- a/server/s3_get_object_action.cc
+++ b/server/s3_get_object_action.cc
@@ -97,22 +97,36 @@ void S3GetObjectAction::fetch_object_info_failed() {
     if (zero(obj_list_idx_lo.oid)) {
       s3_log(S3_LOG_ERROR, request_id, "Object not found\n");
       set_s3_error("NoSuchKey");
-    } else {
-      if (object_metadata->get_state() == S3ObjectMetadataState::missing) {
-        s3_log(S3_LOG_DEBUG, request_id, "Object not found\n");
-        set_s3_error("NoSuchKey");
-      } else if (object_metadata->get_state() ==
-                 S3ObjectMetadataState::failed_to_launch) {
-        s3_log(S3_LOG_ERROR, request_id,
-               "Object metadata load operation failed due to pre launch "
-               "failure\n");
-        set_s3_error("ServiceUnavailable");
+    } else if (request->has_query_param_key("versionId") &&
+               request->get_query_string_value("versionId").empty()) {
+      // VersionId can not be empty
+      s3_log(S3_LOG_DEBUG, request_id,
+             "Empty versionId provided in the request\n");
+      set_s3_error("InvalidArgument");
+      set_s3_error_message("Version id cannot be the empty string");
+      set_invalid_argument("versionId", "");
+    } else if (object_metadata->get_state() == S3ObjectMetadataState::missing) {
+      s3_log(S3_LOG_DEBUG, request_id, "Object not found\n");
+      if (request->has_query_param_key("versionId")) {
+        set_s3_error("InvalidArgument");
+        set_s3_error_message("Invalid version id specified");
+        set_invalid_argument("versionId",
+                             request->get_query_string_value("versionId"));
       } else {
-        s3_log(S3_LOG_DEBUG, request_id, "Object metadata fetch failed\n");
-        set_s3_error("InternalError");
+        set_s3_error("NoSuchKey");
       }
+    } else if (object_metadata->get_state() ==
+               S3ObjectMetadataState::failed_to_launch) {
+      s3_log(S3_LOG_ERROR, request_id,
+             "Object metadata load operation failed due to pre launch "
+             "failure\n");
+      set_s3_error("ServiceUnavailable");
+    } else {
+      s3_log(S3_LOG_DEBUG, request_id, "Object metadata fetch failed\n");
+      set_s3_error("InternalError");
     }
   }
+
   send_response_to_s3_client();
 }
 
@@ -825,6 +839,10 @@ void S3GetObjectAction::send_data_to_client() {
     request->set_out_header_value("Accept-Ranges", "bytes");
     request->set_out_header_value(
         "Content-Length", std::to_string(get_requested_content_length()));
+    if (bucket_metadata->get_bucket_versioning_status() != "Unversioned") {
+      request->set_out_header_value("x-amz-version-id",
+                                    object_metadata->get_obj_version_id());
+    }
     for (auto it : object_metadata->get_user_attributes()) {
       request->set_out_header_value(it.first, it.second);
     }
@@ -1016,7 +1034,11 @@ void S3GetObjectAction::send_response_to_s3_client() {
   } else if (is_error_state() && !get_s3_error_code().empty()) {
     // Invalid Bucket Name
     S3Error error(get_s3_error_code(), request->get_request_id(),
-                  request->get_object_uri());
+                  request->get_object_uri(), get_s3_error_message());
+    if (get_s3_error_code() == "InvalidArgument") {
+      error.set_invalid_arg(get_invalid_argument_name(),
+                            get_invalid_argument_value());
+    }
     std::string& response_xml = error.to_xml();
     request->set_out_header_value("Content-Type", "application/xml");
     request->set_out_header_value("Content-Length",

--- a/server/s3_get_object_action.h
+++ b/server/s3_get_object_action.h
@@ -105,6 +105,9 @@ class S3GetObjectAction : public S3ObjectAction {
               FetchObjectInfoWhenBucketAndObjIndexPresent);
   FRIEND_TEST(S3GetObjectActionTest,
               ValidateObjectWhenMissingObjectReportNoSuckKey);
+  FRIEND_TEST(S3GetObjectActionTest, FetchObjectInfoFailedEmptyVersionId);
+  FRIEND_TEST(S3GetObjectActionTest, FetchObjectInfoFailedInvalidVersionId);
+  FRIEND_TEST(S3GetObjectActionTest, FetchObjectInfoFailedKeyNotPresent);
   FRIEND_TEST(S3GetObjectActionTest,
               ValidateObjectWhenObjInfoFetchFailedReportError);
   FRIEND_TEST(S3GetObjectActionTest, ReadObjectFailedJustEndResponse1);

--- a/server/s3_object_action_base.cc
+++ b/server/s3_object_action_base.cc
@@ -93,6 +93,10 @@ void S3ObjectAction::fetch_object_info() {
   if (zero(obj_list_idx_lo.oid) || zero(obj_version_list_idx_lo.oid)) {
     // Object list index and version list index missing.
     fetch_object_info_failed();
+  } else if (request->has_query_param_key("versionId") &&
+             (request->get_query_string_value("versionId").empty())) {
+    // VersionId can not be empty
+    fetch_object_info_failed();
   } else {
     object_metadata = object_metadata_factory->create_object_metadata_obj(
         request, obj_list_idx_lo, obj_version_list_idx_lo);

--- a/server/s3_object_action_base.h
+++ b/server/s3_object_action_base.h
@@ -106,6 +106,8 @@ class S3ObjectAction : public S3Action {
   FRIEND_TEST(S3ObjectActionTest, SetAuthorizationMeta);
   FRIEND_TEST(S3ObjectActionTest, FetchObjectInfoFailed);
   FRIEND_TEST(S3ObjectActionTest, FetchObjectInfoSuccess);
+  FRIEND_TEST(S3ObjectActionTest, FetchObjectInfo);
+  FRIEND_TEST(S3ObjectActionTest, FetchObjectInfoFailedEmptyVersionId);
 };
 
 #endif

--- a/server/s3_object_metadata.h
+++ b/server/s3_object_metadata.h
@@ -119,6 +119,7 @@ class S3ObjectMetadata : private S3ObjectMetadataCopyable {
   // Used in validation
   std::string requested_bucket_name;
   std::string requested_object_name;
+  std::string requested_object_version_id;
 
   // Reverse epoch time used as version id key in verion index
   std::string rev_epoch_version_id_key;
@@ -440,6 +441,7 @@ class S3ObjectMetadata : private S3ObjectMetadataCopyable {
   FRIEND_TEST(S3ObjectMetadataTest, GetEncodedBucketAcl);
   FRIEND_TEST(S3DeleteObjectActionTest, CleanupOnMetadataDeletion);
   FRIEND_TEST(S3ObjectMetadataTest, ValidateVersionEntryToJson);
+  FRIEND_TEST(S3ObjectMetadataTest, LoadObjectInfoFromVersionListIdex);
 };
 
 // Fragment or the part detail structure

--- a/st/clitests/awss3api.py
+++ b/st/clitests/awss3api.py
@@ -360,15 +360,21 @@ class AwsTest(S3PyCliTest):
         self.with_cli(cmd)
         return self
 
-    def get_object(self, bucket_name, object_name, outfile=None, debug_flag=None, start_range=None, end_range=None):
+    def get_object(self, bucket_name, object_name, version_id=None, outfile=None, debug_flag=None, start_range=None, end_range=None):
         self.bucket_name = bucket_name
         self.object_name = object_name
         if outfile is None:
             outfile = object_name
+        cmd = "aws s3api get-object --bucket " + bucket_name + " --key " + object_name
+        if version_id is not None:
+            if version_id == "empty":
+                cmd += " --version-id \"\""
+            else:
+                cmd += " --version-id " + version_id
         if start_range is not None and end_range is not None:
-            cmd = "aws s3api get-object --bucket " + bucket_name + " --key " + object_name + " " + "--range bytes=" + start_range + "-" + end_range + " " + outfile
+            cmd += " --range bytes=" + start_range + "-" + end_range + " " + outfile
         else:
-            cmd = "aws s3api get-object --bucket " + bucket_name + " --key " + object_name + " " + outfile
+            cmd += " " + outfile
         self.with_cli(cmd)
         if debug_flag is not None:
            self.command += " --debug"

--- a/st/clitests/awss3api_spec.py
+++ b/st/clitests/awss3api_spec.py
@@ -1935,6 +1935,28 @@ AwsTest('Aws can not change the versioning status back to unversioned')\
 AwsTest('Aws can not enable versioning on non-existant bucket').put_bucket_versioning("seagate1", "Enabled")\
     .execute_test(negative_case=True).command_should_fail().command_error_should_have("NoSuchBucket")
 
+#******** GetObject with Bucket versioning enabled ********
+AwsTest('Aws can enable versioning on bucket').put_bucket_versioning("seagatebucket", "Enabled")\
+    .execute_test().command_is_successful()
+
+result = AwsTest('Aws can put object').put_object("seagatebucket", "1kfile", 1024)\
+    .execute_test().command_is_successful()
+
+versionId = result.status.stdout.split('\t')[1]
+
+result = AwsTest('Aws can get object with specific versionId').get_object("seagatebucket", "1kfile", version_id=versionId)\
+    .execute_test().command_is_successful().command_response_should_have(versionId)
+
+result = AwsTest('Aws can get object without specifing versionId').get_object("seagatebucket", "1kfile")\
+    .execute_test().command_is_successful().command_response_should_have(versionId)
+
+result = AwsTest('Aws can not get object with wrong versionId').get_object("seagatebucket", "1kfile", version_id="wrong-id")\
+    .execute_test(negative_case=True).command_should_fail().command_error_should_have("InvalidArgument").command_error_should_have("Invalid version id specified")
+
+result = AwsTest('Aws can not get object with empty versionId').get_object("seagatebucket", "1kfile", version_id="empty")\
+    .execute_test(negative_case=True).command_should_fail().command_error_should_have("InvalidArgument").command_error_should_have("Version id cannot be the empty string")
+
+
 #******** Delete Bucket ********
 AwsTest('Aws can delete bucket').delete_bucket("seagatebucket")\
     .execute_test().command_is_successful()

--- a/ut/s3_abort_multipart_test.cc
+++ b/ut/s3_abort_multipart_test.cc
@@ -58,6 +58,8 @@ class S3AbortMultipartActionTest : public testing::Test {
         .WillRepeatedly(ReturnRef(object_name));
     EXPECT_CALL(*ptr_mock_request, get_bucket_name())
         .WillRepeatedly(ReturnRef(bucket_name));
+    EXPECT_CALL(*ptr_mock_request, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
 
     ptr_mock_s3_motr_api = std::make_shared<MockS3Motr>();
 

--- a/ut/s3_copy_object_action_test.cc
+++ b/ut/s3_copy_object_action_test.cc
@@ -96,6 +96,9 @@ S3CopyObjectActionTest::S3CopyObjectActionTest() {
       .Times(AtLeast(1))
       .WillRepeatedly(ReturnRef(destination_object_name));
 
+  EXPECT_CALL(*ptr_mock_request, has_query_param_key("versionId"))
+      .WillRepeatedly(Return(false));
+
   ptr_mock_bucket_meta_factory =
       std::make_shared<MockS3BucketMetadataFactory>(ptr_mock_request);
 

--- a/ut/s3_delete_bucket_action_test.cc
+++ b/ut/s3_delete_bucket_action_test.cc
@@ -52,6 +52,8 @@ class S3DeleteBucketActionTest : public testing::Test {
         .WillRepeatedly(ReturnRef(bucket_name));
     EXPECT_CALL(*ptr_mock_request, get_object_name())
         .WillRepeatedly(ReturnRef(object_name));
+    EXPECT_CALL(*ptr_mock_request, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
 
     ptr_mock_s3_motr_api = std::make_shared<MockS3Motr>();
 

--- a/ut/s3_delete_multiple_objects_action_test.cc
+++ b/ut/s3_delete_multiple_objects_action_test.cc
@@ -93,6 +93,8 @@ class S3DeleteMultipleObjectsActionTest : public testing::Test {
         .WillRepeatedly(ReturnRef(bucket_name));
     EXPECT_CALL(*mock_request, get_object_name())
         .WillRepeatedly(ReturnRef(object_name));
+    EXPECT_CALL(*mock_request, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
 
     ptr_mock_s3_motr_api = std::make_shared<MockS3Motr>();
 

--- a/ut/s3_delete_object_action_test.cc
+++ b/ut/s3_delete_object_action_test.cc
@@ -92,6 +92,8 @@ class S3DeleteObjectActionTest : public testing::Test {
         .WillRepeatedly(ReturnRef(bucket_name));
     EXPECT_CALL(*mock_request, get_object_name())
         .WillRepeatedly(ReturnRef(object_name));
+    EXPECT_CALL(*mock_request, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
 
     ptr_mock_s3_motr_api = std::make_shared<MockS3Motr>();
 

--- a/ut/s3_delete_object_tagging_action_test.cc
+++ b/ut/s3_delete_object_tagging_action_test.cc
@@ -57,6 +57,8 @@ class S3DeleteObjectTaggingActionTest : public testing::Test {
         .WillRepeatedly(ReturnRef(bucket_name));
     EXPECT_CALL(*request_mock, get_object_name())
         .WillRepeatedly(ReturnRef(object_name));
+    EXPECT_CALL(*request_mock, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
 
     object_list_indx_oid = {0x11ffff, 0x1ffff};
     object_meta_factory =

--- a/ut/s3_get_bucket_action_test.cc
+++ b/ut/s3_get_bucket_action_test.cc
@@ -95,6 +95,8 @@ class S3GetBucketActionTest : public testing::Test {
         .WillRepeatedly(ReturnRef(bucket_name));
     EXPECT_CALL(*request_mock, get_object_name())
         .WillRepeatedly(ReturnRef(object_name));
+    EXPECT_CALL(*request_mock, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
 
     s3_motr_api_mock = std::make_shared<MockS3Motr>();
 

--- a/ut/s3_get_bucket_action_v2_test.cc
+++ b/ut/s3_get_bucket_action_v2_test.cc
@@ -105,6 +105,8 @@ class S3GetBucketActionV2Test : public testing::Test {
         .WillRepeatedly(ReturnRef(bucket_name));
     EXPECT_CALL(*request_mock, get_object_name())
         .WillRepeatedly(ReturnRef(object_name));
+    EXPECT_CALL(*request_mock, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
 
     s3_motr_api_mock = std::make_shared<MockS3Motr>();
     bucket_meta_factory =

--- a/ut/s3_get_multipart_bucket_action_test.cc
+++ b/ut/s3_get_multipart_bucket_action_test.cc
@@ -121,6 +121,8 @@ class S3GetMultipartBucketActionTest : public testing::Test {
         .WillRepeatedly(ReturnRef(bucket_name));
     EXPECT_CALL(*request_mock, get_object_name())
         .WillRepeatedly(ReturnRef(object_name));
+    EXPECT_CALL(*request_mock, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
     s3_motr_api_mock = std::make_shared<MockS3Motr>();
 
     bucket_meta_factory =

--- a/ut/s3_get_multipart_part_action_test.cc
+++ b/ut/s3_get_multipart_part_action_test.cc
@@ -59,6 +59,8 @@ class S3GetMultipartPartActionTest : public testing::Test {
         .WillRepeatedly(ReturnRef(bucket_name_test));
     EXPECT_CALL(*ptr_mock_request, get_object_name())
         .WillRepeatedly(ReturnRef(object_name_test));
+    EXPECT_CALL(*ptr_mock_request, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
     bucket_meta_factory =
         std::make_shared<MockS3BucketMetadataFactory>(ptr_mock_request);
     part_meta_factory = std::make_shared<MockS3PartMetadataFactory>(

--- a/ut/s3_get_object_acl_action_test.cc
+++ b/ut/s3_get_object_acl_action_test.cc
@@ -58,6 +58,8 @@ class S3GetObjectAclActionTest : public testing::Test {
         .WillRepeatedly(ReturnRef(bucket_name));
     EXPECT_CALL(*request_mock, get_object_name())
         .WillRepeatedly(ReturnRef(object_name));
+    EXPECT_CALL(*request_mock, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
 
     index_layout = {{0x11ffff, 0x1ffff}};
     object_meta_factory =

--- a/ut/s3_get_object_tagging_action_test.cc
+++ b/ut/s3_get_object_tagging_action_test.cc
@@ -56,6 +56,8 @@ class S3GetObjectTaggingActionTest : public testing::Test {
         .WillRepeatedly(ReturnRef(bucket_name));
     EXPECT_CALL(*request_mock, get_object_name())
         .WillRepeatedly(ReturnRef(object_name));
+    EXPECT_CALL(*request_mock, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
 
     object_list_indx_oid = {0x11ffff, 0x1ffff};
     object_meta_factory =

--- a/ut/s3_head_object_action_test.cc
+++ b/ut/s3_head_object_action_test.cc
@@ -78,6 +78,8 @@ class S3HeadObjectActionTest : public testing::Test {
         .WillRepeatedly(ReturnRef(bucket_name));
     EXPECT_CALL(*mock_request, get_object_name())
         .WillRepeatedly(ReturnRef(object_name));
+    EXPECT_CALL(*mock_request, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
     // Owned and deleted by shared_ptr in S3HeadObjectAction
     bucket_meta_factory =
         std::make_shared<MockS3BucketMetadataFactory>(mock_request);

--- a/ut/s3_object_list_response_test.cc
+++ b/ut/s3_object_list_response_test.cc
@@ -75,6 +75,8 @@ class S3ObjectListResponseTest : public testing::Test {
         .WillRepeatedly(ReturnRef(bucket_name));
     EXPECT_CALL(*mock_request, get_object_name())
         .WillRepeatedly(ReturnRef(object_name));
+    EXPECT_CALL(*mock_request, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
     mock_request->set_user_id("1");
     mock_request->set_user_name("s3user");
     mock_request->set_account_id("1");

--- a/ut/s3_object_metadata_test.cc
+++ b/ut/s3_object_metadata_test.cc
@@ -59,7 +59,8 @@ class S3ObjectMetadataTest : public testing::Test {
         .WillRepeatedly(ReturnRef(object_name));
     EXPECT_CALL(*ptr_mock_request, get_bucket_name())
         .WillRepeatedly(ReturnRef(bucket_name));
-
+    EXPECT_CALL(*ptr_mock_request, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
     ptr_mock_s3_motr_api = std::make_shared<MockS3Motr>();
     EXPECT_CALL(*ptr_mock_s3_motr_api, m0_h_ufid_next(_))
         .WillRepeatedly(Invoke(dummy_helpers_ufid_next));
@@ -124,6 +125,8 @@ class S3MultipartObjectMetadataTest : public testing::Test {
         .WillRepeatedly(ReturnRef(object_name));
     EXPECT_CALL(*ptr_mock_request, get_bucket_name())
         .WillRepeatedly(ReturnRef(bucket_name));
+    EXPECT_CALL(*ptr_mock_request, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
 
     ptr_mock_s3_motr_api = std::make_shared<MockS3Motr>();
 
@@ -324,6 +327,8 @@ TEST_F(S3ObjectMetadataTest, Load) {
               get_keyval(_, "objectname", _, _)).Times(1);
   metadata_obj_under_test->set_object_list_index_layout(
       object_list_index_layout);
+  metadata_obj_under_test->set_objects_version_list_index_layout(
+      objects_version_list_index_layout);
 
   metadata_obj_under_test->load(
       std::bind(&S3CallBack::on_success, &s3objectmetadata_callbackobj),
@@ -331,6 +336,24 @@ TEST_F(S3ObjectMetadataTest, Load) {
 
   EXPECT_TRUE(metadata_obj_under_test->handler_on_success != nullptr);
   EXPECT_TRUE(metadata_obj_under_test->handler_on_failed != nullptr);
+}
+
+TEST_F(S3ObjectMetadataTest, LoadObjectInfoFromVersionListIdex) {
+  std::string obj_ver_id = "MTg0NDY3NDI0MzcyNjA2NzM4Mj";
+  metadata_obj_under_test->set_version_id(obj_ver_id);
+  EXPECT_CALL(*(motr_kvs_reader_factory->mock_motr_kvs_reader),
+              get_keyval(_, "objectname/1844674243726067382", _, _)).Times(1);
+  metadata_obj_under_test->set_object_list_index_layout(
+      object_list_index_layout);
+  metadata_obj_under_test->set_objects_version_list_index_layout(
+      objects_version_list_index_layout);
+  metadata_obj_under_test->load(
+      std::bind(&S3CallBack::on_success, &s3objectmetadata_callbackobj),
+      std::bind(&S3CallBack::on_failed, &s3objectmetadata_callbackobj));
+
+  EXPECT_TRUE(metadata_obj_under_test->handler_on_success != nullptr);
+  EXPECT_TRUE(metadata_obj_under_test->handler_on_failed != nullptr);
+  EXPECT_EQ(metadata_obj_under_test->requested_object_version_id, obj_ver_id);
 }
 
 TEST_F(S3ObjectMetadataTest, LoadSuccessful) {

--- a/ut/s3_post_complete_action_test.cc
+++ b/ut/s3_post_complete_action_test.cc
@@ -125,6 +125,8 @@ class S3PostCompleteActionTest : public testing::Test {
         .WillRepeatedly(ReturnRef(bucket_name));
     EXPECT_CALL(*request_mock, get_object_name())
         .WillRepeatedly(ReturnRef(object_name));
+    EXPECT_CALL(*request_mock, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
     EXPECT_CALL(*s3_motr_api_mock, m0_h_ufid_next(_))
         .WillRepeatedly(Invoke(dummy_helpers_ufid_next));
 

--- a/ut/s3_post_multipartobject_action_test.cc
+++ b/ut/s3_post_multipartobject_action_test.cc
@@ -55,6 +55,8 @@ class S3PostMultipartObjectTest : public testing::Test {
         .WillRepeatedly(ReturnRef(bucket_name));
     EXPECT_CALL(*ptr_mock_request, get_object_name())
         .WillRepeatedly(ReturnRef(object_name));
+    EXPECT_CALL(*ptr_mock_request, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
 
     ptr_mock_s3_motr_api = std::make_shared<MockS3Motr>();
 

--- a/ut/s3_put_chunk_upload_object_action_test.cc
+++ b/ut/s3_put_chunk_upload_object_action_test.cc
@@ -93,6 +93,8 @@ class S3PutChunkUploadObjectActionTestBase : public testing::Test {
         .WillRepeatedly(ReturnRef(object_name));
     EXPECT_CALL(*(mock_request), get_header_value(StrEq("x-amz-tagging")))
         .WillOnce(Return(""));
+    EXPECT_CALL(*mock_request, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
     EXPECT_CALL(*ptr_mock_s3_motr_api, m0_h_ufid_next(_))
         .WillRepeatedly(Invoke(dummy_helpers_ufid_next));
 

--- a/ut/s3_put_multiobject_action_test.cc
+++ b/ut/s3_put_multiobject_action_test.cc
@@ -70,6 +70,8 @@ class S3PutMultipartObjectActionTest : public testing::Test {
         .WillRepeatedly(ReturnRef(bucket_name));
     EXPECT_CALL(*ptr_mock_request, get_object_name())
         .WillRepeatedly(ReturnRef(object_name));
+    EXPECT_CALL(*ptr_mock_request, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
 
     ptr_mock_s3_motr_api = std::make_shared<MockS3Motr>();
 

--- a/ut/s3_put_object_acl_action_test.cc
+++ b/ut/s3_put_object_acl_action_test.cc
@@ -56,6 +56,8 @@ class S3PutObjectACLActionTest : public testing::Test {
         .WillRepeatedly(ReturnRef(bucket_name));
     EXPECT_CALL(*request_mock, get_object_name())
         .WillRepeatedly(ReturnRef(object_name));
+    EXPECT_CALL(*request_mock, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
 
     object_list_indx_oid = {0x11ffff, 0x1ffff};
     object_meta_factory =

--- a/ut/s3_put_object_action_test.cc
+++ b/ut/s3_put_object_action_test.cc
@@ -124,6 +124,9 @@ class S3PutObjectActionTest : public testing::Test {
         .WillRepeatedly(ReturnRef(object_name));
     EXPECT_CALL(*(ptr_mock_request), get_header_value(StrEq("x-amz-tagging")))
         .WillOnce(Return(""));
+    EXPECT_CALL(*ptr_mock_request, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
+
     // Owned and deleted by shared_ptr in S3PutObjectAction
     bucket_meta_factory =
         std::make_shared<MockS3BucketMetadataFactory>(ptr_mock_request);

--- a/ut/s3_put_object_tagging_action_test.cc
+++ b/ut/s3_put_object_tagging_action_test.cc
@@ -57,6 +57,8 @@ class S3PutObjectTaggingActionTest : public testing::Test {
         .WillRepeatedly(ReturnRef(bucket_name));
     EXPECT_CALL(*request_mock, get_object_name())
         .WillRepeatedly(ReturnRef(object_name));
+    EXPECT_CALL(*request_mock, has_query_param_key("versionId"))
+        .WillRepeatedly(Return(false));
 
     object_list_indx_oid = {0x11ffff, 0x1ffff};
     object_meta_factory =


### PR DESCRIPTION
# Problem Statement

- Get Latest object data if versioning is either enabled or suspended and no version ID is specified in the request.
- Get object data for a specific version if version ID is specified in the request for a version enabled or suspended bucket.
- If wrong versionId is specified, return error - InvalidArgument.

# Design
https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/766902714/GetObject+LLD

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
