### PR TITLE
EOS-27000: Use Motr EP address as unique server ID for DataUsage

### DIFF
--- a/server/s3_data_usage.cc
+++ b/server/s3_data_usage.cc
@@ -125,8 +125,13 @@ std::string S3DataUsageCache::generate_cache_key(
 
 std::string get_server_id() {
   s3_log(S3_LOG_DEBUG, "", "%s Entry\n", __func__);
-  s3_log(S3_LOG_DEBUG, "", "%s Exit\n", __func__);
-  return "1";
+  extern struct m0_config motr_conf;
+  // static std::string s3server_ID = motr_conf.mc_process_fid;
+  // FID is not properly integrated in dev env, so will be using Motr EP
+  // address:
+  static std::string s3server_ID = motr_conf.mc_local_addr;
+  s3_log(S3_LOG_DEBUG, "", "%s Exit, ret %s\n", __func__, s3server_ID.c_str());
+  return s3server_ID;
 }
 
 std::shared_ptr<DataUsageItem> S3DataUsageCache::get_item(


### PR DESCRIPTION
Signed-off-by: Ivan Tishchenko <ivan.tishchenko@seagate.com>

# Problem Statement
- Server ID is hard-coded to "1" now; need to use real server ID.

# Design
-  Using server motr EP address as server ID.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
