### PR TITLE
EOS-26811: Get object with range read is not working on multipart-uploaded object

### DIFF
--- a/server/s3_object_metadata.h
+++ b/server/s3_object_metadata.h
@@ -58,6 +58,7 @@ struct S3ExtendedObjectInfo {
     total_blocks_in_object = 0;
     object_size = 0;
     requested_object_size = 0;
+    total_readable_blocks = 0;
   }
   size_t start_offset_in_object;
   size_t total_blocks_in_object;
@@ -67,6 +68,7 @@ struct S3ExtendedObjectInfo {
   struct m0_uint128 object_OID;
   int object_layout;
   struct m0_fid object_pvid;
+  size_t total_readable_blocks;
 };
 
 enum class S3ObjectMetadataType {

--- a/ut/s3_get_object_action_test.cc
+++ b/ut/s3_get_object_action_test.cc
@@ -1116,6 +1116,7 @@ TEST_F(S3GetObjectActionTest, SetTotalBlocksToReadFromNextObject) {
   std::vector<struct S3ExtendedObjectInfo> extended_objects;
   struct S3ExtendedObjectInfo extendinfo;
   extendinfo.total_blocks_in_object = 10;
+  extendinfo.total_readable_blocks = extendinfo.total_blocks_in_object;
   action_under_test->extended_objects.push_back(extendinfo);
   action_under_test->next_fragment_object = 0;
   action_under_test->set_total_blocks_to_read_from_next_object();


### PR DESCRIPTION
Signed-off-by: Dattaprasad Govekar <dattaprasad.govekar@seagate.com>

# Problem Statement
- Range based Get object on multipart uploaded object fails when first byte offset of range does
not coincide with the start of the data block unit. The issue is seen only when max units read/write per request is more than one (say, 8 or 32)

# Design
-  Handled situation when the first byte range is not aligned to start of data block

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
