### PR TITLE
[data-usage] EOS-26626: API for CSM

### DIFF
--- a/server/s3_addb_map_auto.c
+++ b/server/s3_addb_map_auto.c
@@ -25,7 +25,7 @@
 
 #include "s3_addb_map.h"
 
-const uint64_t g_s3_to_addb_idx_func_name_map_size = 233;
+const uint64_t g_s3_to_addb_idx_func_name_map_size = 235;
 
 const char* g_s3_to_addb_idx_func_name_map[] = {
     "Action::check_authentication",
@@ -86,6 +86,8 @@ const char* g_s3_to_addb_idx_func_name_map[] = {
     "S3CopyObjectAction::set_source_bucket_authorization_metadata",
     "S3CopyObjectAction::validate_copyobject_request",
     "S3CopyObjectActionTest::func_callback_one",
+    "S3DataUsageAction::get_data_usage_counters",
+    "S3DataUsageAction::send_response_to_s3_client",
     "S3DeleteBucketAction::delete_bucket",
     "S3DeleteBucketAction::delete_multipart_objects",
     "S3DeleteBucketAction::fetch_first_object_metadata",

--- a/server/s3_data_usage.h
+++ b/server/s3_data_usage.h
@@ -22,6 +22,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <json/json.h>
 #include <map>
 #include <string>
 #include <gtest/gtest_prod.h>
@@ -128,6 +129,10 @@ class DataUsageItem {
   // Item's place in the list of inactive items that the cache maintains
   std::list<DataUsageItem *>::iterator ptr_inactive;
 
+  static const char JSON_KEY_ACCOUNT_ID_DELIMITER;
+  static const std::string JSON_OBJECTS_COUNT;
+  static const std::string JSON_BYTES_COUNT;
+
   std::string get_item_request_id();
   void set_state(DataUsageItemState new_state);
   void do_kvs_read();
@@ -139,8 +144,6 @@ class DataUsageItem {
   void run_successful_callbacks();
   void run_failure_callbacks();
   void fail_all();
-  std::string to_json();
-  int from_json(std::string content);
 
  public:
   DataUsageItem(std::shared_ptr<RequestObject> req,
@@ -156,6 +159,15 @@ class DataUsageItem {
                     int64_t bytes_count_increment,
                     std::function<void()> on_success,
                     std::function<void()> on_failure);
+  static std::string extract_account_id_from_motr_key(
+      const std::string &req_id, const std::string &motr_key);
+  static int from_json(const std::string &req_id, const std::string &content,
+                       int64_t *p_objects_count, int64_t *p_bytes_count);
+  static std::string to_json(const std::string &req_id, int64_t objects_count,
+                             int64_t bytes_count);
+  static Json::Value to_json_value(const std::string &req_id,
+                                   int64_t *p_objects_count,
+                                   int64_t *p_bytes_count);
 
   friend S3DataUsageCache;
   friend class DataUsageItemTest;

--- a/server/s3_data_usage_action.cc
+++ b/server/s3_data_usage_action.cc
@@ -18,14 +18,40 @@
  *
  */
 
-#include "s3_error_codes.h"
-#include "s3_log.h"
+#include <iostream>
+#include <json/json.h>
+
 #include "s3_api_handler.h"
 #include "s3_data_usage_action.h"
-#include <iostream>
+#include "s3_error_codes.h"
+#include "s3_log.h"
+#include "s3_option.h"
 
-S3DataUsageAction::S3DataUsageAction(std::shared_ptr<S3RequestObject> req)
+extern struct s3_motr_idx_layout data_usage_accounts_index_layout;
+#define JSON_OBJECTS_COUNT "objects_count"
+#define JSON_BYTES_COUNT "bytes_count"
+
+S3DataUsageAction::S3DataUsageAction(
+    std::shared_ptr<S3RequestObject> req,
+    std::shared_ptr<S3MotrKVSReaderFactory> kvs_reader_factory,
+    std::shared_ptr<MotrAPI> motr_api)
     : S3Action(req, true, nullptr, true, true), request(req) {
+  if (motr_api) {
+    motr_kvs_api = std::move(motr_api);
+  } else {
+    motr_kvs_api = std::make_shared<ConcreteMotrAPI>();
+  }
+  if (kvs_reader_factory) {
+    motr_kvs_reader_factory = std::move(kvs_reader_factory);
+  } else {
+    motr_kvs_reader_factory = std::make_shared<S3MotrKVSReaderFactory>();
+  }
+  motr_kvs_reader =
+      motr_kvs_reader_factory->create_motr_kvs_reader(request, motr_kvs_api);
+  max_records_per_request =
+      S3Option::get_instance()->get_motr_idx_fetch_count();
+  last_key = "";
+
   setup_steps();
 }
 
@@ -33,18 +59,128 @@ S3DataUsageAction::~S3DataUsageAction() {
   s3_log(S3_LOG_DEBUG, "", "%s\n", __func__);
 }
 
-void S3DataUsageAction::prepare_the_response() {
-  json_response =
-      "[ \"12345\": { \"bytes_count\": 123456789 }, \"54321\": { "
-      "\"bytes_count\": 987654321 } ]";
+void S3DataUsageAction::get_data_usage_counters() {
+  // json_response =
+  //     "[ \"12345\": { \"bytes_count\": 123456789 }, \"54321\": { "
+  //     "\"bytes_count\": 987654321 } ]";
+
+  motr_kvs_reader->next_keyval(
+      data_usage_accounts_index_layout, last_key, max_records_per_request,
+      std::bind(&S3DataUsageAction::get_next_keyval_success, this),
+      std::bind(&S3DataUsageAction::get_next_keyval_failure, this));
+}
+
+std::string extract_account_id_from_motr_key(const std::string& motr_key) {
+  const char account_id_delimeter = '/';
+  auto pos = motr_key.find(account_id_delimeter);
+  return (pos != std::string::npos ? motr_key.substr(0, pos) : "");
+}
+
+int from_json(std::string json, int64_t* p_objects_count,
+              int64_t* p_bytes_count) {
+  Json::Value newroot;
+  Json::Reader reader;
+  bool parsingSuccessful = reader.parse(json.c_str(), newroot);
+  if (!parsingSuccessful) {
+    return -1;
+  }
+
+  if (!newroot.isMember(JSON_OBJECTS_COUNT) ||
+      !newroot.isMember(JSON_BYTES_COUNT)) {
+    return -1;
+  }
+
+  *p_objects_count = newroot[JSON_OBJECTS_COUNT].asInt64();
+  *p_bytes_count = newroot[JSON_BYTES_COUNT].asInt64();
+  return 0;
+}
+
+void S3DataUsageAction::get_next_keyval_success() {
+  s3_log(S3_LOG_DEBUG, stripped_request_id, "%s Entry\n", __func__);
+  auto& kvps = motr_kvs_reader->get_key_values();
+  size_t length = kvps.size();
+  for (auto& kv : kvps) {
+    std::string key = kv.first;
+    std::string json = kv.second.second;
+    s3_log(S3_LOG_DEBUG, request_id, "Read key = %s\n", key.c_str());
+    s3_log(S3_LOG_DEBUG, request_id, "Read Value = %s\n", json.c_str());
+    std::string account_id = extract_account_id_from_motr_key(key);
+    if (account_id.empty()) {
+      s3_log(
+          S3_LOG_ERROR, stripped_request_id,
+          "Failed to extract the account ID from key %s. Skipping the record",
+          key.c_str());
+      continue;
+    }
+    int64_t objects_counter;
+    int64_t bytes_counter;
+    if (from_json(json, &objects_counter, &bytes_counter) != 0) {
+      s3_log(S3_LOG_ERROR, stripped_request_id,
+             "Failed to extract the counters from json %s. Skipping the record",
+             json.c_str());
+      continue;
+    }
+
+    if (counters.find(account_id) != counters.end()) {
+      counters[account_id] = bytes_counter;
+    } else {
+      counters[account_id] += bytes_counter;
+    }
+  }
+
+  if (length < max_records_per_request) {
+    // Read all, move forward.
+    next();
+  } else {
+    // Read the next chunk of counter records.
+    last_key = kvps.rbegin()->first;
+    motr_kvs_reader->next_keyval(
+        data_usage_accounts_index_layout, last_key, max_records_per_request,
+        std::bind(&S3DataUsageAction::get_next_keyval_success, this),
+        std::bind(&S3DataUsageAction::get_next_keyval_failure, this));
+  }
+  s3_log(S3_LOG_DEBUG, stripped_request_id, "%s Exit\n", __func__);
+}
+
+void S3DataUsageAction::get_next_keyval_failure() {
+  s3_log(S3_LOG_DEBUG, stripped_request_id, "%s Entry\n", __func__);
+  auto reader_state = motr_kvs_reader->get_state();
+  if (reader_state == S3MotrKVSReaderOpState::missing) {
+    s3_log(S3_LOG_DEBUG, request_id, "No(more) records in data usage index");
+    next();
+    return;
+  } else if (reader_state == S3MotrKVSReaderOpState::failed_to_launch) {
+    s3_log(S3_LOG_ERROR, request_id,
+           "Failed to launch data usage index listing");
+    set_s3_error("ServiceUnavailable");
+  } else {
+    s3_log(S3_LOG_DEBUG, request_id,
+           "Internal error during data usage index listing");
+    set_s3_error("InternalError");
+  }
+  send_response_to_s3_client();
+  s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }
 
 void S3DataUsageAction::setup_steps() {
-  prepare_the_response();
-  send_response_to_s3_client();
+  s3_log(S3_LOG_DEBUG, request_id, "Setting up the Data Usage action");
+  ACTION_TASK_ADD(S3DataUsageAction::get_data_usage_counters, this);
+  ACTION_TASK_ADD(S3DataUsageAction::send_response_to_s3_client, this);
 }
 
 void S3DataUsageAction::send_response_to_s3_client() {
   s3_log(S3_LOG_DEBUG, "", "%s Entry \n", __func__);
-  request->send_response(S3HttpSuccess200, json_response);
+  Json::Value root(Json::arrayValue);
+  for (auto& cnt : counters) {
+    Json::Value account;
+    Json::Value counters;
+    counters[JSON_BYTES_COUNT] = Json::Value((Json::Value::Int64)(cnt.second));
+    account[cnt.first] = counters;
+    root.append(account);
+  }
+
+  Json::FastWriter fastWriter;
+  std::string json = fastWriter.write(root);
+  request->send_response(S3HttpSuccess200, json);
+  s3_log(S3_LOG_DEBUG, "", "%s Exit \n", __func__);
 }

--- a/server/s3_data_usage_action.cc
+++ b/server/s3_data_usage_action.cc
@@ -169,8 +169,8 @@ void S3DataUsageAction::setup_steps() {
   s3_log(S3_LOG_DEBUG, stripped_request_id, "%s Exit", __func__);
 }
 
-void S3DataUsageAction::send_response_to_s3_client() {
-  s3_log(S3_LOG_DEBUG, stripped_request_id, "%s Entry\n", __func__),;
+std::string S3DataUsageAction::create_json_response() {
+  s3_log(S3_LOG_DEBUG, stripped_request_id, "%s Entry\n", __func__);
   // Create response in the following format:
   // ["account_id": {"bytes_count": <number>}, ...]
   Json::Value root(Json::arrayValue);
@@ -181,9 +181,15 @@ void S3DataUsageAction::send_response_to_s3_client() {
     account[cnt.first] = counters;
     root.append(account);
   }
-
   Json::FastWriter fastWriter;
   std::string json = fastWriter.write(root);
+  s3_log(S3_LOG_DEBUG, "", "%s Exit with ret %s\n", __func__, json.c_str());
+  return json;
+}
+
+void S3DataUsageAction::send_response_to_s3_client() {
+  s3_log(S3_LOG_DEBUG, stripped_request_id, "%s Entry\n", __func__);
+  std::string json = create_json_response();
   request->send_response(S3HttpSuccess200, json);
   s3_log(S3_LOG_DEBUG, "", "%s Exit\n", __func__);
 }

--- a/server/s3_data_usage_action.h
+++ b/server/s3_data_usage_action.h
@@ -50,4 +50,10 @@ class S3DataUsageAction : public S3Action {
   void send_response_to_s3_client();
   void setup_steps();
   std::string create_json_response();
+
+  friend class S3DataUsageActionTest;
+  FRIEND_TEST(S3DataUsageActionTest, Constructor);
+  FRIEND_TEST(S3DataUsageActionTest, GetDataUsageCountersMissing);
+  FRIEND_TEST(S3DataUsageActionTest, GetDataUsageCountersFailed);
+  FRIEND_TEST(S3DataUsageActionTest, GetDataUsageCountersSuccess);
 };

--- a/server/s3_data_usage_action.h
+++ b/server/s3_data_usage_action.h
@@ -49,4 +49,5 @@ class S3DataUsageAction : public S3Action {
   virtual ~S3DataUsageAction();
   void send_response_to_s3_client();
   void setup_steps();
+  std::string create_json_response();
 };

--- a/server/s3_data_usage_action.h
+++ b/server/s3_data_usage_action.h
@@ -18,17 +18,34 @@
  *
  */
 
+#include <map>
 #include <string>
+
 #include "s3_request_object.h"
 #include "s3_action_base.h"
-class S3DataUsageAction : public S3Action {
-  std::string json_response;
-  std::shared_ptr<S3RequestObject> request;
+#include "s3_factory.h"
+#include "s3_motr_kvs_reader.h"
+#include "s3_motr_kvs_writer.h"
 
-  void prepare_the_response();
+class S3DataUsageAction : public S3Action {
+  std::shared_ptr<S3RequestObject> request;
+  std::shared_ptr<S3MotrKVSReaderFactory> motr_kvs_reader_factory;
+  std::shared_ptr<S3MotrKVSReader> motr_kvs_reader;
+  std::shared_ptr<MotrAPI> motr_kvs_api;
+
+  std::string last_key;
+  unsigned max_records_per_request;
+  std::map<std::string, int64_t> counters;
+
+  void get_data_usage_counters();
+  void get_next_keyval_success();
+  void get_next_keyval_failure();
 
  public:
-  S3DataUsageAction(std::shared_ptr<S3RequestObject> req);
+  S3DataUsageAction(std::shared_ptr<S3RequestObject> req,
+                    std::shared_ptr<S3MotrKVSReaderFactory> kvs_reader_factory =
+                        nullptr,
+                    std::shared_ptr<MotrAPI> motr_api = nullptr);
   virtual ~S3DataUsageAction();
   void send_response_to_s3_client();
   void setup_steps();

--- a/ut/s3_data_usage_action_test.cc
+++ b/ut/s3_data_usage_action_test.cc
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include "mock_s3_motr_wrapper.h"
+#include "mock_s3_factory.h"
+#include "mock_s3_request_object.h"
+#include "s3_ut_common.h"
+#include "s3_m0_uint128_helper.h"
+
+#include "s3_data_usage_action.h"
+
+using ::testing::Eq;
+using ::testing::Ne;
+using ::testing::Invoke;
+using ::testing::StrEq;
+using ::testing::ReturnRef;
+using ::testing::Return;
+using ::testing::_;
+
+class S3DataUsageActionTest : public testing::Test {
+ protected:
+  std::shared_ptr<MockS3RequestObject> mock_request;
+  std::shared_ptr<MockS3Motr> mock_s3_motr_api;
+  std::shared_ptr<MockS3MotrKVSReaderFactory> mock_kvs_reader_factory;
+  std::shared_ptr<S3DataUsageAction> action_under_test;
+
+  std::string mock_xml;
+
+ public:
+  S3DataUsageActionTest() {
+    evhtp_request_t *req = NULL;
+    EvhtpInterface *evhtp_obj_ptr = new EvhtpWrapper();
+
+    mock_request = std::make_shared<MockS3RequestObject>(req, evhtp_obj_ptr);
+    mock_s3_motr_api = std::make_shared<MockS3Motr>();
+    EXPECT_CALL(*mock_s3_motr_api, m0_h_ufid_next(_))
+        .WillRepeatedly(Invoke(dummy_helpers_ufid_next));
+    mock_kvs_reader_factory = std::make_shared<MockS3MotrKVSReaderFactory>(
+        mock_request, mock_s3_motr_api);
+
+    std::map<std::string, std::string> input_headers;
+    EXPECT_CALL(*mock_request, get_in_headers_copy()).Times(1).WillOnce(
+        ReturnRef(input_headers));
+
+    action_under_test = std::make_shared<S3DataUsageAction>(
+        mock_request, mock_kvs_reader_factory, mock_s3_motr_api);
+  }
+};
+
+TEST_F(S3DataUsageActionTest, Constructor) {
+  EXPECT_TRUE(action_under_test->motr_kvs_reader_factory != nullptr);
+  EXPECT_TRUE(action_under_test->motr_kvs_api != nullptr);
+  EXPECT_TRUE(action_under_test->motr_kvs_reader != nullptr);
+  EXPECT_TRUE(action_under_test->last_key.empty());
+}
+
+TEST_F(S3DataUsageActionTest, GetDataUsageCountersMissing) {
+  EXPECT_CALL(*(mock_kvs_reader_factory->mock_motr_kvs_reader), get_state())
+      .Times(1)
+      .WillRepeatedly(Return(S3MotrKVSReaderOpState::missing));
+  action_under_test->get_data_usage_counters();
+  action_under_test->get_next_keyval_failure();
+  EXPECT_FALSE(action_under_test->is_error_state());
+  EXPECT_STREQ(action_under_test->create_json_response().c_str(), "[]\n");
+}
+
+TEST_F(S3DataUsageActionTest, GetDataUsageCountersFailed) {
+  EXPECT_CALL(*(mock_kvs_reader_factory->mock_motr_kvs_reader), get_state())
+      .Times(1)
+      .WillRepeatedly(Return(S3MotrKVSReaderOpState::failed_to_launch));
+
+  EXPECT_CALL(*mock_request, c_get_full_path())
+      .WillOnce(Return("/s3/data_usage"));
+  action_under_test->get_data_usage_counters();
+  action_under_test->get_next_keyval_failure();
+  EXPECT_TRUE(action_under_test->is_error_state());
+  EXPECT_STREQ("ServiceUnavailable",
+               action_under_test->get_s3_error_code().c_str());
+}
+
+TEST_F(S3DataUsageActionTest, GetDataUsageCountersSuccess) {
+  std::map<std::string, std::pair<int, std::string>> result_keys_values;
+  result_keys_values.insert(std::make_pair(
+      "acc1/1", std::make_pair(0, "{\"bytes_count\":5,\"objects_count\":2}")));
+  result_keys_values.insert(std::make_pair(
+      "acc1/2",
+      std::make_pair(0, "{\"bytes_count\":-2,\"objects_count\":-1}")));
+  result_keys_values.insert(std::make_pair(
+      "acc2/1",
+      std::make_pair(0, "{\"bytes_count\":13,\"objects_count\":13}")));
+  std::string expected_json =
+      "[{\"acc1\":{\"bytes_count\":3}},{\"acc2\":{\"bytes_count\":13}}]\n";
+
+  EXPECT_CALL(*(mock_kvs_reader_factory->mock_motr_kvs_reader),
+              get_key_values()).WillRepeatedly(ReturnRef(result_keys_values));
+
+  action_under_test->get_data_usage_counters();
+  action_under_test->get_next_keyval_success();
+  EXPECT_FALSE(action_under_test->is_error_state());
+  EXPECT_STREQ(action_under_test->create_json_response().c_str(),
+               expected_json.c_str());
+}


### PR DESCRIPTION
# Problem Statement
- [EOS-26626](https://jts.seagate.com/EOS-26626): API for CSM

# Design
- Full implementation of Accounts Data Usage API from S3 to CSM
- [Design page in Confluence](https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/782663777/Option+3+store+counters+in+dedicated+index+in+Motr+per+instance+per+account)

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
