### PR TITLE
[EOS-26854] Adding dev scripts.

### DIFF
--- a/format-code.sh
+++ b/format-code.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+usage() {
+	echo "Usage:"
+	echo Run without arguments for intercative mode.
+	echo -q :  For non-interactive mode. Files will be modified if code formating is needed.
+	echo -h : For usage.
+	exit 0
+}
+
+interactive=1
+while getopts :hq opt; do
+	case "$opt" in
+	q)
+		interactive=0
+		;;
+	h)
+		usage
+		;;
+	*)
+		usage
+		;;
+	esac
+done
+trap 'rm -f "$PATCH_FILE"' EXIT
+PATCH_FILE=$(mktemp) || exit 1
+
+git clang-format --style=Google --extensions=c,cc,h,java --diff --commit HEAD~1 > "$PATCH_FILE"
+require_changes=$(grep -c "clang-format did not modify any files" "$PATCH_FILE")
+if [ "$require_changes" -eq 0 ]; then
+	if [ "$interactive" -eq 1 ]; then
+		echo -ne "\nApply changes?[y/n] - "
+		read input
+		if [ "$input" != "y" ]; then
+			echo -ne "\nExiting without making any change..\n"
+			exit 0
+		fi
+	fi
+	echo -ne "\nUpdating files..\n"
+	git apply "$PATCH_FILE"
+else
+	echo "No change required."
+fi

--- a/runut.sh
+++ b/runut.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+usage() {
+        USAGE="Usage:
+-a : To run all the s3ut test cases.
+-f : To provide gtest filter.
+     Run with –f \"TestSuit.Testcase\" to run specific test suit or test case.
+     Ex 1. Run specific test suit -
+        runut.sh –f \"S3GetObjectActionTest.*\"
+
+     Ex 2. Run specific test case -
+        runut.sh –f \"S3GetObjectActionTest.ValidateObjectOfSizeZero\"
+-h : For usage."
+        echo -e "$USAGE"
+	exit 0
+}
+
+
+filter=
+extra_opts=
+while getopts :fh opt; do
+	case "$opt" in
+	a)
+		;;
+	f)
+		shift
+		filter="$1"
+		if [ -z "$filter" ]; then
+			echo -e "\nMust specify some UT pattern with -f option\n"
+			usage
+		fi
+		extra_opts="--gtest_filter=$filter"
+		;;
+	h)
+		usage
+		;;
+	*)
+		usage
+		;;
+	esac
+done
+
+export LD_LIBRARY_PATH="$(pwd)/third_party/motr/motr/.libs/:"\
+"$(pwd)/third_party/motr/helpers/.libs/:"\
+"$(pwd)/third_party/motr/extra-libs/gf-complete/src/.libs/:"\
+"$(pwd)/third_party/motr/extra-libs/galois/src/.libs/:"
+
+echo "Running UTs..."
+./bazel-bin/s3ut "$extra_opts"

--- a/s3build.sh
+++ b/s3build.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+build=1
+install=0
+stop_bazel=0
+usage() {
+	echo "Usage:"
+	echo "- Build s3server if run without argument"
+	echo "-i : To build and install s3server binary."
+	echo "-I : To only install previously build s3server binary."
+	echo "-s : To stop bazel server after build."
+	echo "-h : For usage."
+	exit 0
+}
+
+while getopts :iIhs opt; do
+	case "$opt" in
+	i)
+		install=1
+		;;
+	I)
+		install=1
+		build=0
+		;;
+	s)
+		stop_bazel=1
+		;;
+	h)
+		usage
+		;;
+	*)
+		usage
+		;;
+        esac
+done
+
+if [ "$build" -eq 1 ]; then
+	echo "Building s3server ..."
+	bazel build //:s3server --cxxopt=-std=c++11 --define MOTR_INC=./third_party/motr/ --define MOTR_LIB=./third_party/motr/motr/.libs --define MOTR_HELPERS_LIB=./third_party/motr/helpers/.libs/ --spawn_strategy=standalone --strip=never '--local_cpu_resources=HOST_CPUS*0.7' '--local_ram_resources=HOST_RAM*0.7'
+	if [ "$stop_bazel" -eq 1 ]; then
+		# Just to free up resources
+		echo "Stopping bazel server..."
+		bazel shutdown
+	fi
+fi
+
+if [ "$install" -eq 1 ]; then
+	echo "Installing s3server ..."
+	./dev-stops3.sh
+	cp bazel-bin/s3server /opt/seagate/cortx/s3/bin/s3server
+	./dev-starts3.sh
+	if [ "$?" -eq 0 ]; then
+		echo -e "\nS3server is started!"
+	else
+		echo -e "\nCould not start s3server!"
+	fi
+fi

