### PR TITLE
[versioning] EOS-26911: Implemented additional UT and ST for List Object Versions API

### DIFF
--- a/server/s3_list_object_versions_action.cc
+++ b/server/s3_list_object_versions_action.cc
@@ -778,9 +778,7 @@ std::string& S3ListObjectVersionsAction::get_response_xml() {
     } else {
       response_xml += "<DeleteMarker>";
       response_xml += S3CommonUtilities::format_xml_string(
-          "IsLatest",
-          (version->get_state() == S3ObjectMetadataState::invalid ? "true"
-                                                                  : "false"));
+          "IsLatest", (version->is_latest() ? "true" : "false"));
       response_xml += S3CommonUtilities::format_xml_string(
           "Key", get_encoded_key_value(version->get_object_name()));
       response_xml += S3CommonUtilities::format_xml_string(

--- a/server/s3_list_object_versions_action.h
+++ b/server/s3_list_object_versions_action.h
@@ -103,13 +103,17 @@ class S3ListObjectVersionsAction : public S3BucketAction {
   FRIEND_TEST(S3ListObjectVersionsTest, FetchBucketInfoFailedMissing);
   FRIEND_TEST(S3ListObjectVersionsTest, FetchBucketInfoFailedToLaunch);
   FRIEND_TEST(S3ListObjectVersionsTest, FetchBucketInfoFailedInternalError);
-  FRIEND_TEST(S3ListObjectVersionsTest, ValidateRequestInvalidArgument);
+  FRIEND_TEST(S3ListObjectVersionsTest, ValidateRequestInvalidMaxKeys);
+  FRIEND_TEST(S3ListObjectVersionsTest, ValidateRequestNegativeMaxKeys);
+  FRIEND_TEST(S3ListObjectVersionsTest, ValidateRequestInvalidEncodingType);
   FRIEND_TEST(S3ListObjectVersionsTest, GetNextVersionsZeroMaxkeys);
   FRIEND_TEST(S3ListObjectVersionsTest, GetNextVersionsZeroOid);
   FRIEND_TEST(S3ListObjectVersionsTest, GetNextVersions);
   FRIEND_TEST(S3ListObjectVersionsTest, GetNextVersionsFailed);
   FRIEND_TEST(S3ListObjectVersionsTest, GetNextVersionsSuccessful);
   FRIEND_TEST(S3ListObjectVersionsTest, GetNextVersionsSuccessfulJsonError);
+  FRIEND_TEST(S3ListObjectVersionsTest, GetNextVersionsSuccessfulPrefix);
+  FRIEND_TEST(S3ListObjectVersionsTest, GetNextVersionsSuccessfulDelimiter);
   FRIEND_TEST(S3ListObjectVersionsTest, SendResponseToClientServiceUnavailable);
   FRIEND_TEST(S3ListObjectVersionsTest, SendResponseToClientNoSuchBucket);
   FRIEND_TEST(S3ListObjectVersionsTest, SendResponseToClientSuccess);


### PR DESCRIPTION
# Problem Statement
Implement additional UT and ST for List Object Versions API

# Design
https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/766050414/ListObjectVersions+LLD

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide
