### PR TITLE
EOS-27020 [Fix] Clang Error in jenkins-build.sh 

### DIFF
--- a/server/s3_put_multiobject_copy_action.h
+++ b/server/s3_put_multiobject_copy_action.h
@@ -71,7 +71,7 @@ class S3PutMultipartCopyAction : public S3PutObjectActionBase {
   bool auth_in_progress = false;
   bool auth_failed = false;
   bool auth_completed = false;
-    
+
   bool motr_write_in_progress = false;
   bool motr_write_completed = false;  // full object write
   bool write_failed = false;
@@ -84,7 +84,8 @@ class S3PutMultipartCopyAction : public S3PutObjectActionBase {
   S3Timer s3_timer;
 
   int get_part_number() {
-    return strtol((request->get_query_string_value("partNumber")).c_str(), 0, 10);
+    return strtol((request->get_query_string_value("partNumber")).c_str(), 0,
+                  10);
   }
 
   void set_authorization_meta();
@@ -98,7 +99,8 @@ class S3PutMultipartCopyAction : public S3PutObjectActionBase {
   S3PutMultipartCopyAction(
       std::shared_ptr<S3RequestObject> req,
       std::shared_ptr<MotrAPI> motr_api = nullptr,
-      std::shared_ptr<S3ObjectMultipartMetadataFactory> object_mp_meta_factory = nullptr,
+      std::shared_ptr<S3ObjectMultipartMetadataFactory> object_mp_meta_factory =
+          nullptr,
       std::shared_ptr<S3PartMetadataFactory> part_meta_factory = nullptr,
       std::shared_ptr<S3BucketMetadataFactory> bucket_meta_factory = nullptr,
       std::shared_ptr<S3ObjectMetadataFactory> object_meta_factory = nullptr,
@@ -145,6 +147,5 @@ class S3PutMultipartCopyAction : public S3PutObjectActionBase {
   void delete_old_object();
   void remove_old_object_version_metadata();
   void delete_new_object();
-
 };
 #endif  // __S3_SERVER_S3_PUT_MULTIPART_COPY_ACTION_H__


### PR DESCRIPTION
Signed-off-by: Sumedh A. Kulkarni <sumedh.a.kulkarni@seagate.com>

# Problem Statement
The newly added {{s3_put_multiobject_copy_action.h/cc}} classes does not follow the syntax as per clang standard, which results in the error while running {{jenkins-build.sh.}}
Error:
```
One or more modified files do not comply with clang-format.
Running below command to see required changes:
        'git clang-format --style=Google --extensions=c,cc,h,java --diff --commit HEAD~1'

====================================================================




diff --git a/server/s3_put_multiobject_copy_action.cc b/server/s3_put_multiobject_copy_action.cc
index 66de8503..f8adfeaa 100644
--- a/server/s3_put_multiobject_copy_action.cc
+++ b/server/s3_put_multiobject_copy_action.cc
@@ -51,15 +51,16 @@ S3PutMultipartCopyAction::S3PutMultipartCopyAction(
     : S3PutObjectActionBase(std::move(req), std::move(bucket_meta_factory),
                             std::move(object_meta_factory), std::move(motr_api),
                             std::move(motr_s3_writer_factory),
-                            std::move(kv_writer_factory)){
+                            std::move(kv_writer_factory)) {
   part_number = get_part_number();
   upload_id = request->get_query_string_value("uploadId");
   s3_log(S3_LOG_DEBUG, request_id, "%s Ctor\n", __func__);
   s3_log(S3_LOG_INFO, stripped_request_id,
          "S3 API: UploadPartCopy. Destination: [%s], Source: [%s], \
          Part[%d] for UploadId [%s]\n",
-         request->get_object_uri().c_str(), request->get_headers_copysource().c_str(),
-         part_number, upload_id.c_str());
+         request->get_object_uri().c_str(),
+         request->get_headers_copysource().c_str(), part_number,
+         upload_id.c_str());

   action_uses_cleanup = true;
   s3_copy_part_action_state = S3PutObjectActionState::empty;
@@ -111,19 +112,21 @@ S3PutMultipartCopyAction::S3PutMultipartCopyAction(

   S3UriToMotrOID(s3_motr_api, request->get_object_uri().c_str(), request_id,
                  &new_object_oid);
-
+
   setup_steps();
 }
====================================================================
Code formatting check...Failed
```

# Design
ran the following cmds to address the issue.
```
clang-format server/s3_put_multiobject_copy_action.cc -i --style=Google
clang-format server/s3_put_multiobject_copy_action.h -i --style=Google
```
# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