--- a/s3log.sh
+++ b/s3log.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+#####################################################
+#
+# This file can be placed in system executable path,
+# for easy access to the script.
+#
+# cp s3log.sh /usr/local/sbin/s3log
+#
+#####################################################
+
+info=0
+debug=0
+warn=0
+error=0
+tail=0
+vim=0
+auth=0
+bd=0
+bd_schedular=0
+
+usage() {
+		echo "Usage:"
+		echo "-i : For info logs."
+		echo "-d : For debug logs."
+		echo "-w : For warning logs."
+		echo "-e : For error logs."
+		echo "## Note: Only one of the above options can be used."
+		echo "-a : To see auth server logs. Can not be used along with -b."
+		echo "-b : To see background processor logs. Can not be used along with -a."
+		echo "-s : To see background schedular logs. To be used along with -b."
+		echo "-t : To tail log file. Can not be used with -v option."
+		echo "-v : To open log in vim editor. Can not be used with -t option."
+		echo "-h : For usage."
+		exit 1
+}
+
+if [ "$#" -eq 0 ]; then
+	usage
+fi
+while getopts :idwetvhabs opt; do
+	case "$opt" in
+	i)
+		info=1
+		if [ "$debug" -eq 1 ] || [ "$error" -eq 1 ] || [ "$warn" -eq 1 ]; then
+			usage
+		fi
+		;;
+	d)
+		debug=1
+		if [ "$info" -eq 1 ] || [ "$error" -eq 1 ] || [ $warn -eq 1 ]; then
+			usage
+		fi
+		;;
+	w)
+		warn=1
+		if [ "$info" -eq 1 ] || [ "$error" -eq 1 ] || [ "$debug" -eq 1 ]; then
+				usage
+		fi
+		;;
+	e)
+		error=1
+		if [ "$debug" -eq 1 ] || [ "$info" -eq 1 ] || [ "$warn" -eq 1 ]; then
+			usage
+		fi
+		;;
+	t)
+		tail=1
+		if [ "$vim" -eq 1 ]; then
+			usage
+		fi
+		;;
+	v)
+		vim=1
+		if [ "$tail" -eq 1 ]; then
+			usage
+		fi
+		;;
+	a)
+		auth=1
+		if [ "$bd" -eq 1 ]; then
+			usage
+		fi
+		;;
+	b)
+		bd=1
+		if [ "$auth" -eq 1 ]; then
+			usage
+		fi
+		;;
+	s)
+		bd_schedular=1
+		;;
+	h)
+		usage
+		;;
+	*)
+		usage
+		;;
+	esac
+done
+
+if [ -z $info ] && [ -z $debug ] && [ -z $error ] && [ -z $warn ] && [ ! -z $auth ] && [ ! -z $bd ]; then
+	usage
+fi
+
+if [ -z $tail ] && [ -z $vim ]; then
+	usage
+fi
+
+filename=
+if [ $info -eq 1 ]; then
+	filename=/var/log/cortx/s3/s3server.INFO
+fi
+
+if [ $debug -eq 1 ]; then
+	filename=/var/log/cortx/s3/s3server.INFO
+fi
+
+if [ $warn -eq 1 ]; then
+	filename=/var/log/cortx/s3/s3server.WARNING
+fi
+
+if [ $error -eq 1 ]; then
+	filename=/var/log/cortx/s3/s3server.ERROR
+fi
+
+if [ $auth -eq 1 ]; then
+	filename=/var/log/cortx/auth/server/app.log
+fi
+
+if [ $bd -eq 1 ]; then
+	filename=/var/log/cortx/s3/s3backgrounddelete/object_recovery_processor.log
+	if [  $bd_schedular -eq 1 ]; then
+		filename=/var/log/cortx/s3/s3backgrounddelete/object_recovery_scheduler.log
+	fi
+fi
+
+if [ $tail -eq 1 ]; then
+	tail -f $filename
+	exit 0
+fi
+
+if [ $vim -eq 1 ]; then
+	vim $filename
+	exit 0
+fi

