### PR TITLE
EOS-27000: bugfix for negative counters

### DIFF
--- a/server/s3_data_usage.cc
+++ b/server/s3_data_usage.cc
@@ -502,9 +502,9 @@ std::string DataUsageItem::to_json() {
 
   Json::Value root;
   root[JSON_OBJECTS_COUNT] = Json::Value(
-      (Json::Value::UInt64)(objects_count + current_objects_increment));
+      (Json::Value::Int64)(objects_count + current_objects_increment));
   root[JSON_BYTES_COUNT] =
-      Json::Value((Json::Value::UInt64)(bytes_count + current_bytes_increment));
+      Json::Value((Json::Value::Int64)(bytes_count + current_bytes_increment));
 
   Json::FastWriter fastWriter;
   std::string json = fastWriter.write(root);


### PR DESCRIPTION
# Problem Statement
- Negative counter values were saved as huge positive integers.

# Design
-  Use Int64 instead of UInt64.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide


-----
[View rendered docs/notes.md](https://github.com/Seagate/cortx-s3server/blob/br/it/EOS-27000-bugfix-negative-counters/docs/notes.md)
[View rendered s3backgrounddelete/readme.md](https://github.com/Seagate/cortx-s3server/blob/br/it/EOS-27000-bugfix-negative-counters/s3backgrounddelete/readme.md)