### PR TITLE
[F-71A] [data-usage] EOS-26536: Enabler - stub out API for CSM

### DIFF
--- a/server/s3_addb_plugin_auto.cc
+++ b/server/s3_addb_plugin_auto.cc
@@ -46,6 +46,7 @@
 #include "s3_abort_multipart_action.h"
 #include "s3_account_delete_metadata_action.h"
 #include "s3_copy_object_action.h"
+#include "s3_data_usage_action.h"
 #include "s3_delete_bucket_action.h"
 #include "s3_delete_bucket_policy_action.h"
 #include "s3_delete_bucket_tagging_action.h"
@@ -108,6 +109,8 @@ int s3_addb_init() {
       S3_ADDB_S3_ACCOUNT_DELETE_METADATA_ACTION_ID;
   gs_addb_map[std::type_index(typeid(S3CopyObjectAction))] =
       S3_ADDB_S3_COPY_OBJECT_ACTION_ID;
+  gs_addb_map[std::type_index(typeid(S3DataUsageAction))] =
+      S3_ADDB_S3_DATA_USAGE_ACTION_ID;
   gs_addb_map[std::type_index(typeid(S3DeleteBucketAction))] =
       S3_ADDB_S3_DELETE_BUCKET_ACTION_ID;
   gs_addb_map[std::type_index(typeid(S3DeleteBucketPolicyAction))] =
@@ -240,6 +243,12 @@ int s3_addb_init() {
          ": class S3CopyObjectAction\n",
          (uint64_t)S3_ADDB_S3_COPY_OBJECT_ACTION_ID,
          (int64_t)S3_ADDB_S3_COPY_OBJECT_ACTION_ID);
+
+  s3_log(S3_LOG_DEBUG, "",
+         "  * id 0x%" PRIx64 "/%" PRId64  // suppress clang warning
+         ": class S3DataUsageAction\n",
+         (uint64_t)S3_ADDB_S3_DATA_USAGE_ACTION_ID,
+         (int64_t)S3_ADDB_S3_DATA_USAGE_ACTION_ID);
 
   s3_log(S3_LOG_DEBUG, "",
          "  * id 0x%" PRIx64 "/%" PRId64  // suppress clang warning

--- a/server/s3_addb_plugin_auto.h
+++ b/server/s3_addb_plugin_auto.h
@@ -87,6 +87,8 @@ enum S3AddbActionTypeId {
   S3_ADDB_S3_ACCOUNT_DELETE_METADATA_ACTION_ID,
   /* S3CopyObjectAction: */
   S3_ADDB_S3_COPY_OBJECT_ACTION_ID,
+  /* S3DataUsageAction: */
+  S3_ADDB_S3_DATA_USAGE_ACTION_ID,
   /* S3DeleteBucketAction: */
   S3_ADDB_S3_DELETE_BUCKET_ACTION_ID,
   /* S3DeleteBucketPolicyAction: */

--- a/server/s3_data_usage_action.cc
+++ b/server/s3_data_usage_action.cc
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+#include "s3_error_codes.h"
+#include "s3_log.h"
+#include "s3_api_handler.h"
+#include "s3_data_usage_action.h"
+#include <iostream>
+
+S3DataUsageAction::S3DataUsageAction(std::shared_ptr<S3RequestObject> req)
+    : S3Action(req, true, nullptr, true, true), schema("hii") {
+
+  setup_steps();
+}
+S3DataUsageAction::~S3DataUsageAction() {
+  s3_log(S3_LOG_DEBUG, "", "%s\n", __func__);
+}
+void S3DataUsageAction::setup_steps() { send_response_to_s3_client(); }
+
+void S3DataUsageAction::send_response_to_s3_client() {
+  s3_log(S3_LOG_DEBUG, "", "%s Entry \n", __func__);
+  request->send_response(S3HttpSuccess200, schema);
+}

--- a/server/s3_data_usage_action.cc
+++ b/server/s3_data_usage_action.cc
@@ -25,16 +25,26 @@
 #include <iostream>
 
 S3DataUsageAction::S3DataUsageAction(std::shared_ptr<S3RequestObject> req)
-    : S3Action(req, true, nullptr, true, true), schema("hii") {
-
+    : S3Action(req, true, nullptr, true, true), request(req) {
   setup_steps();
 }
+
 S3DataUsageAction::~S3DataUsageAction() {
   s3_log(S3_LOG_DEBUG, "", "%s\n", __func__);
 }
-void S3DataUsageAction::setup_steps() { send_response_to_s3_client(); }
+
+void S3DataUsageAction::prepare_the_response() {
+  json_response =
+      "[ \"12345\": { \"bytes_count\": 123456789 }, \"54321\": { "
+      "\"bytes_count\": 987654321 } ]";
+}
+
+void S3DataUsageAction::setup_steps() {
+  prepare_the_response();
+  send_response_to_s3_client();
+}
 
 void S3DataUsageAction::send_response_to_s3_client() {
   s3_log(S3_LOG_DEBUG, "", "%s Entry \n", __func__);
-  request->send_response(S3HttpSuccess200, schema);
+  request->send_response(S3HttpSuccess200, json_response);
 }

--- a/server/s3_data_usage_action.h
+++ b/server/s3_data_usage_action.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+#include <string>
+#include "s3_request_object.h"
+#include "s3_action_base.h"
+class S3DataUsageAction : public S3Action {
+  std::string schema = "hello this is not implemented yet.";
+  std::shared_ptr<S3RequestObject> request;
+
+ public:
+  S3DataUsageAction(std::shared_ptr<S3RequestObject> req);
+  virtual ~S3DataUsageAction();
+  void send_response_to_s3_client();
+  void setup_steps();
+};

--- a/server/s3_data_usage_action.h
+++ b/server/s3_data_usage_action.h
@@ -22,8 +22,10 @@
 #include "s3_request_object.h"
 #include "s3_action_base.h"
 class S3DataUsageAction : public S3Action {
-  std::string schema = "hello this is not implemented yet.";
+  std::string json_response;
   std::shared_ptr<S3RequestObject> request;
+
+  void prepare_the_response();
 
  public:
   S3DataUsageAction(std::shared_ptr<S3RequestObject> req);

--- a/server/s3_management_api_handler.cc
+++ b/server/s3_management_api_handler.cc
@@ -22,6 +22,7 @@
 #include "s3_api_handler.h"
 #include "s3_account_delete_metadata_action.h"
 #include "s3_get_audit_log_schema_action.h"
+#include "s3_data_usage_action.h"
 
 void S3ManagementAPIHandler::create_action() {
   s3_log(S3_LOG_DEBUG, request_id, "%s Entry", __func__);
@@ -40,6 +41,11 @@ void S3ManagementAPIHandler::create_action() {
           if (full_uri.compare("/s3/audit-log/schema") == 0) {
             action = std::make_shared<S3GetAuditLogSchemaAction>(request);
             s3_log(S3_LOG_DEBUG, request_id, "S3GetAuditLogSchemaAction");
+          } else {
+            if (full_uri.compare("/s3/data_usage") == 0) {
+              action = std::make_shared<S3DataUsageAction>(request);
+              s3_log(S3_LOG_DEBUG, request_id, "S3GetDataUsageAction");
+            }
           }
         } break;
         default:


### PR DESCRIPTION
# Problem Statement
- [EOS-26536](https://jts.seagate.com/browse/EOS-26536): stub out the data usage API for CSM (/s3/data_usage).

# Design
-  The stub returns `[ "12345": { "bytes_count": 123456789 }, "54321": { "bytes_count": 987654321 } ]`

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