--- a/st/clitests/awss3api_spec_short.py
+++ b/st/clitests/awss3api_spec_short.py
@@ -1,0 +1,171 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import os
+import yaml
+import hashlib
+from framework import S3PyCliTest
+from awss3api import AwsTest
+from s3client_config import S3ClientConfig
+from auth import AuthTest
+# Helps debugging
+# Config.log_enabled = True
+# Config.dummy_run = True
+# Config.client_execution_timeout = 300 * 1000
+# Config.request_timeout = 300 * 1000
+# Config.socket_timeout = 300 * 1000
+
+# Transform AWS CLI text output into an object(dictionary)
+# with content:
+# {
+#   "prefix":<list of common prefix>,
+#   "keys": <list of regular keys>,
+#   "next_token": <token>
+# }
+def get_aws_cli_object(raw_aws_cli_output):
+    cli_obj = {}
+    raw_lines = raw_aws_cli_output.split('\n')
+    common_prefixes = []
+    content_keys = []
+    for _, item in enumerate(raw_lines):
+        if (item.startswith("COMMONPREFIXES")):
+            # E.g. COMMONPREFIXES  quax/
+            line = item.split('\t')
+            common_prefixes.append(line[1])
+        elif (item.startswith("CONTENTS")):
+            # E.g. CONTENTS\t"98b5e3f766f63787ea1ddc35319cedf7"\tasdf\t2020-09-25T11:42:54.000Z\t3072\tSTANDARD
+            line = item.split('\t')
+            content_keys.append(line[2])
+        elif (item.startswith("NEXTTOKEN")):
+            # E.g. NEXTTOKEN       eyJDb250aW51YXRpb25Ub2tlbiI6IG51bGwsICJib3RvX3RydW5jYXRlX2Ftb3VudCI6IDN9
+            line = item.split('\t')
+            cli_obj["next_token"] = line[1]
+        else:
+            continue
+
+    if (common_prefixes is not None):
+        cli_obj["prefix"] = common_prefixes
+    if (content_keys is not None):
+        cli_obj["keys"] = content_keys
+
+    return cli_obj
+
+# Extract the upload id from response which has the following format
+# [bucketname    objecctname    uploadid]
+
+def get_upload_id(response):
+    key_pairs = response.split('\t')
+    return key_pairs[2]
+
+def get_etag(response):
+    key_pairs = response.split('\t')
+    return key_pairs[3]
+
+def load_test_config():
+    conf_file = os.path.join(os.path.dirname(__file__),'s3iamcli_test_config.yaml')
+    with open(conf_file, 'r') as f:
+            config = yaml.safe_load(f)
+            S3ClientConfig.ldapuser = config['ldapuser']
+            S3ClientConfig.ldappasswd = config['ldappasswd']
+
+def get_response_elements(response):
+    response_elements = {}
+    key_pairs = response.split(',')
+
+    for key_pair in key_pairs:
+        tokens = key_pair.split('=')
+        response_elements[tokens[0].strip()] = tokens[1].strip()
+
+    return response_elements
+
+def create_object_list_file(file_name, obj_list=[], quiet_mode="false"):
+    cwd = os.getcwd()
+    file_to_create = os.path.join(cwd, file_name)
+    objects = "{ \"Objects\": [ { \"Key\": \"" + obj_list[0] + "\" }"
+    for obj in obj_list[1:]:
+        objects += ", { \"Key\": \"" + obj + "\" }"
+    objects += " ], \"Quiet\": " + quiet_mode + " }"
+    with open(file_to_create, 'w') as file:
+        file.write(objects)
+    return file_to_create
+
+def delete_object_list_file(file_name):
+    os.remove(file_name)
+
+def get_md5_sum(fname):
+    hash_md5 = hashlib.md5()
+    with open(fname, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_md5.update(chunk)
+    return hash_md5.hexdigest()
+
+# Helps debugging
+# Config.log_enabled = True
+# Config.dummy_run = True
+# Config.client_execution_timeout = 300 * 1000
+# Config.request_timeout = 300 * 1000
+# Config.socket_timeout = 300 * 1000
+
+# Run before all to setup the test environment.
+print("Configuring LDAP")
+S3PyCliTest('Before_all').before_all()
+load_test_config()
+
+#Create account sourceAccount
+test_msg = "Create account sourceAccount"
+source_account_args = {'AccountName': 'sourceAccount', 'Email': 'sourceAccount@seagate.com', \
+                   'ldapuser': S3ClientConfig.ldapuser, \
+                   'ldappasswd': S3ClientConfig.ldappasswd}
+account_response_pattern = "AccountId = [\w-]*, CanonicalId = [\w-]*, RootUserName = [\w+=,.@-]*, AccessKeyId = [\w-]*, SecretKey = [\w/+]*$"
+result1 = AuthTest(test_msg).create_account(**source_account_args).execute_test()
+result1.command_should_match_pattern(account_response_pattern)
+print(result1.status.stdout)
+account_response_elements = get_response_elements(result1.status.stdout)
+source_access_key_args = {}
+source_access_key_args['AccountName'] = "sourceAccount"
+source_access_key_args['AccessKeyId'] = account_response_elements['AccessKeyId']
+source_access_key_args['SecretAccessKey'] = account_response_elements['SecretKey']
+
+bucket_name = "seagatebuckettest"
+
+#******** Create Bucket ********
+AwsTest('Aws can create bucket').create_bucket(bucket_name)\
+    .execute_test().command_is_successful()
+###########################################
+##### Add your STs here to test out #######
+###########################################
+
+
+
+
+#******** Delete Bucket ********
+AwsTest('Aws can delete bucket').delete_bucket(bucket_name)\
+    .execute_test().command_is_successful()
+
+#-------------------Delete Accounts------------------
+test_msg = "Delete account sourceAccount"
+s3test_access_key = S3ClientConfig.access_key_id
+s3test_secret_key = S3ClientConfig.secret_key
+S3ClientConfig.access_key_id = source_access_key_args['AccessKeyId']
+S3ClientConfig.secret_key = source_access_key_args['SecretAccessKey']
+
+account_args = {'AccountName': 'sourceAccount', 'Email': 'sourceAccount@seagate.com',  'force': True}
+AuthTest(test_msg).delete_account(**source_account_args).execute_test()\
+            .command_response_should_have("Account deleted successfully")
+

--- a/utbuild.sh
+++ b/utbuild.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+s3ut=0
+s3utdeathtests=0
+s3mempoolut=0
+s3mempoolmgrut=0
+stop_bazel=0
+
+usage() {
+	echo "Usage:"
+	echo "--all : To build all the UTs run without argument."
+	echo "--ut : To build only s3ut."
+	echo "--death : To build s3utdeathtests."
+	echo "--mempool : To build s3mempoolut."
+	echo "--mempoolmgr : To build s3mempoolmgrut."
+	echo "-s : Stop bazel server after build."
+	exit 0
+}
+
+if [ "$#" -eq 0 ]; then
+	usage
+else
+	while [ "$1" != "" ]; do
+	case "$1" in
+	--ut)
+		s3ut=1
+		;;
+	--death)
+		s3utdeathtests=1
+		;;
+	--mempool)
+		s3mempoolut=1
+		;;
+	--mempoolmgr)
+		s3mempoolmgrut=1
+		;;
+	--all)
+		s3ut=1
+		s3utdeathtests=1
+		s3mempoolut=1
+		s3mempoolmgrut=1
+		;;
+	-s)
+		stop_bazel=1
+		;;
+	--help | -h)
+		usage
+		;;
+	*)
+		usage
+		;;
+	esac
+	shift
+	done
+fi
+
+bazel_cpu_limit=0.6
+bazel_ram_limit=0.6
+
+if [ "$s3ut" -eq 1 ]; then
+	echo "Building s3ut..."
+	bazel build //:s3ut --cxxopt=-std=c++11 --define MOTR_INC=./third_party/motr/ --define MOTR_LIB=./third_party/motr/motr/.libs --define MOTR_HELPERS_LIB=./third_party/motr/helpers/.libs/ --spawn_strategy=standalone --strip=never "--local_cpu_resources=HOST_CPUS*$bazel_cpu_limit" "--local_ram_resources=HOST_RAM*$bazel_ram_limit" --verbose_failures
+
+fi
+
+if [ "$s3utdeathtests" -eq 1 ]; then
+	echo "Building s3utdeathtests..."
+	bazel build //:s3utdeathtests --cxxopt=-std=c++11 --define MOTR_INC=./third_party/motr/ --define MOTR_LIB=./third_party/motr/motr/.libs --define MOTR_HELPERS_LIB=./third_party/motr/helpers/.libs/ --spawn_strategy=standalone --strip=never "--local_cpu_resources=HOST_CPUS*$bazel_cpu_limit" "--local_ram_resources=HOST_RAM*$bazel_ram_limit"
+
+fi
+
+if [ "$s3mempoolut" -eq 1 ]; then
+	echo "Building s3mempoolut..."
+	bazel build //:s3mempoolut --cxxopt=-std=c++11 --spawn_strategy=standalone --strip=never "--local_cpu_resources=HOST_CPUS*$bazel_cpu_limit" "--local_ram_resources=HOST_RAM*$bazel_ram_limit"
+
+fi
+
+if [ "$s3mempoolmgrut" -eq 1 ]; then
+	echo "Building s3mempoolmgrut..."
+	bazel build //:s3mempoolmgrut --cxxopt=-std=c++11 --define MOTR_INC=./third_party/motr/ --define MOTR_LIB=./third_party/motr/motr/.libs --define MOTR_HELPERS_LIB=./third_party/motr/helpers/.libs/ --spawn_strategy=standalone --strip=never "--local_cpu_resources=HOST_CPUS*$bazel_cpu_limit" "--local_ram_resources=HOST_RAM*$bazel_ram_limit"
+
+fi
+
+if [  "$stop_bazel" -eq 1 ]; then
+	# Just to free up resources
+	echo "Stopping bazel server..."
+	bazel shutdown
+fi


