### PR TITLE
[versioning] [EOS-25874] - PutObject with null version

### DIFF
--- a/server/s3_object_metadata.h
+++ b/server/s3_object_metadata.h
@@ -126,6 +126,8 @@ class S3ObjectMetadata : private S3ObjectMetadataCopyable {
   // holds base64 encoding value of rev_epoch_version_id_key, this is used
   // in S3 REST APIs as http header x-amz-version-id or query param "VersionId"
   std::string object_version_id;
+  // holds reference/version key to object with null version.
+  std::string null_object_version_id;
 
   std::string upload_id;
   // Maximum retry count for collision resolution.
@@ -156,6 +158,7 @@ class S3ObjectMetadata : private S3ObjectMetadataCopyable {
   bool is_multipart = false;
   bool latest = false;
   bool is_delete_marker_ = false;
+  bool _null = false;
 
   std::shared_ptr<S3MotrKVSReader> motr_kv_reader;
   std::shared_ptr<S3MotrKVSWriter> motr_kv_writer;
@@ -276,12 +279,18 @@ class S3ObjectMetadata : private S3ObjectMetadataCopyable {
   std::string const get_obj_version_id() { return object_version_id; }
   std::string const get_obj_version_key() { return rev_epoch_version_id_key; }
 
-  void set_version_id(std::string ver_id);
+  virtual void set_version_id(std::string ver_id);
+
+  void set_null_object_version_id(const std::string& null_version_key);
+  std::string const get_null_object_version_id();
 
   void set_latest(bool is_latest) { latest = is_latest; }
   bool is_latest() const {
     return latest;
   };
+
+  void set_null(bool is_null) { _null = is_null; }
+  bool is_null() const { return _null; }
 
   std::string get_old_obj_version_id() { return motr_old_object_version_id; }
   void set_old_version_id(std::string old_obj_ver_id);
@@ -367,7 +376,7 @@ class S3ObjectMetadata : private S3ObjectMetadataCopyable {
   // For object metadata in object listing
   std::string to_json();
   // For storing minimal version entry in version listing
-  std::string version_entry_to_json();
+  std::string version_entry_to_json(bool obj_index = false);
 
   // returns 0 on success, -1 on parsing error.
   virtual int from_json(std::string content);

--- a/ut/mock_s3_factory.h
+++ b/ut/mock_s3_factory.h
@@ -70,6 +70,8 @@ class MockS3ObjectMetadataFactory : public S3ObjectMetadataFactory {
         std::make_shared<MockS3ObjectExtendedMetadata>(req, s3_motr_mock_ptr);
     mock_delete_marker_metadata =
         std::make_shared<MockS3ObjectMetadata>(req, s3_motr_mock_ptr);
+    mock_null_object_metadata =
+        std::make_shared<MockS3ObjectMetadata>(req, s3_motr_mock_ptr);
   }
   void set_object_list_index_oid(const struct m0_uint128& id) {
     mock_object_metadata->set_object_list_index_layout({id});
@@ -118,6 +120,7 @@ class MockS3ObjectMetadataFactory : public S3ObjectMetadataFactory {
   std::shared_ptr<MockS3ObjectMetadata> mock_object_metadata;
   std::shared_ptr<MockS3ObjectExtendedMetadata> mock_object_extnd_metadata;
   std::shared_ptr<MockS3ObjectMetadata> mock_delete_marker_metadata;
+  std::shared_ptr<MockS3ObjectMetadata> mock_null_object_metadata;
 };
 
 class MockS3PartMetadataFactory : public S3PartMetadataFactory {

--- a/ut/mock_s3_object_metadata.h
+++ b/ut/mock_s3_object_metadata.h
@@ -51,6 +51,7 @@ class MockS3ObjectMetadata : public S3ObjectMetadata {
   MOCK_METHOD0(get_content_length, size_t());
   MOCK_METHOD1(set_content_length, void(std::string length));
   MOCK_METHOD1(set_content_type, void(std::string length));
+  MOCK_METHOD1(set_version_id, void(std::string));
   MOCK_METHOD0(get_content_length_str, std::string());
   MOCK_METHOD0(get_last_modified_gmt, std::string());
   MOCK_METHOD0(get_user_id, std::string());


### PR DESCRIPTION
# Problem Statement
PutObject when bucket versioning is suspended.
Jira: https://jts.seagate.com/browse/EOS-25874

# Design
https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/768639283/PutObject+LLD

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide
