### PR TITLE
EOS-26572: Services separation in s3_start, rename of BG services 

### DIFF
--- a/scripts/provisioning/configcmd.py
+++ b/scripts/provisioning/configcmd.py
@@ -102,11 +102,11 @@ class ConfigCmd(SetupCmd):
         self.logger.info("authserver config started")
         self.process_authserver()
         self.logger.info("authserver config completed")
-      if "s3bgschedular" in self.services:
+      if "bgscheduler" in self.services:
         self.logger.info("s3bgschedular config started")
         self.process_s3bgschedular()
         self.logger.info("s3bgschedular config completed")
-      if "s3bgworker" in self.services:
+      if "bgworker" in self.services:
         self.logger.info("s3bgworker config started")
         self.process_s3bgworker()
         self.logger.info("s3bgworker config completed")

--- a/scripts/provisioning/initcmd.py
+++ b/scripts/provisioning/initcmd.py
@@ -75,14 +75,14 @@ class InitCmd(SetupCmd):
                               'properties://')
       self.logger.info("validate auth config files completed")
 
-    if "s3bgschedular" in self.services:
+    if "bgscheduler" in self.services:
       self.logger.info("validate s3 bgdelete scheduler config file started")
       self.validate_config_file(self.get_confkey('S3_BGDELETE_CONFIG_FILE').replace("/opt/seagate/cortx", self.base_config_file_path),
                                 self.get_confkey('S3_BGDELETE_CONFIG_SAMPLE_FILE').replace("/opt/seagate/cortx", self.base_config_file_path),
                                 'yaml://')
     self.logger.info("validate s3 bgdelete scheduler config files completed")
 