### PR DESCRIPTION
# Problem Statement
I have created few scripts to make it easy for developer to access different logs, do incremental builds, run UTs with specific filters and develop & test STs. Basically reducing some manual steps.

**s3log.sh** - To access different logs for services like s3server, auth-server, background delete.
```
Usage:
-i : For info logs.
-d : For debug logs.
-w : For warning logs.
-e : For error logs.
## Note: Only one of the above options can be used.
-a : To see auth server logs. Can not be used along with -b.
-b : To see background processor logs. Can not be used along with -a.
-s : To see background schedular logs. To be used along with -b.
-t : To tail log file. Can not be used with -v option.
-v : To open log in vim editor. Can not be used with -t option.
-h : For usage.
```
**s3build.sh** - To build s3server code and install s3server binary.
```
Usage:
- Build s3server if run without argument
-i : To build and install s3server binary.
-I : To only install previously build s3server binary.
-s : To stop bazel server after build.
-h : For usage.
```
**utbuild.sh** - To build all the UT code.
```
Usage:
--all : To build all the UTs run without argument.
--ut : To build only s3ut.
--death : To build s3utdeathtests.
--mempool : To build s3mempoolut.
--mempoolmgr : To build s3mempoolmgrut.
-s : Stop bazel server after build.
```
**runut.sh** - To run s3ut UTs. It Also allows to run specific test suit and testcase.
```
Usage:
-a : To run all the s3ut test cases.
-f : To provide gtest filter.
     Run with –f "TestSuit.Testcase" to run specific test suit or test case.
     Ex 1. Run specific test suit -
        runut.sh –f "S3GetObjectActionTest.*"

     Ex 2. Run specific test case -
        runut.sh –f "S3GetObjectActionTest.ValidateObjectOfSizeZero"
-h : For usage.
```

**format-code.sh** - To format the code with git clang-format command. This allows developer to format the code even before committing it. Unlike standard git clang-format don't make any changes if there are uncommit changes present. 
```
Usage:
Run without arguments for intercative mode.
-q : For non-interactive mode. Files will be modified if code formating is needed.
-h : For usage.
```

**awss3api_spec_short.py** - To develop and test new STs. Its short version of awss3api_spec.py which has minimum required code to run a STs. We can add set of STs to this file which we want to develop or test. This will allow developer to only run the ST that he/she is working on. If the STs is being newly created and needs to be committed then move these STs to awss3api_spec.py file and run it once to verify everything is working fine. Changes done in awss3api_spec_short.py can be discarded later on and do not required to be committed. 

# Design
NA

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
