### PR TITLE
EOS-26897: Implement logic to copy source multipart object as part in…

### DIFF
--- a/server/s3_addb_map_auto.c
+++ b/server/s3_addb_map_auto.c
@@ -223,7 +223,7 @@ const char* g_s3_to_addb_idx_func_name_map[] = {
     "S3PutMultiObjectAction::validate_multipart_request",
     "S3PutMultipartCopyAction::check_part_details",
     "S3PutMultipartCopyAction::check_source_bucket_authorization",
-    "S3PutMultipartCopyAction::create_part_object",
+    "S3PutMultipartCopyAction::create_part",
     "S3PutMultipartCopyAction::delete_new_object",
     "S3PutMultipartCopyAction::delete_old_object",
     "S3PutMultipartCopyAction::fetch_multipart_metadata",

--- a/server/s3_object_data_copier.h
+++ b/server/s3_object_data_copier.h
@@ -54,6 +54,9 @@ class S3ObjectDataCopier {
   std::shared_ptr<S3MotrReader> motr_reader;
   bool copy_parts_fragment = 0;
   int vector_index;
+  unsigned int part_vector_index = 0;
+  bool copy_parts_fragment_in_single_source = false;
+  std::vector<struct s3_part_frag_context> part_fragment_context_list;
   S3BufferSequence data_blocks_read;  // Source's data has been read but not
                                       // taken for writing.
 
@@ -101,7 +104,15 @@ class S3ObjectDataCopier {
       std::function<void(int)> on_success_for_fragment,
       std::function<void(int)> on_failure_for_fragment);
 
-  const std::string& get_s3_error() { return s3_error; }
+  void copy_part_fragment_in_single_source(
+      std::vector<struct s3_part_frag_context> fragment_context_list,
+      std::function<bool(void)> check_shutdown_and_rollback,
+      std::function<void(void)> on_success,
+      std::function<void(void)> on_failure);
+
+  void set_next_part_context();
+
+  const std::string &get_s3_error() { return s3_error; }
   // Trims input 'buffer' to the expected size
   // Used when we need specific portion of 'buffer', discarding the remianing
   // data.

--- a/server/s3_put_multiobject_copy_action.h
+++ b/server/s3_put_multiobject_copy_action.h
@@ -127,13 +127,13 @@ class S3PutMultipartCopyAction : public S3PutObjectActionBase {
   void fetch_part_info();
   void fetch_part_info_success();
   void fetch_part_info_failed();
-  void create_part_object();
   void create_objects();
   void create_part();
   void create_part_object_successful();
   void create_part_object_failed();
   void initiate_part_copy();
   void copy_part_object();
+  void copy_multipart_source_object();
   bool copy_part_object_cb();
   void copy_part_object_success();
   void copy_part_object_failed();


### PR DESCRIPTION
# Problem Statement
- Copy multipart object in single part object for upload-par-copy API

# Design
- Use object_data_copier methods to  to read data from part objects and write to single object

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
