### PR TITLE
[versioning] EOS-25996: GetObject - deleteMarker

### DIFF
--- a/server/s3_get_object_action.h
+++ b/server/s3_get_object_action.h
@@ -173,6 +173,9 @@ class S3GetObjectAction : public S3ObjectAction {
   FRIEND_TEST(
       S3GetObjectActionTest,
       CheckFullOrRangeObjectReadWithUnsupportMultiRangeForContentLength8000);
+  FRIEND_TEST(S3GetObjectActionTest, LatestObjectIsDeleteMarker);
+  FRIEND_TEST(S3GetObjectActionTest,
+              RequestedObjectVersionIdBelongsToDeleteMarker);
 };
 
 #endif

--- a/server/s3_object_metadata.h
+++ b/server/s3_object_metadata.h
@@ -288,7 +288,7 @@ class S3ObjectMetadata : private S3ObjectMetadataCopyable {
 
   // delete marker handler
   virtual void set_delete_marker();
-  bool is_delete_marker() const {
+  virtual bool is_delete_marker() const {
     return is_delete_marker_;
   };
 

--- a/ut/mock_s3_object_metadata.h
+++ b/ut/mock_s3_object_metadata.h
@@ -62,6 +62,7 @@ class MockS3ObjectMetadata : public S3ObjectMetadata {
   MOCK_METHOD0(get_upload_id, std::string());
   MOCK_METHOD0(check_object_tags_exists, bool());
   MOCK_METHOD0(delete_object_tags, void());
+  MOCK_METHOD(bool, is_delete_marker, (), (const));
   MOCK_METHOD2(add_user_defined_attribute,
                void(std::string key, std::string val));
   MOCK_METHOD2(load, void(std::function<void(void)> on_success,


### PR DESCRIPTION
# Problem Statement
For GetObject API, handle the case when requested object is a delete marker -  

- If the latest object is a delete marker , return error - NoSuchKey.
- If specified versionId belongs to a delete marker, return error - MethodNotAllowed.

Jira - https://jts.seagate.com/browse/EOS-25996
# Design
- https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/766902714/GetObject+LLD

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide
