### PR TITLE
[multipart-partcopy] EOS-24345: Part Copy Based on Specified Range for Simple Objects

### DIFF
--- a/server/s3_object_data_copier.cc
+++ b/server/s3_object_data_copier.cc
@@ -329,8 +329,8 @@ void S3ObjectDataCopier::write_data_block_failed() {
 void S3ObjectDataCopier::copy(
     struct m0_uint128 src_obj_id, size_t object_size, int layout_id,
     struct m0_fid pvid, std::function<bool(void)> check_shutdown_and_rollback,
-    std::function<void(void)> on_success,
-    std::function<void(void)> on_failure) {
+    std::function<void(void)> on_success, std::function<void(void)> on_failure,
+    size_t first_byte_offset) {
   s3_log(S3_LOG_INFO, request_id, "%s Entry\n", __func__);
 
   assert(non_zero(src_obj_id));
@@ -349,7 +349,10 @@ void S3ObjectDataCopier::copy(
 
   motr_reader = motr_reader_factory->create_motr_reader(
       request_object, src_obj_id, layout_id, pvid, motr_api);
-  motr_reader->set_last_index(0);
+  // motr_reader->set_last_index(0);
+
+  size_t block_start_offset = first_byte_offset - (first_byte_offset % motr_unit_size);
+  motr_reader->set_last_index(block_start_offset);
 
   bytes_left_to_read = object_size;
 

--- a/server/s3_object_data_copier.cc
+++ b/server/s3_object_data_copier.cc
@@ -151,7 +151,7 @@ void S3ObjectDataCopier::read_data_block_success() {
     }
     return;
   }
-  // Calculating actial size of data that has just been read
+  // Calculating actual size of data that has just been read
 
   for (size_t i = 0, n = data_blocks_read.size(); i < n; ++i) {
     const auto motr_block_size = data_blocks_read[i].second;
@@ -351,7 +351,8 @@ void S3ObjectDataCopier::copy(
       request_object, src_obj_id, layout_id, pvid, motr_api);
   // motr_reader->set_last_index(0);
 
-  size_t block_start_offset = first_byte_offset - (first_byte_offset % motr_unit_size);
+  size_t block_start_offset =
+      first_byte_offset - (first_byte_offset % motr_unit_size);
   motr_reader->set_last_index(block_start_offset);
 
   bytes_left_to_read = object_size;

--- a/server/s3_object_data_copier.h
+++ b/server/s3_object_data_copier.h
@@ -91,7 +91,8 @@ class S3ObjectDataCopier {
             struct m0_fid pvid,
             std::function<bool(void)> check_shutdown_and_rollback,
             std::function<void(void)> on_success,
-            std::function<void(void)> on_failure);
+            std::function<void(void)> on_failure,
+            size_t first_byte_offset = 0);
 
   void copy_part_fragment(
       std::vector<struct s3_part_frag_context> fragment_context_list,

--- a/server/s3_put_multiobject_copy_action.cc
+++ b/server/s3_put_multiobject_copy_action.cc
@@ -176,7 +176,7 @@ void S3PutMultipartCopyAction::validate_multipart_partcopy_request() {
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
-bool S3GetObjectAction::validate_range_header(
+bool S3PutMultipartCopyAction::validate_range_header(
     const std::string& range_value) {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
   // The header can consist of 'blank' character(s) only
@@ -254,16 +254,16 @@ bool S3GetObjectAction::validate_range_header(
   }
   // Return last 'nnn' bytes from object.
   if (first_byte.empty()) {
-    first_byte_offset_to_read = content_length - atol(last_byte.c_str());
+    first_byte_offset_to_read = content_length - strtol(last_byte.c_str(), 0, 10);
     last_byte_offset_to_read = content_length - 1;
   } else if (last_byte.empty()) {
     // Return from 'nnn' bytes to content_length-1 from object.
-    first_byte_offset_to_read = atol(first_byte.c_str());
+    first_byte_offset_to_read = strtol(first_byte.c_str(), 0, 10);
     last_byte_offset_to_read = content_length - 1;
   } else {
     // both are not empty
-    first_byte_offset_to_read = atol(first_byte.c_str());
-    last_byte_offset_to_read = atol(last_byte.c_str());
+    first_byte_offset_to_read = strtol(first_byte.c_str(), 0, 10);
+    last_byte_offset_to_read = strtol(last_byte.c_str(), 0, 10);
   }
   // last_byte_offset_to_read is greater than or equal to the current length of
   // the entity-body, last_byte_offset_to_read is taken to be equal to

--- a/server/s3_put_multiobject_copy_action.cc
+++ b/server/s3_put_multiobject_copy_action.cc
@@ -157,6 +157,7 @@ void S3PutMultipartCopyAction::validate_multipart_partcopy_request() {
       s3_copy_part_action_state = S3PutObjectActionState::validationFailed;
       set_s3_error("InvalidRequest");
       send_response_to_s3_client();
+      return;
     } else {
       last_byte_offset_to_copy = source_object_size - 1;
     }
@@ -168,6 +169,7 @@ void S3PutMultipartCopyAction::validate_multipart_partcopy_request() {
     if (!validate_range_header(range_header_value)) {
       set_s3_error("InvalidRange");
       send_response_to_s3_client();
+      return;
     }
   }
   total_data_to_copy = last_byte_offset_to_copy - first_byte_offset_to_copy;

--- a/server/s3_put_multiobject_copy_action.cc
+++ b/server/s3_put_multiobject_copy_action.cc
@@ -146,22 +146,21 @@ void S3PutMultipartCopyAction::validate_multipart_partcopy_request() {
     send_response_to_s3_client();
     return;
   }
-  std::string range_header_value = request->get_header_value("x-amz-copy-source-range");
+  std::string range_header_value =
+      request->get_header_value("x-amz-copy-source-range");
   if (range_header_value.empty()) {
     // Range is not specified, read complete object
     s3_log(S3_LOG_DEBUG, request_id, "Range is not specified\n");
     if (MaxPartCopySourcePartSize <
-      additional_object_metadata->get_content_length()) {
-        s3_copy_part_action_state = S3PutObjectActionState::validationFailed;
-        set_s3_error("InvalidRequest");
-        send_response_to_s3_client();
-    } 
-    else {
+        additional_object_metadata->get_content_length()) {
+      s3_copy_part_action_state = S3PutObjectActionState::validationFailed;
+      set_s3_error("InvalidRequest");
+      send_response_to_s3_client();
+    } else {
       total_data_to_copy = additional_object_metadata->get_content_length();
       next();
     }
-  }
-  else{
+  } else {
     // parse the Range header value
     // eg: bytes=0-1024 value
     s3_log(S3_LOG_DEBUG, request_id, "Range found(%s)\n",
@@ -183,7 +182,7 @@ bool S3PutMultipartCopyAction::validate_range_header(
   if (std::find_if_not(range_value.begin(), range_value.end(), &::isspace) ==
       range_value.end()) {
     s3_log(S3_LOG_DEBUG, request_id,
-           "\"Range:\" header consists of blank symbol(s) only");
+           "Range header consists of blank symbol(s) only");
     return true;
   }
   // parse the Range header value
@@ -216,14 +215,9 @@ bool S3PutMultipartCopyAction::validate_range_header(
   pos = byte_range_set.find(',');
   if (pos != std::string::npos) {
     // found ,
-    // in this case, AWS returns full object and hence we do too
     s3_log(S3_LOG_INFO, stripped_request_id, "unsupported multirange(%s)\n",
            byte_range_set.c_str());
-    // initialize the first and last offset values with actual object offsets
-    // to read complete object
-    first_byte_offset_to_read = 0;
-    last_byte_offset_to_read = content_length - 1;
-    return true;
+    return false;
   }
   pos = byte_range_set.find('-');
   if (pos == std::string::npos) {
@@ -252,39 +246,14 @@ bool S3PutMultipartCopyAction::validate_range_header(
            range_value.c_str());
     return false;
   }
-  // Return last 'nnn' bytes from object.
-  if (first_byte.empty()) {
-    first_byte_offset_to_read = content_length - strtol(last_byte.c_str(), 0, 10);
-    last_byte_offset_to_read = content_length - 1;
-  } else if (last_byte.empty()) {
-    // Return from 'nnn' bytes to content_length-1 from object.
-    first_byte_offset_to_read = strtol(first_byte.c_str(), 0, 10);
-    last_byte_offset_to_read = content_length - 1;
-  } else {
-    // both are not empty
-    first_byte_offset_to_read = strtol(first_byte.c_str(), 0, 10);
-    last_byte_offset_to_read = strtol(last_byte.c_str(), 0, 10);
-  }
-  // last_byte_offset_to_read is greater than or equal to the current length of
-  // the entity-body, last_byte_offset_to_read is taken to be equal to
-  // one less than the current length of the entity- body in bytes.
-  if (last_byte_offset_to_read > content_length - 1) {
-    last_byte_offset_to_read = content_length - 1;
-  }
-  // Range validation
-  // If a syntactically valid byte-range-set includes at least one byte-
-  // range-spec whose first-byte-pos is less than the current length of the
-  // entity-body, or at least one suffix-byte-range-spec with a non-zero
-  // suffix-length, then the byte-range-set is satisfiable.
-  if ((first_byte_offset_to_read >= content_length) ||
-      (first_byte_offset_to_read > last_byte_offset_to_read)) {
-    s3_log(S3_LOG_INFO, stripped_request_id, "Invalid range(%s)\n",
-           range_value.c_str());
-    return false;
-  }
+
   // valid range
+  first_byte_offset_to_copy = strtol(first_byte.c_str(), 0, 10);
+  last_byte_offset_to_copy = strtol(last_byte.c_str(), 0, 10);
+
+  total_data_to_copy = last_byte_offset_to_copy - first_byte_offset_to_copy;
   s3_log(S3_LOG_DEBUG, request_id, "valid range(%zu-%zu) found\n",
-         first_byte_offset_to_read, last_byte_offset_to_read);
+          first_byte_offset_to_copy, last_byte_offset_to_copy);
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
   return true;
 }
@@ -517,10 +486,11 @@ void S3PutMultipartCopyAction::copy_part_object() {
         additional_object_metadata->get_pvid(),
         std::bind(&S3PutMultipartCopyAction::copy_part_object_cb, this),
         std::bind(&S3PutMultipartCopyAction::copy_part_object_success, this),
-        std::bind(&S3PutMultipartCopyAction::copy_part_object_failed, this));
+        std::bind(&S3PutMultipartCopyAction::copy_part_object_failed, this),
+        first_byte_offset_to_copy);
     f_success = true;
   }
-  catch (const std::exception &ex) {
+  catch (const std::exception& ex) {
     s3_log(S3_LOG_ERROR, stripped_request_id, "%s", ex.what());
   }
   catch (...) {

--- a/server/s3_put_multiobject_copy_action.cc
+++ b/server/s3_put_multiobject_copy_action.cc
@@ -171,8 +171,12 @@ void S3PutMultipartCopyAction::validate_multipart_partcopy_request() {
     }
   }
   total_data_to_copy = last_byte_offset_to_copy - first_byte_offset_to_copy;
-  s3_log(S3_LOG_DEBUG, request_id, "valid range(%zu-%zu) found\n",
+  s3_log(S3_LOG_DEBUG, request_id, "Validated range: %zu-%zu\n",
          first_byte_offset_to_copy, last_byte_offset_to_copy);
+  s3_log(S3_LOG_DEBUG, request_id,
+         "Total data to copy in part [%d]: %zu bytes\n", part_number,
+         total_data_to_copy);
+  next();
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 

--- a/server/s3_put_multiobject_copy_action.cc
+++ b/server/s3_put_multiobject_copy_action.cc
@@ -149,7 +149,7 @@ void S3PutMultipartCopyAction::validate_multipart_partcopy_request() {
   std::string range_header_value =
       request->get_header_value("x-amz-copy-source-range");
   source_object_size = additional_object_metadata->get_content_length();
-  
+
   if (range_header_value.empty()) {
     // Range is not specified, read complete object
     s3_log(S3_LOG_DEBUG, request_id, "Range is not specified\n");
@@ -157,9 +157,9 @@ void S3PutMultipartCopyAction::validate_multipart_partcopy_request() {
       s3_copy_part_action_state = S3PutObjectActionState::validationFailed;
       set_s3_error("InvalidRequest");
       send_response_to_s3_client();
-    }else {
-      last_byte_offset_to_copy = source_object_size -1;
-    } 
+    } else {
+      last_byte_offset_to_copy = source_object_size - 1;
+    }
   } else {
     // parse the Range header value
     // eg: bytes=0-1024 value
@@ -172,7 +172,7 @@ void S3PutMultipartCopyAction::validate_multipart_partcopy_request() {
   }
   total_data_to_copy = last_byte_offset_to_copy - first_byte_offset_to_copy;
   s3_log(S3_LOG_DEBUG, request_id, "valid range(%zu-%zu) found\n",
-          first_byte_offset_to_copy, last_byte_offset_to_copy);
+         first_byte_offset_to_copy, last_byte_offset_to_copy);
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
@@ -474,7 +474,8 @@ void S3PutMultipartCopyAction::copy_part_object() {
   s3_log(S3_LOG_INFO, stripped_request_id, "%s Entry\n", __func__);
 
   if (!total_data_to_copy) {
-    s3_log(S3_LOG_DEBUG, stripped_request_id, "Source object/specified range is empty");
+    s3_log(S3_LOG_DEBUG, stripped_request_id,
+           "Source object/specified range is empty");
     next();
     return;
   }
@@ -701,7 +702,9 @@ void S3PutMultipartCopyAction::send_response_to_s3_client() {
       if (if_source_and_destination_same()) {  // Source and Destination same
         error.set_auth_error_message(
             InvalidRequestPartCopySourceAndDestinationSame);
-      } else if (source_object_size > MaxPartCopySourcePartSize) {  // Source object size greater than 5GB
+      } else if (source_object_size >
+                 MaxPartCopySourcePartSize) {  // Source object size greater
+                                               // than 5GB
         error.set_auth_error_message(
             InvalidRequestSourcePartSizeGreaterThan5GB);
       }

--- a/server/s3_put_multiobject_copy_action.h
+++ b/server/s3_put_multiobject_copy_action.h
@@ -41,6 +41,7 @@
 #include "s3_timer.h"
 
 const uint64_t MaxPartCopySourcePartSize = 5368709120UL;  // 5GB
+const uint64_t MinRangeCopyObjectSize = 5242880UL;  // 5MB
 
 const char InvalidRequestSourcePartSizeGreaterThan5GB[] =
     "The specified part in copy source is larger than the maximum allowable "
@@ -79,8 +80,10 @@ class S3PutMultipartCopyAction : public S3PutObjectActionBase {
   int part_number;
   std::string upload_id;
   size_t total_data_to_copy = 0;
-  size_t first_byte_offset_to_copy;
-  size_t last_byte_offset_to_copy;
+  size_t source_object_size = 0;
+
+  size_t first_byte_offset_to_copy = 0;
+  size_t last_byte_offset_to_copy = 0;
   unsigned motr_write_payload_size;
   bool if_source_and_destination_same();
   S3Timer s3_timer;

--- a/server/s3_put_multiobject_copy_action.h
+++ b/server/s3_put_multiobject_copy_action.h
@@ -79,6 +79,8 @@ class S3PutMultipartCopyAction : public S3PutObjectActionBase {
   int part_number;
   std::string upload_id;
   size_t total_data_to_copy = 0;
+  size_t first_byte_offset_to_copy;
+  size_t last_byte_offset_to_copy;
   unsigned motr_write_payload_size;
   bool if_source_and_destination_same();
   S3Timer s3_timer;
@@ -115,7 +117,7 @@ class S3PutMultipartCopyAction : public S3PutObjectActionBase {
   void check_part_details();
   void fetch_multipart_metadata();
   void fetch_multipart_failed();
-  bool validate_range_header();
+  bool validate_range_header(const std::string& range_value);
   void validate_multipart_partcopy_request();
   void fetch_part_info();
   void fetch_part_info_success();

--- a/server/s3_put_multiobject_copy_action.h
+++ b/server/s3_put_multiobject_copy_action.h
@@ -41,7 +41,7 @@
 #include "s3_timer.h"
 
 const uint64_t MaxPartCopySourcePartSize = 5368709120UL;  // 5GB
-const uint64_t MinRangeCopyObjectSize = 5242880UL;  // 5MB
+const uint64_t MinRangeCopyObjectSize = 5242880UL;        // 5MB
 
 const char InvalidRequestSourcePartSizeGreaterThan5GB[] =
     "The specified part in copy source is larger than the maximum allowable "
@@ -59,7 +59,7 @@ class S3PutMultipartCopyAction : public S3PutObjectActionBase {
   std::shared_ptr<S3MotrReaderFactory> motr_reader_factory;
   std::unique_ptr<S3ObjectDataCopier> object_data_copier;
   std::shared_ptr<S3ObjectDataCopier> fragment_data_copier;
-  std::vector<std::shared_ptr<S3ObjectDataCopier>> fragment_data_copier_list;
+  std::vector<std::shared_ptr<S3ObjectDataCopier> > fragment_data_copier_list;
   std::shared_ptr<S3PartMetadata> part_metadata = NULL;
   std::shared_ptr<S3ObjectMetadata> object_multipart_metadata = NULL;
   std::shared_ptr<S3MotrKVSWriterFactory> motr_kv_writer_factory;
@@ -120,7 +120,7 @@ class S3PutMultipartCopyAction : public S3PutObjectActionBase {
   void check_part_details();
   void fetch_multipart_metadata();
   void fetch_multipart_failed();
-  bool validate_range_header(const std::string& range_value);
+  bool validate_range_header(const std::string &range_value);
   void validate_multipart_partcopy_request();
   void fetch_part_info();
   void fetch_part_info_success();

--- a/server/s3_put_multiobject_copy_action.h
+++ b/server/s3_put_multiobject_copy_action.h
@@ -115,6 +115,7 @@ class S3PutMultipartCopyAction : public S3PutObjectActionBase {
   void check_part_details();
   void fetch_multipart_metadata();
   void fetch_multipart_failed();
+  bool validate_range_header();
   void validate_multipart_partcopy_request();
   void fetch_part_info();
   void fetch_part_info_success();


### PR DESCRIPTION
# Problem Statement
- Multipart upload part copy based on range specified in `x-amz-copy-source-range`

# Design
-  Modified `s3_object_data_copier.cc` to support range based copy.
-  Added extra validations for range based copy.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
> Unit tests will be updated with [#1725](https://github.com/Seagate/cortx-s3server/pull/1725)

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
