### PR TITLE
[iam policy] EOS-25967: Unit tests for IAM Policy attach and detach

### DIFF
--- a/auth/server/src/test/java/com/seagates3/dao/ldap/UserPolicyLdapStoreTest.java
+++ b/auth/server/src/test/java/com/seagates3/dao/ldap/UserPolicyLdapStoreTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Matchers.anyString;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
@@ -124,7 +123,6 @@ import com.seagates3.model.UserPolicy;
  private
   void verifyLDAPUtilsModifyCalls() throws LDAPException {
     PowerMockito.verifyStatic(Mockito.times(2));
-    LDAPUtils.modify(Matchers.anyString(),
-                     Matchers.any(LDAPModification.class));
+    LDAPUtils.modify(anyString(), any(LDAPModification.class));
   }
 }

--- a/auth/server/src/test/java/com/seagates3/dao/ldap/UserPolicyLdapStoreTest.java
+++ b/auth/server/src/test/java/com/seagates3/dao/ldap/UserPolicyLdapStoreTest.java
@@ -121,8 +121,10 @@ import com.seagates3.model.UserPolicy;
     return policy;
   }
 
- private void verifyLDAPUtilsModifyCalls() throws LDAPException {
-	    PowerMockito.verifyStatic(Mockito.times(2));
-	    LDAPUtils.modify(Matchers.anyString(), Matchers.any(LDAPModification.class));
- }
+ private
+  void verifyLDAPUtilsModifyCalls() throws LDAPException {
+    PowerMockito.verifyStatic(Mockito.times(2));
+    LDAPUtils.modify(Matchers.anyString(),
+                     Matchers.any(LDAPModification.class));
+  }
 }

--- a/auth/server/src/test/java/com/seagates3/dao/ldap/UserPolicyLdapStoreTest.java
+++ b/auth/server/src/test/java/com/seagates3/dao/ldap/UserPolicyLdapStoreTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Matchers.anyString;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -46,7 +48,8 @@ import com.seagates3.model.UserPolicy;
                                   new LDAPModification());
     UserPolicyLdapStore userPolicyLdapStore = new UserPolicyLdapStore();
     userPolicyLdapStore.attach(userPolicy);
-    assert(true);
+
+    verifyLDAPUtilsModifyCalls();
   }
 
   @Test public void testDetachSuccess() throws Exception {
@@ -54,7 +57,8 @@ import com.seagates3.model.UserPolicy;
                                   new LDAPModification());
     UserPolicyLdapStore userPolicyLdapStore = new UserPolicyLdapStore();
     userPolicyLdapStore.detach(userPolicy);
-    assert(true);
+
+    verifyLDAPUtilsModifyCalls();
   }
 
   @Test public void testAttachFailed() throws Exception {
@@ -116,4 +120,9 @@ import com.seagates3.model.UserPolicy;
 
     return policy;
   }
+
+ private void verifyLDAPUtilsModifyCalls() throws LDAPException {
+	    PowerMockito.verifyStatic(Mockito.times(2));
+	    LDAPUtils.modify(Matchers.anyString(), Matchers.any(LDAPModification.class));
+ }
 }

--- a/auth/server/src/test/java/com/seagates3/dao/ldap/UserPolicyLdapStoreTest.java
+++ b/auth/server/src/test/java/com/seagates3/dao/ldap/UserPolicyLdapStoreTest.java
@@ -1,0 +1,119 @@
+package com.seagates3.dao.ldap;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.novell.ldap.LDAPException;
+import com.novell.ldap.LDAPModification;
+import com.seagates3.exception.DataAccessException;
+import com.seagates3.model.Policy;
+import com.seagates3.model.User;
+import com.seagates3.model.UserPolicy;
+
+@RunWith(PowerMockRunner.class) @PrepareForTest({LDAPUtils.class})
+    @PowerMockIgnore(
+        {"javax.management.*"}) public class UserPolicyLdapStoreTest {
+
+ private
+  static final String USER_ID = "AAABBBCCCDDD";
+ private
+  static final String USER_NAME = "iamuser1";
+ private
+  static final String POLICY_ID = "EEEFFFGGGHHH";
+
+ private
+  UserPolicy userPolicy;
+
+  @Before public void setUp() throws Exception {
+    PowerMockito.mockStatic(LDAPUtils.class);
+
+    userPolicy = new UserPolicy();
+    userPolicy.setPolicy(buildPolicy());
+    userPolicy.setUser(buildUser());
+  }
+
+  @Test public void testAttachSuccess() throws Exception {
+    PowerMockito.doNothing().when(LDAPUtils.class, "modify", "",
+                                  new LDAPModification());
+    UserPolicyLdapStore userPolicyLdapStore = new UserPolicyLdapStore();
+    userPolicyLdapStore.attach(userPolicy);
+    assert(true);
+  }
+
+  @Test public void testDetachSuccess() throws Exception {
+    PowerMockito.doNothing().when(LDAPUtils.class, "modify", "",
+                                  new LDAPModification());
+    UserPolicyLdapStore userPolicyLdapStore = new UserPolicyLdapStore();
+    userPolicyLdapStore.detach(userPolicy);
+    assert(true);
+  }
+
+  @Test public void testAttachFailed() throws Exception {
+    UserPolicyLdapStore userPolicyLdapStore =
+        buildUserPolicyLdapStoreObjToThrowEx();
+
+    try {
+      userPolicyLdapStore.attach(userPolicy);
+      assert(false);
+    }
+    catch (DataAccessException ex) {
+      String errMsgPart = "Failed to attach policy [" + POLICY_ID +
+                          "] to user [" + USER_NAME + "]";
+      assertTrue("Unexpected exception message.",
+                 ex.getMessage().contains(errMsgPart));
+    }
+  }
+
+  @Test public void testDetachFailed() throws Exception {
+    UserPolicyLdapStore userPolicyLdapStore =
+        buildUserPolicyLdapStoreObjToThrowEx();
+
+    try {
+      userPolicyLdapStore.detach(userPolicy);
+      assert(false);
+    }
+    catch (DataAccessException ex) {
+      String errMsgPart = "Failed to detach policy [" + POLICY_ID +
+                          "] from user [" + USER_NAME + "]";
+      assertTrue("Unexpected exception message.",
+                 ex.getMessage().contains(errMsgPart));
+    }
+  }
+
+ private
+  UserPolicyLdapStore buildUserPolicyLdapStoreObjToThrowEx()
+      throws LDAPException {
+    PowerMockito.doThrow(new LDAPException()).when(LDAPUtils.class);
+    LDAPUtils.modify(anyString(), any(LDAPModification.class));
+    UserPolicyLdapStore userPolicyLdapStore = new UserPolicyLdapStore();
+
+    return userPolicyLdapStore;
+  }
+
+ private
+  User buildUser() {
+    User user = new User();
+    user.setId(USER_ID);
+    user.setName(USER_NAME);
+
+    return user;
+  }
+
+ private
+  Policy buildPolicy() {
+    Policy policy = new Policy();
+    policy.setPolicyId(POLICY_ID);
+    policy.setIsPolicyAttachable("true");
+
+    return policy;
+  }
+}


### PR DESCRIPTION
# Problem Statement
- Unit tests for attach and detach IAM policy.

# Design
-  NA

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide

# Pre-Merge Test
- http://eos-jenkins.colo.seagate.com/job/S3server/job/S3Server-PreMerge-Test/784/

Signed-off-by: Shri Metta <shri.metta@seagate.com>
