### PR TITLE
[versioning] [EOS-26658] Preventing bucket to go in suspended state [temporary]

### DIFF
--- a/server/s3_addb_map_auto.c
+++ b/server/s3_addb_map_auto.c
@@ -25,7 +25,7 @@
 
 #include "s3_addb_map.h"
 
-const uint64_t g_s3_to_addb_idx_func_name_map_size = 225;
+const uint64_t g_s3_to_addb_idx_func_name_map_size = 226;
 
 const char* g_s3_to_addb_idx_func_name_map[] = {
     "Action::check_authentication",
@@ -190,6 +190,7 @@ const char* g_s3_to_addb_idx_func_name_map[] = {
     "S3PutBucketTaggingAction::validate_request",
     "S3PutBucketTaggingAction::validate_request_xml_tags",
     "S3PutBucketTaggingActionTest::func_callback_one",
+    "S3PutBucketVersioningAction::can_update_versioning_status",
     "S3PutBucketVersioningAction::save_versioning_status_to_bucket_metadata",
     "S3PutBucketVersioningAction::send_response_to_s3_client",
     "S3PutBucketVersioningAction::validate_request",

--- a/server/s3_put_bucket_versioning_action.h
+++ b/server/s3_put_bucket_versioning_action.h
@@ -28,12 +28,17 @@
 
 #include "s3_bucket_action_base.h"
 #include "s3_bucket_metadata.h"
+#include "s3_motr_kvs_reader.h"
 #include "s3_factory.h"
 
 class S3PutBucketVersioningAction : public S3BucketAction {
   std::shared_ptr<S3BucketMetadataFactory> bucket_metadata_factory;
   std::shared_ptr<S3PutBucketVersioningBodyFactory> put_bucket_version_factory;
   std::shared_ptr<S3PutVersioningBody> put_bucket_version_body;
+  std::shared_ptr<S3MotrKVSReaderFactory> s3_motr_kvs_reader_factory;
+  std::shared_ptr<S3ObjectMetadataFactory> object_metadata_factory;
+  std::shared_ptr<S3MotrKVSReader> motr_kv_reader;
+  std::shared_ptr<MotrAPI> s3_motr_api;
 
   std::string bucket_content_string;
   std::string bucket_version_status;
@@ -54,6 +59,10 @@ class S3PutBucketVersioningAction : public S3BucketAction {
   void save_versioning_status_to_bucket_metadata_failed();
   void fetch_bucket_info_failed();
   void send_response_to_s3_client();
+  void can_update_versioning_status();
+  void check_if_bucket_empty();
+  void get_object_successful();
+  void get_object_failed();
 
   // For Testing purpose
   FRIEND_TEST(S3PutBucketVersioningActionTest, Constructor);
@@ -81,6 +90,13 @@ class S3PutBucketVersioningAction : public S3BucketAction {
   FRIEND_TEST(S3PutBucketVersioningActionTest, SendResponseToClientSuccess);
   FRIEND_TEST(S3PutBucketVersioningActionTest,
               SendResponseToClientInternalError);
+  FRIEND_TEST(S3PutBucketVersioningActionTest,
+              CanUpdateVersioningStatusSuspended);
+  FRIEND_TEST(S3PutBucketVersioningActionTest,
+              CanUpdateVersioningStatusEnabled);
+  FRIEND_TEST(S3PutBucketVersioningActionTest, CheckIfBucketEmpty);
+  FRIEND_TEST(S3PutBucketVersioningActionTest, GetObjectSuccessFull);
+  FRIEND_TEST(S3PutBucketVersioningActionTest, GetObjectFailed);
 };
 
 #endif

--- a/st/clitests/awss3api_spec.py
+++ b/st/clitests/awss3api_spec.py
@@ -1786,16 +1786,27 @@ AwsTest('Aws can not get object with empty versionId')\
     .command_error_should_have("Version id cannot be the empty string")
 
 #******** Suspend Versioning on Bucket ********
-AwsTest('Aws can suspend versioning on bucket')\
-    .put_bucket_versioning(bucket, "Suspended")\
-    .execute_test()\
-    .command_is_successful()
+# XXX: Temporarily disabled until suspension is supported
+# AwsTest('Aws can suspend versioning on bucket')\
+#     .put_bucket_versioning(bucket, "Suspended")\
+#     .execute_test()\
+#     .command_is_successful()
 
 #******** Get Bucket Versioning Suspended status ********
-AwsTest('Aws can get bucket versioning Suspended status')\
-    .get_bucket_versioning(bucket)\
-    .execute_test()\
-    .command_response_should_have("Suspended")
+# XXX: Temporarily disabled until suspension is supported
+# AwsTest('Aws can get bucket versioning Suspended status')\
+#     .get_bucket_versioning(bucket)\
+#     .execute_test()\
+#     .command_response_should_have("Suspended")
+
+#******** Suspend Versioning on Bucket ********
+# XXX: Temporary until suspension is supported
+AwsTest('Can not suspend versioning on bucket')\
+    .put_bucket_versioning(bucket, "Suspended")\
+    .execute_test(negative_case=True)\
+    .command_should_fail()\
+    .command_error_should_have("OperationNotSupported")
+
 
 #******** Test Cleanup ********
 AwsTest('Aws can delete the object')\

--- a/ut/s3_put_bucket_versioning_action_test.cc
+++ b/ut/s3_put_bucket_versioning_action_test.cc
@@ -183,8 +183,7 @@ TEST_F(S3PutBucketVersioningActionTest,
   EXPECT_EQ(1, call_count_one);
 }
 
-TEST_F(S3PutBucketVersioningActionTest, ValidateRequestXmlWithSuspendedState)
-{
+TEST_F(S3PutBucketVersioningActionTest, ValidateRequestXmlWithSuspendedState) {
 
   mock_bucket_version_str =
       "<VersioningConfiguration "

--- a/ut/s3_put_bucket_versioning_action_test.cc
+++ b/ut/s3_put_bucket_versioning_action_test.cc
@@ -183,7 +183,6 @@ TEST_F(S3PutBucketVersioningActionTest,
   EXPECT_EQ(1, call_count_one);
 }
 
-#if 0
 TEST_F(S3PutBucketVersioningActionTest, ValidateRequestXmlWithSuspendedState)
 {
 
@@ -211,7 +210,6 @@ TEST_F(S3PutBucketVersioningActionTest, ValidateRequestXmlWithSuspendedState)
   action_under_test_ptr->validate_request_xml_versioning_status();
   EXPECT_EQ(1, call_count_one);
 }
-#endif
 
 TEST_F(S3PutBucketVersioningActionTest, ValidateInvalidRequestXmlTags) {
 


### PR DESCRIPTION
# Problem Statement
- For PI-5 we should not allow users to suspend versioning.
- Putbucketversioning with suspended versioning should return an error.
- Versioning should be enabled and disabling should return a message - call not supported.
- If a bucket already has objects, versioning cannot be enabled on it.  
- Disable the UT/ST for the suspended test.

# Design
Design docs not prepared as this is a temporary change.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide
