### PR TITLE
Upgrade log4j to 2.16.0

### DIFF
--- a/auth-utils/jclient/pom.xml
+++ b/auth-utils/jclient/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
     </dependencies>
 

--- a/auth/encryptcli/pom.xml
+++ b/auth/encryptcli/pom.xml
@@ -43,17 +43,17 @@
         <dependency>
            <groupId>org.apache.logging.log4j</groupId>
            <artifactId>log4j-api</artifactId>
-           <version>2.15.0</version>
+           <version>2.16.0</version>
         </dependency>
         <dependency>
            <groupId>org.apache.logging.log4j</groupId>
            <artifactId>log4j-core</artifactId>
-           <version>2.15.0</version>
+           <version>2.16.0</version>
         </dependency>
         <dependency>
            <groupId>org.apache.logging.log4j</groupId>
            <artifactId>log4j-slf4j-impl</artifactId>
-           <version>2.15.0</version>
+           <version>2.16.0</version>
            </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/auth/encryptutil/pom.xml
+++ b/auth/encryptutil/pom.xml
@@ -45,17 +45,17 @@
     <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
     </dependency>
     <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
     </dependency>
     <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j-impl</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
     </dependency>
     <dependency>
         <groupId>junit</groupId>

--- a/auth/server/pom.xml
+++ b/auth/server/pom.xml
@@ -53,17 +53,17 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
         
         <!-- https://mvnrepository.com/artifact/com.github.stefanbirkner/system-rules -->


### PR DESCRIPTION
Another vulnerability is reported on log4j library CVE-2021-45046 with Low CVSS score of 3.7

Which means, the severity is LOW

However since a newer version of log4j (v 2.16.0 ) is available, it will be upgraded

So reopening this issue to upgrade log4j library to v 2.16.0

# Problem Statement
- Problem statement

Another vulnerability is reported on log4j library CVE-2021-45046 with Low CVSS score of 3.7

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

Link to Story -> https://jts.seagate.com/browse/EOS-26894
References to org.apache.logging.log4j version changed to 2.16.0

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

Not applicable

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

Not applicable

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [X] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [X] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
Not applicable