-    if "s3bgworker" in self.services:
+    if "bgworker" in self.services:
       self.logger.info("validate s3 bgdelete worker config file started")
       self.validate_config_file(self.get_confkey('S3_BGDELETE_CONFIG_FILE').replace("/opt/seagate/cortx", self.base_config_file_path),
                                 self.get_confkey('S3_BGDELETE_CONFIG_SAMPLE_FILE').replace("/opt/seagate/cortx", self.base_config_file_path),

--- a/scripts/provisioning/s3_start
+++ b/scripts/provisioning/s3_start
@@ -88,6 +88,8 @@ def main():
 
     # Service mapping
     service = args.service
+    # follwing mapping needs to be removed once the services names are changed in provisioner and solution framework
+    ######### start
     services_map = {
                 "s3server": "s3server",
                 "s3authserver": "authserver",
@@ -98,8 +100,9 @@ def main():
     if service in services_map:
         service = services_map[service]
     logger.info(f"Mapped Service: {service}")
+    ######### end
 
-    if service == 's3server':
+    if service == "s3server":
       if not args.index:
         raise Exception("provide instance id")
 
@@ -143,7 +146,7 @@ def main():
 
       # Print last few line of S3 server log file
       os.system(f"tail -f {s3_log_file_path}")
-    elif service == 'authserver':
+    elif service == "authserver":
       # Start S3 Auth Server
       logger.info(f"sh /opt/seagate/cortx/auth/startauth.sh {base_config_path}")
       logger.info(f"Starting S3 Auth Server...")
@@ -158,7 +161,7 @@ def main():
 
       # Print last few line of S3 authserver log  file
       os.system(f"tail -f {s3_auth_server_log_file_path}")
-    elif service == 's3bgschedular':
+    elif service == "bgscheduler":
       # Uncomment below two lines if you want return bgdelete schedule timings.
       # os.system("sed -i -e \"s,scheduler_schedule_interval:.*,scheduler_schedule_interval:\ 120,\" /etc/cortx/s3/s3backgrounddelete/config.yaml")
       # os.system("sed -i -e \"s,leak_processing_delay_in_mins:.*,leak_processing_delay_in_mins:\ 2,\" /etc/cortx/s3/s3backgrounddelete/config.yaml")
@@ -174,7 +177,7 @@ def main():
       # Print last few line of S3 bgdelete producer log  file
       os.system(f"tail -f {s3_bgdelete_producer_log_file_path}")
 
-    elif service == 's3bgworker':
+    elif service == "bgworker":
       # Start the Background Consumer
       logger.info(f"sh /opt/seagate/cortx/s3/s3backgrounddelete/starts3backgroundconsumer.sh {base_config_path} yaml://")
       logger.info(f"Starting S3 Background delete Consumer...")
@@ -187,7 +190,7 @@ def main():
       # Print last few line of S3 bgdelete consumer log  file
       os.system(f"tail -f {s3_bgdelete_consumer_log_file_path}")
 
-    elif service == 'haproxy':
+    elif service == "haproxy":
       haproxy_log_path = os.path.join(base_logdir_path, 's3', machine_id, 'haproxy/haproxy.log')
       logger.info(f"haproxy_log_path: {haproxy_log_path}")
       # create haproxy log directory path if does not exist

--- a/scripts/provisioning/s3_start
+++ b/scripts/provisioning/s3_start
@@ -91,8 +91,8 @@ def main():
     services_map = {
                 "s3server": "s3server",
                 "s3authserver": "authserver",
-                "s3bgproducer": "s3bgschedular",
-                "s3bgconsumer": "s3bgworker",
+                "s3bgproducer": "bgscheduler",
+                "s3bgconsumer": "bgworker",
                 "haproxy": "haproxy"}
     logger.info(f"Input Service: {service}")
     if service in services_map:

--- a/scripts/provisioning/s3_start
+++ b/scripts/provisioning/s3_start
@@ -86,7 +86,20 @@ def main():
     create_logger_directory(s3_single_entry_log_directory)
     logger = create_logger(s3_single_entry_log_file, s3_single_entry_logger_name, s3_single_entry_log_format)
 
-    if args.service == 's3server':
+    # Service mapping
+    service = args.service
+    services_map = {
+                "s3server": "s3server",
+                "s3authserver": "authserver",
+                "s3bgproducer": "s3bgschedular",
+                "s3bgconsumer": "s3bgworker",
+                "haproxy": "haproxy"}
+    logger.info(f"Input Service: {service}")
+    if service in services_map:
+        service = services_map[service]
+    logger.info(f"Mapped Service: {service}")
+
+    if service == 's3server':
       if not args.index:
         raise Exception("provide instance id")
 
@@ -130,7 +143,7 @@ def main():
 
       # Print last few line of S3 server log file
       os.system(f"tail -f {s3_log_file_path}")
-    elif args.service == 's3authserver':
+    elif service == 'authserver':
       # Start S3 Auth Server
       logger.info(f"sh /opt/seagate/cortx/auth/startauth.sh {base_config_path}")
       logger.info(f"Starting S3 Auth Server...")
@@ -145,7 +158,7 @@ def main():
 
       # Print last few line of S3 authserver log  file
       os.system(f"tail -f {s3_auth_server_log_file_path}")
-    elif args.service == 's3bgproducer':
+    elif service == 's3bgschedular':
       # Uncomment below two lines if you want return bgdelete schedule timings.
       # os.system("sed -i -e \"s,scheduler_schedule_interval:.*,scheduler_schedule_interval:\ 120,\" /etc/cortx/s3/s3backgrounddelete/config.yaml")
       # os.system("sed -i -e \"s,leak_processing_delay_in_mins:.*,leak_processing_delay_in_mins:\ 2,\" /etc/cortx/s3/s3backgrounddelete/config.yaml")
@@ -161,7 +174,7 @@ def main():
       # Print last few line of S3 bgdelete producer log  file
       os.system(f"tail -f {s3_bgdelete_producer_log_file_path}")
 
-    elif args.service == 's3bgconsumer':
+    elif service == 's3bgworker':
       # Start the Background Consumer
       logger.info(f"sh /opt/seagate/cortx/s3/s3backgrounddelete/starts3backgroundconsumer.sh {base_config_path} yaml://")
       logger.info(f"Starting S3 Background delete Consumer...")
@@ -174,7 +187,7 @@ def main():
       # Print last few line of S3 bgdelete consumer log  file
       os.system(f"tail -f {s3_bgdelete_consumer_log_file_path}")
 
-    elif args.service == 'haproxy':
+    elif service == 'haproxy':
       haproxy_log_path = os.path.join(base_logdir_path, 's3', machine_id, 'haproxy/haproxy.log')
       logger.info(f"haproxy_log_path: {haproxy_log_path}")
       # create haproxy log directory path if does not exist
@@ -199,7 +212,7 @@ def main():
       # Print last few line of S3 HAProxy log  file
       os.system(f"tail -f {haproxy_log_path}")
     else:
-      logger.error(f"Invalid argument {args.service}")
+      logger.error(f"Service {service} is not supported")
 
 
   except Exception as e:

--- a/scripts/provisioning/setupcmd.py
+++ b/scripts/provisioning/setupcmd.py
@@ -76,11 +76,11 @@ class SetupCmd(object):
     self.consul_confstore = None
 
     # validate supported services
-    lookup_service = ["haproxy", "s3server", "authserver", "s3bgschedular", "s3bgworker"]
+    lookup_service = ["haproxy", "s3server", "authserver", "bgscheduler", "bgworker"]
     if self.services is None:
       self.services = "haproxy,s3server,authserver,s3bgschedular,s3bgworker"
 
-    self.bg_delete_service = "s3bgworker"
+    self.bg_delete_service = "bgworker"
     if -1 != self.services.find("bg_"):
       self.bg_delete_service = "bg_consumer"
     # follwing mapping needs to be removed once the services names are changed in provisioner and solution framework
@@ -88,8 +88,8 @@ class SetupCmd(object):
     services_map = {
                 "io": "s3server,haproxy",
                 "auth": "authserver",
-                "bg_producer": "s3bgschedular",
-                "bg_consumer": "s3bgworker"}
+                "bg_producer": "bgscheduler",
+                "bg_consumer": "bgworker"}
     for service in services_map:
         if -1 != self.services.find(service):
           if (service == "auth") and (-1 != services.find("authserver")):

--- a/scripts/provisioning/upgradecmd.py
+++ b/scripts/provisioning/upgradecmd.py
@@ -49,16 +49,16 @@ class UpgradeCmd(SetupCmd):
       # check for old files before merge logic
       self.old_file_check(
             [os.path.join(self.s3_tmp_dir, "s3_cluster.yaml.sample.old")])
-      if 'haproxy' in self.services:
+      if "haproxy" in self.services:
         pass
-      if 's3server' in self.services:
+      if "s3server" in self.services:
         self.old_file_check(
             [os.path.join(self.s3_tmp_dir, "s3config.yaml.sample.old")])
-      if 'authserver' in self.services:
+      if "authserver" in self.services:
         self.old_file_check(
             [os.path.join(self.s3_tmp_dir, "keystore.properties.sample.old"),
              os.path.join(self.s3_tmp_dir, "authserver.properties.sample.old")])
-      if 's3bgschedular' in self.services or 's3bgworker' in self.services:
+      if "bgscheduler" in self.services or "bgworker" in self.services:
         self.old_file_check(
             [os.path.join(self.s3_tmp_dir, "config.yaml.sample.old")])
       # copy sample and unsafe attribute files to /etc/cortx for merge logic
@@ -80,9 +80,9 @@ class UpgradeCmd(SetupCmd):
              'yaml://')
       # after calling merge logic, make '.old' files
       self.make_sample_old_files([self.get_confkey('S3_CLUSTER_CONFIG_SAMPLE_FILE')])
