### PR TITLE
[replication] Update CopyObject to apply destination bucket replication policy

### DIFF
--- a/server/s3_copy_object_action.cc
+++ b/server/s3_copy_object_action.cc
@@ -418,6 +418,19 @@ void S3CopyObjectAction::save_metadata() {
     new_object_metadata->add_user_defined_attribute(it.first, it.second);
   }
 
+  // If replication is enabled on the destination bucket then
+  // enable replication state in the new object's metadata
+  if ((bucket_metadata->check_bucket_replication_exists())) {
+    s3_log(S3_LOG_DEBUG, request_id,
+           "Replication policy exists for bucket :: %s.\n",
+           request->get_bucket_name().c_str());
+    std::string rep_config_json =
+        bucket_metadata->get_replication_config_as_json_string();
+
+    new_object_metadata->set_replication_status_and_dest_bucket(
+        true, additional_object_metadata->get_tags(), rep_config_json);
+  }
+
   // bypass shutdown signal check for next task
   check_shutdown_signal_for_next_task(false);
   new_object_metadata->save(


### PR DESCRIPTION
Quick update to add replication support to CopyObject. This follows essentially the same steps as the other put-related API changes, with minor adjustments for source/destination buckets in this operation. I tested in a VM, seems to work as expected.

@shraddhaghatol @mbcortx Could you review?

For EOS-26850

Signed-off-by: Tim Shaffer <tim.shaffer@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
