### PR TITLE
Upgrade .whitesource configuration to scan main and kubernetes branches

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,6 +1,7 @@
 {
   "scanSettings": {
-    "configMode": "LOCAL"
+    "configMode": "LOCAL",
+    "baseBranches": ["main","kubernetes"]
   },
   "checkRunSettings": {
     "displayMode": "diff",


### PR DESCRIPTION
Signed-off-by: Swanand S Gadre <swanand.s.gadre@seagate.com>

# Problem Statement
- Problem statement

Whitesource scan need to run on both main and kubernetes branches.
By default it only covers main (default) branch

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

https://jts.seagate.com/browse/EOS-27073

# Coding
   Checklist for Author
-  [X] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

This changes is already done on other repos like CSM
https://github.com/Seagate/cortx-management-portal/blob/main/.whitesource

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [X] JIRA number/GitHub Issue added to PR
- [X] PR is self reviewed
- [X] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained


# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
Not applicable