### PR TITLE
Update log4j package version

### DIFF
--- a/auth-utils/jclient/pom.xml
+++ b/auth-utils/jclient/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.1</version>
+            <version>2.15.0</version>
         </dependency>
     </dependencies>
 

--- a/auth/encryptcli/pom.xml
+++ b/auth/encryptcli/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
            <groupId>org.apache.logging.log4j</groupId>
            <artifactId>log4j-slf4j-impl</artifactId>
-           <version>2.13.2</version>
+           <version>2.15.0</version>
            </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/auth/encryptcli/pom.xml
+++ b/auth/encryptcli/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
            <groupId>org.apache.logging.log4j</groupId>
            <artifactId>log4j-api</artifactId>
-           <version>2.13.2</version>
+           <version>2.15.0</version>
         </dependency>
         <dependency>
            <groupId>org.apache.logging.log4j</groupId>

--- a/auth/encryptcli/pom.xml
+++ b/auth/encryptcli/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
            <groupId>org.apache.logging.log4j</groupId>
            <artifactId>log4j-core</artifactId>
-           <version>2.13.2</version>
+           <version>2.15.0</version>
         </dependency>
         <dependency>
            <groupId>org.apache.logging.log4j</groupId>

--- a/auth/encryptutil/pom.xml
+++ b/auth/encryptutil/pom.xml
@@ -50,12 +50,12 @@
     <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.13.2</version>
+        <version>2.15.0</version>
     </dependency>
     <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j-impl</artifactId>
-        <version>2.13.2</version>
+        <version>2.15.0</version>
     </dependency>
     <dependency>
         <groupId>junit</groupId>

--- a/auth/encryptutil/pom.xml
+++ b/auth/encryptutil/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.13.2</version>
+        <version>2.15.0</version>
     </dependency>
     <dependency>
         <groupId>org.apache.logging.log4j</groupId>

--- a/auth/server/pom.xml
+++ b/auth/server/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.13.2</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/auth/server/pom.xml
+++ b/auth/server/pom.xml
@@ -58,12 +58,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.2</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.13.2</version>
+            <version>2.15.0</version>
         </dependency>
         
         <!-- https://mvnrepository.com/artifact/com.github.stefanbirkner/system-rules -->


### PR DESCRIPTION
- Updating log4j package version to 2.15.0
- Most recent version of log4j is 2.15.0
- Earlier versions of log4j are vulnerable to CVE-2021-44228

Corresponding story is raised here -> https://jts.seagate.com/browse/EOS-26894

# Problem Statement
- Problem statement

Earlier versions of log4j are vulnerable to CVE-2021-44228

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

Fix ix to upgrade log4j version to the latest version

# Coding
   Checklist for Author
-  [X] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM


# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

its  3rd party library upgrade

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [X] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide

NA