-      if 'haproxy' in self.services:
+      if "haproxy" in self.services:
         pass
-      if 's3server' in self.services:
+      if "s3server" in self.services:
         self.copy_config_files([self.get_confkey('S3_CONFIG_SAMPLE_FILE'),
                                 self.get_confkey('S3_CONFIG_UNSAFE_ATTR_FILE')])
         self.logger.info(f"merge config for s3server started")
@@ -98,7 +98,7 @@ class UpgradeCmd(SetupCmd):
                os.path.join(self.base_config_file_path, "s3/conf/s3config.yaml.sample"),
                'yaml://')
         self.make_sample_old_files([self.get_confkey('S3_CONFIG_SAMPLE_FILE')])
-      if 'authserver' in self.services:
+      if "authserver" in self.services:
         self.copy_config_files([self.get_confkey('S3_KEYSTORE_CONFIG_SAMPLE_FILE'),
                                 self.get_confkey('S3_KEYSTORE_CONFIG_UNSAFE_ATTR_FILE'),
                                 self.get_confkey('S3_AUTHSERVER_CONFIG_SAMPLE_FILE'),
@@ -129,7 +129,7 @@ class UpgradeCmd(SetupCmd):
                'properties://')
         self.make_sample_old_files([self.get_confkey('S3_KEYSTORE_CONFIG_SAMPLE_FILE'),
                                     self.get_confkey('S3_AUTHSERVER_CONFIG_SAMPLE_FILE')])
-      if 's3bgschedular' in self.services or 's3bgworker' in self.services:
+      if "bgscheduler" in self.services or "bgworker" in self.services:
         self.copy_config_files([self.get_confkey('S3_BGDELETE_CONFIG_SAMPLE_FILE'),
                                 self.get_confkey('S3_BGDELETE_CONFIG_UNSAFE_ATTR_FILE')])
         self.logger.info(f"merge config for background service started")


### PR DESCRIPTION
# Problem Statement
Services separation in s3_start 

# Design
Services separation in s3_start 

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide


-----
[View rendered docs/notes.md](https://github.com/Seagate/cortx-s3server/blob/br/vr/EOS-26572-III/docs/notes.md)
[View rendered s3backgrounddelete/readme.md](https://github.com/Seagate/cortx-s3server/blob/br/vr/EOS-26572-III/s3backgrounddelete/readme.md)