### PR TITLE
EOS-25627: Handle parallel multipart POST complete and Put part operations

### DIFF
--- a/server/s3_addb_map_auto.c
+++ b/server/s3_addb_map_auto.c
@@ -25,7 +25,7 @@
 
 #include "s3_addb_map.h"
 
-const uint64_t g_s3_to_addb_idx_func_name_map_size = 219;
+const uint64_t g_s3_to_addb_idx_func_name_map_size = 223;
 
 const char* g_s3_to_addb_idx_func_name_map[] = {
     "Action::check_authentication",
@@ -149,6 +149,7 @@ const char* g_s3_to_addb_idx_func_name_map[] = {
     "S3HeadServiceAction::send_response_to_s3_client",
     "S3ObjectActionTest::func_callback_one",
     "S3PostCompleteAction::add_object_oid_to_probable_dead_oid_list",
+    "S3PostCompleteAction::add_oid_for_parallel_leak_check",
     "S3PostCompleteAction::delete_multipart_metadata",
     "S3PostCompleteAction::delete_new_object",
     "S3PostCompleteAction::delete_old_object",
@@ -189,6 +190,7 @@ const char* g_s3_to_addb_idx_func_name_map[] = {
     "S3PutBucketTaggingAction::validate_request",
     "S3PutBucketTaggingAction::validate_request_xml_tags",
     "S3PutBucketTaggingActionTest::func_callback_one",
+    "S3PutChunkUploadObjectAction::add_oid_for_parallel_leak_check",
     "S3PutChunkUploadObjectAction::create_object",
     "S3PutChunkUploadObjectAction::delete_new_object",
     "S3PutChunkUploadObjectAction::delete_old_object",
@@ -204,6 +206,7 @@ const char* g_s3_to_addb_idx_func_name_map[] = {
     "S3PutChunkUploadObjectActionTestBase::func_callback_one",
     "S3PutFiAction::send_response_to_s3_client",
     "S3PutFiAction::set_fault_injection",
+    "S3PutMultiObjectAction::add_oid_for_parallel_leak_check",
     "S3PutMultiObjectAction::check_part_details",
     "S3PutMultiObjectAction::create_part_object",
     "S3PutMultiObjectAction::delete_new_object",
@@ -223,6 +226,7 @@ const char* g_s3_to_addb_idx_func_name_map[] = {
     "S3PutObjectACLAction::setacl",
     "S3PutObjectACLAction::validate_acl_with_auth",
     "S3PutObjectACLAction::validate_request",
+    "S3PutObjectAction::add_oid_for_parallel_leak_check",
     "S3PutObjectAction::create_object",
     "S3PutObjectAction::delete_new_object",
     "S3PutObjectAction::delete_old_object",

--- a/server/s3_post_complete_action.h
+++ b/server/s3_post_complete_action.h
@@ -160,6 +160,7 @@ class S3PostCompleteAction : public S3ObjectAction {
   void add_object_oid_to_probable_dead_oid_list();
   void add_object_oid_to_probable_dead_oid_list_success();
   void add_object_oid_to_probable_dead_oid_list_failed();
+  void add_oid_for_parallel_leak_check();
 
   // Add object part to the new object's extended metadata portion
   void add_part_object_to_object_extended(

--- a/server/s3_put_chunk_upload_object_action.cc
+++ b/server/s3_put_chunk_upload_object_action.cc
@@ -996,6 +996,9 @@ void S3PutChunkUploadObjectAction::startcleanup() {
       ACTION_TASK_ADD(S3PutChunkUploadObjectAction::mark_old_oid_for_deletion,
                       this);
     }
+    // Add new oid for parallel leak check in S3 Background delete service
+    ACTION_TASK_ADD(
+        S3PutChunkUploadObjectAction::add_oid_for_parallel_leak_check, this);
     // remove new oid from probable delete list.
     ACTION_TASK_ADD(
         S3PutChunkUploadObjectAction::remove_new_oid_probable_record, this);
@@ -1215,6 +1218,42 @@ void S3PutChunkUploadObjectAction::delete_new_object() {
       std::bind(&S3PutChunkUploadObjectAction::next, this), new_object_oid,
       layout_id, new_object_metadata->get_pvid());
 
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
+
+void S3PutChunkUploadObjectAction::add_oid_for_parallel_leak_check() {
+  s3_log(S3_LOG_DEBUG, stripped_request_id, "%s Entry\n", __func__);
+  std::map<std::string, std::string> oid_key_val_mp;
+  if (!motr_kv_writer) {
+    motr_kv_writer =
+        mote_kv_writer_factory->create_motr_kvs_writer(request, s3_motr_api);
+  }
+  std::string oid_str =
+      S3M0Uint128Helper::to_string(new_object_metadata->get_oid());
+  // For parallel leak check, assume size as 0 (as it is dummy leak entry)
+  // This entry in probable delete list index helps S3 BD to process
+  // object leak caused due to parallel upload requests.
+  S3CommonUtilities::size_based_bucketing_of_objects(oid_str, 0);
+  std::unique_ptr<S3ProbableDeleteRecord> delete_rec;
+  s3_log(S3_LOG_DEBUG, request_id,
+         "Adding new object for parallel leak check, with key [%s]\n",
+         oid_str.c_str());
+  delete_rec.reset(new S3ProbableDeleteRecord(
+      oid_str, old_object_oid, new_object_metadata->get_object_name(),
+      new_object_metadata->get_oid(), layout_id,
+      new_object_metadata->get_pvid_str(),
+      bucket_metadata->get_object_list_index_layout().oid,
+      bucket_metadata->get_objects_version_list_index_layout().oid,
+      new_object_metadata->get_version_key_in_index(), false /* force_delete */,
+      false, {0ULL, 0ULL}, 0, 0,
+      bucket_metadata->get_extended_metadata_index_layout().oid,
+      new_object_metadata->get_obj_version_key(), {0ULL, 0ULL}));
+
+  oid_key_val_mp[delete_rec->get_key()] = delete_rec->to_json();
+  motr_kv_writer->put_keyval(
+      global_probable_dead_object_list_index_layout, oid_key_val_mp,
+      std::bind(&S3PutChunkUploadObjectAction::next, this),
+      std::bind(&S3PutChunkUploadObjectAction::next, this));
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 

--- a/server/s3_put_chunk_upload_object_action.h
+++ b/server/s3_put_chunk_upload_object_action.h
@@ -149,6 +149,9 @@ class S3PutChunkUploadObjectAction : public S3ObjectAction {
   void add_part_object_to_probable_dead_oid_list(
       const std::shared_ptr<S3ObjectMetadata> &,
       std::vector<std::unique_ptr<S3ProbableDeleteRecord>> &);
+  // Finally, when object md is saved, we would need S3 BD to
+  // process leak due to parallel PUT requests. So, add entry.
+  void add_oid_for_parallel_leak_check();
 
   // Rollback tasks
   void startcleanup() override;

--- a/server/s3_put_multiobject_action.h
+++ b/server/s3_put_multiobject_action.h
@@ -52,6 +52,8 @@ class S3PutMultiObjectAction : public S3ObjectAction {
   S3PutPartActionState s3_put_action_state;
   struct m0_uint128 old_object_oid;
   int old_layout_id;
+  std::string old_pvid_str;
+  size_t old_part_size = 0;
   struct m0_uint128 new_object_oid;
   int layout_id;
   S3Timer s3_timer;
@@ -133,6 +135,10 @@ class S3PutMultiObjectAction : public S3ObjectAction {
 
   void add_object_oid_to_probable_dead_oid_list();
   void add_object_oid_to_probable_dead_oid_list_failed();
+  // Finally, when object md is saved, we would need S3 BD to
+  // process leak due to parallel part PUT requests.
+  // Below function adds entry to probable index.
+  void add_oid_for_parallel_leak_check();
 
   void initiate_data_streaming();
   void consume_incoming_content();

--- a/server/s3_put_object_action.cc
+++ b/server/s3_put_object_action.cc
@@ -923,6 +923,8 @@ void S3PutObjectAction::startcleanup() {
       // backgrounddelete decisions.
       ACTION_TASK_ADD(S3PutObjectAction::mark_old_oid_for_deletion, this);
     }
+    // Add new oid for parallel leak check in S3 Background delete service
+    ACTION_TASK_ADD(S3PutObjectAction::add_oid_for_parallel_leak_check, this);
     // remove new oid from probable delete list.
     ACTION_TASK_ADD(S3PutObjectAction::remove_new_oid_probable_record, this);
     if (old_object_oid.u_hi || old_object_oid.u_lo) {
@@ -1049,6 +1051,42 @@ void S3PutObjectAction::remove_new_oid_probable_record() {
                                 new_oid_str,
                                 std::bind(&S3PutObjectAction::next, this),
                                 std::bind(&S3PutObjectAction::next, this));
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
+}
+
+void S3PutObjectAction::add_oid_for_parallel_leak_check() {
+  s3_log(S3_LOG_DEBUG, stripped_request_id, "%s Entry\n", __func__);
+  std::map<std::string, std::string> oid_key_val_mp;
+  if (!motr_kv_writer) {
+    motr_kv_writer =
+        mote_kv_writer_factory->create_motr_kvs_writer(request, s3_motr_api);
+  }
+  std::string oid_str =
+      S3M0Uint128Helper::to_string(new_object_metadata->get_oid());
+  // For parallel leak check, assume size as 0 (as it is dummy leak entry)
+  // This entry in probable delete list index helps S3 BD to process
+  // object leak caused due to parallel upload requests.
+  S3CommonUtilities::size_based_bucketing_of_objects(oid_str, 0);
+  std::unique_ptr<S3ProbableDeleteRecord> delete_rec;
+  s3_log(S3_LOG_DEBUG, request_id,
+         "Adding new object for parallel leak check, with key [%s]\n",
+         oid_str.c_str());
+  delete_rec.reset(new S3ProbableDeleteRecord(
+      oid_str, old_object_oid, new_object_metadata->get_object_name(),
+      new_object_metadata->get_oid(), layout_id,
+      new_object_metadata->get_pvid_str(),
+      bucket_metadata->get_object_list_index_layout().oid,
+      bucket_metadata->get_objects_version_list_index_layout().oid,
+      new_object_metadata->get_version_key_in_index(), false /* force_delete */,
+      false, {0ULL, 0ULL}, 0, 0,
+      bucket_metadata->get_extended_metadata_index_layout().oid,
+      new_object_metadata->get_obj_version_key(), {0ULL, 0ULL}));
+
+  oid_key_val_mp[delete_rec->get_key()] = delete_rec->to_json();
+  motr_kv_writer->put_keyval(global_probable_dead_object_list_index_layout,
+                             oid_key_val_mp,
+                             std::bind(&S3PutObjectAction::next, this),
+                             std::bind(&S3PutObjectAction::next, this));
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 

--- a/server/s3_put_object_action.h
+++ b/server/s3_put_object_action.h
@@ -112,6 +112,10 @@ class S3PutObjectAction : public S3ObjectAction {
   void add_part_object_to_probable_dead_oid_list(
       const std::shared_ptr<S3ObjectMetadata> &,
       std::vector<std::unique_ptr<S3ProbableDeleteRecord>> &);
+  // Finally, when object md is saved, we would need S3 BD to
+  // process leak due to parallel PUT requests.
+  // Below function adds entry to probable index.
+  void add_oid_for_parallel_leak_check();
 
   void initiate_data_streaming();
   void consume_incoming_content();

--- a/st/clitests/negative_spec.py
+++ b/st/clitests/negative_spec.py
@@ -393,7 +393,7 @@ for i, type in enumerate(config_types):
         execute_test().command_is_successful()
 
     S3fiTest('s3cmd can enable FI motr_idx_op_fail').\
-        enable_fi_offnonm("enable", "motr_idx_op_fail", "26", "99").\
+        enable_fi_offnonm("enable", "motr_idx_op_fail", "36", "99").\
         execute_test().command_is_successful()
     #Post complete operation -- fetch_multipart_info
     S3cmdTest('s3cmd can not upload 18MBfile file').\
@@ -550,7 +550,7 @@ for i, type in enumerate(config_types):
         disable_fi("motr_idx_op_fail").\
         execute_test().command_is_successful()
 
-    fi_off="25"
+    fi_off="29"
     S3fiTest('s3cmd enable FI motr idx op fail').\
         enable_fi_offnonm("enable", "motr_idx_op_fail", fi_off, "99").\
         execute_test().command_is_successful()

--- a/ut/s3_put_object_action_test.cc
+++ b/ut/s3_put_object_action_test.cc
@@ -153,6 +153,12 @@ class S3PutObjectActionTest : public testing::Test {
 
  public:
   void func_callback_one() { call_count_one += 1; }
+  void dummy_put_keyval(const struct s3_motr_idx_layout &,
+                        const std::map<std::string, std::string> &,
+                        std::function<void(void)> on_success,
+                        std::function<void(void)> on_failed) {
+    action_under_test->next();
+  }
 };
 
 TEST_F(S3PutObjectActionTest, ConstructorTest) {
@@ -1191,6 +1197,48 @@ TEST_F(S3PutObjectActionTest, SendSuccessResponse) {
   EXPECT_CALL(*ptr_mock_request, set_out_header_value(_, _)).Times(AtLeast(1));
   EXPECT_CALL(*ptr_mock_request, send_response(200, _)).Times(AtLeast(1));
   EXPECT_CALL(*ptr_mock_request, resume(_)).Times(1);
+  action_under_test->old_object_oid = {0x1ffff, 0x1ffff};
+  action_under_test->old_oid_str = "abcd";
+  action_under_test->new_oid_str = "abcd";
+  action_under_test->new_object_oid = oid;
+  action_under_test->layout_id = 9;
+  action_under_test->bucket_metadata =
+      bucket_meta_factory->mock_bucket_metadata;
+  action_under_test->new_object_metadata =
+      object_meta_factory->mock_object_metadata;
+  action_under_test->new_object_metadata->set_extended_object_metadata(
+      object_meta_factory->mock_object_extnd_metadata);
+  EXPECT_CALL(*(object_meta_factory->mock_object_metadata), get_oid())
+      .WillRepeatedly(Return(oid));
+  EXPECT_CALL(*(object_meta_factory->mock_object_metadata), get_object_name())
+      .WillRepeatedly(Return(std::string("abcd")));
+  EXPECT_CALL(*(object_meta_factory->mock_object_metadata), get_layout_id())
+      .WillRepeatedly(Return(9));
+  EXPECT_CALL(*(object_meta_factory->mock_object_metadata),
+              get_version_key_in_index())
+      .WillRepeatedly(Return(std::string("abcd/18133434")));
+  EXPECT_CALL(*(object_meta_factory->mock_object_metadata),
+              get_obj_version_key())
+      .WillRepeatedly(Return(std::string("18133434")));
+  object_meta_factory->mock_object_metadata->set_pvid_str(
+      action_under_test->new_oid_str);
+
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),
+              get_object_list_index_layout())
+      .WillRepeatedly(ReturnRef(index_layout));
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),
+              get_objects_version_list_index_layout())
+      .WillRepeatedly(ReturnRef(index_layout));
+  EXPECT_CALL(*(bucket_meta_factory->mock_bucket_metadata),
+              get_extended_metadata_index_layout())
+      .WillRepeatedly(ReturnRef(index_layout));
+
+  EXPECT_CALL(*(object_meta_factory->mock_object_extnd_metadata),
+              get_part_count()).WillRepeatedly(Return(2));
+  EXPECT_CALL(*(motr_kvs_writer_factory->mock_motr_kvs_writer),
+              put_keyval(_, _, _, _))
+      .Times(1)
+      .WillRepeatedly(Invoke(this, &S3PutObjectActionTest::dummy_put_keyval));
 
   action_under_test->send_response_to_s3_client();
 }


### PR DESCRIPTION
Signed-off-by: Dattaprasad Govekar <dattaprasad.govekar@seagate.com>

# Problem Statement
-  Parallel operations lead to object leak

# Design
-  Handling object leak due to parallel S3 operations (POST complete, multipart PUT, simple PUT)

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
