### PR TITLE
EOS-26124: Create S3Account failure fix

### DIFF
--- a/auth/server/src/main/java/com/seagates3/dao/ldap/AccountImpl.java
+++ b/auth/server/src/main/java/com/seagates3/dao/ldap/AccountImpl.java
@@ -329,7 +329,7 @@ public class AccountImpl implements AccountDAO {
         attributeSet.add(new LDAPAttribute(LDAPUtils.CANONICAL_ID,
                 account.getCanonicalId()));
 
-        LOGGER.debug("Saving account dn: " + dn);
+        LOGGER.info("Saving account dn: " + dn);
 
         try {
             LDAPUtils.add(new LDAPEntry(dn, attributeSet));
@@ -354,7 +354,7 @@ public class AccountImpl implements AccountDAO {
                 LDAPUtils.ORGANIZATIONAL_NAME, account.getName(),
                 LDAPUtils.ORGANIZATIONAL_UNIT_NAME, LDAPUtils.BASE_DN);
 
-        LOGGER.debug("Deleting account dn: " + dn);
+        LOGGER.info("Deleting account dn: " + dn);
 
         try {
             LDAPUtils.delete(dn);
@@ -378,7 +378,7 @@ public class AccountImpl implements AccountDAO {
           LDAPUtils.ORGANIZATIONAL_UNIT_NAME, LDAPUtils.ACCOUNT_OU,
           LDAPUtils.BASE_DN);
 
-        LOGGER.debug("Deleting account dn: " + dn);
+        LOGGER.info("Deleting account dn: " + dn);
 
         try {
             LDAPUtils.delete(dn);
@@ -407,7 +407,7 @@ public class AccountImpl implements AccountDAO {
         attributeSet.add(new LDAPAttribute(LDAPUtils.ORGANIZATIONAL_UNIT_NAME,
                 LDAPUtils.USER_OU));
 
-        LOGGER.debug("Creating user dn: " + dn);
+        LOGGER.info("Creating user dn: " + dn);
 
         try {
             LDAPUtils.add(new LDAPEntry(dn, attributeSet));
@@ -434,7 +434,7 @@ public class AccountImpl implements AccountDAO {
                 LDAPUtils.ORGANIZATIONAL_UNIT_CLASS));
         attributeSet.add(new LDAPAttribute("ou", "roles"));
 
-        LOGGER.debug("Creating role dn: " + dn);
+        LOGGER.info("Creating role dn: " + dn);
 
         try {
             LDAPUtils.add(new LDAPEntry(dn, attributeSet));
@@ -463,7 +463,7 @@ public class AccountImpl implements AccountDAO {
         attributeSet.add(new LDAPAttribute(LDAPUtils.ORGANIZATIONAL_UNIT_NAME,
                 LDAPUtils.POLICY_OU));
 
-        LOGGER.debug("Creating Policy dn: " + dn);
+        LOGGER.info("Creating Policy dn: " + dn);
 
         try {
             LDAPUtils.add(new LDAPEntry(dn, attributeSet));
@@ -486,7 +486,7 @@ public class AccountImpl implements AccountDAO {
           LDAPUtils.ORGANIZATIONAL_UNIT_NAME, LDAPUtils.ACCOUNT_OU,
           LDAPUtils.BASE_DN);
 
-        LOGGER.debug("Creating Groups dn: " + dn);
+        LOGGER.info("Creating Groups dn: " + dn);
 
         LDAPAttributeSet attributeSet = new LDAPAttributeSet();
         attributeSet.add(new LDAPAttribute(LDAPUtils.OBJECT_CLASS,

--- a/auth/server/src/main/java/com/seagates3/dao/ldap/AccountImpl.java
+++ b/auth/server/src/main/java/com/seagates3/dao/ldap/AccountImpl.java
@@ -378,7 +378,7 @@ public class AccountImpl implements AccountDAO {
           LDAPUtils.ORGANIZATIONAL_UNIT_NAME, LDAPUtils.ACCOUNT_OU,
           LDAPUtils.BASE_DN);
 
-        LOGGER.info("Deleting account dn: " + dn);
+      LOGGER.info("Deleting account dn: " + dn);
 
         try {
             LDAPUtils.delete(dn);
@@ -486,7 +486,7 @@ public class AccountImpl implements AccountDAO {
           LDAPUtils.ORGANIZATIONAL_UNIT_NAME, LDAPUtils.ACCOUNT_OU,
           LDAPUtils.BASE_DN);
 
-        LOGGER.info("Creating Groups dn: " + dn);
+      LOGGER.info("Creating Groups dn: " + dn);
 
         LDAPAttributeSet attributeSet = new LDAPAttributeSet();
         attributeSet.add(new LDAPAttribute(LDAPUtils.OBJECT_CLASS,

--- a/auth/server/src/main/java/com/seagates3/dao/ldap/LDAPUtils.java
+++ b/auth/server/src/main/java/com/seagates3/dao/ldap/LDAPUtils.java
@@ -20,6 +20,8 @@
 
 package com.seagates3.dao.ldap;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -198,10 +200,7 @@ class LDAPUtils {
 
                 lc.add(newEntry);
             } catch (LDAPException ldapException) {
-                LOGGER.error("Error occurred while adding new entry. Cause: "
-                        + ldapException.getCause() + ". Message: "
-                        + ldapException.getMessage());
-                LOGGER.debug("Stacktrace: " + ldapException);
+                logErrorStackTrace("adding", newEntry.getDN(), ldapException);
                 IEMUtil.log(
                     IEMUtil.Level.ERROR, IEMUtil.LDAP_EX,
                     "An error occurred while establishing ldap " +
@@ -241,10 +240,7 @@ class LDAPUtils {
 
                 lc.delete(dn);
             } catch (LDAPException ldapException) {
-                LOGGER.error("Error occurred while deleting entry. Cause: "
-                        + ldapException.getCause() + ". Message: "
-                        + ldapException.getMessage());
-                LOGGER.debug("Stacktrace: " + ldapException);
+            	logErrorStackTrace("deleting", dn, ldapException);
                 IEMUtil.log(
                     IEMUtil.Level.ERROR, IEMUtil.LDAP_EX,
                     "An error occurred while establishing ldap " +
@@ -398,5 +394,13 @@ class LDAPUtils {
         finally { lc.disconnect(); }
       }
     }
+   
+   private static void logErrorStackTrace(String operation, String dn, LDAPException ex) {
+       LOGGER.error(String.format("Error occurred while %s entry with dn %s. Cause: %s. Message: %s.", operation, dn, ex.getCause(), ex.getMessage()));
+       StringWriter sw = new StringWriter();
+       PrintWriter pw = new PrintWriter(sw);
+       ex.printStackTrace(pw);
+       LOGGER.error(sw.toString());
+   }
 }
 

--- a/auth/server/src/main/java/com/seagates3/dao/ldap/LDAPUtils.java
+++ b/auth/server/src/main/java/com/seagates3/dao/ldap/LDAPUtils.java
@@ -200,7 +200,7 @@ class LDAPUtils {
 
                 lc.add(newEntry);
             } catch (LDAPException ldapException) {
-                logErrorStackTrace("adding", newEntry.getDN(), ldapException);
+              logErrorStackTrace("adding", newEntry.getDN(), ldapException);
                 IEMUtil.log(
                     IEMUtil.Level.ERROR, IEMUtil.LDAP_EX,
                     "An error occurred while establishing ldap " +
@@ -240,7 +240,7 @@ class LDAPUtils {
 
                 lc.delete(dn);
             } catch (LDAPException ldapException) {
-            	logErrorStackTrace("deleting", dn, ldapException);
+              logErrorStackTrace("deleting", dn, ldapException);
                 IEMUtil.log(
                     IEMUtil.Level.ERROR, IEMUtil.LDAP_EX,
                     "An error occurred while establishing ldap " +
@@ -394,13 +394,17 @@ class LDAPUtils {
         finally { lc.disconnect(); }
       }
     }
-   
-   private static void logErrorStackTrace(String operation, String dn, LDAPException ex) {
-       LOGGER.error(String.format("Error occurred while %s entry with dn %s. Cause: %s. Message: %s.", operation, dn, ex.getCause(), ex.getMessage()));
-       StringWriter sw = new StringWriter();
-       PrintWriter pw = new PrintWriter(sw);
-       ex.printStackTrace(pw);
-       LOGGER.error(sw.toString());
-   }
+
+   private
+    static void logErrorStackTrace(String operation, String dn,
+                                   LDAPException ex) {
+      LOGGER.error(String.format(
+          "Error occurred while %s entry with dn %s. Cause: %s. Message: %s.",
+          operation, dn, ex.getCause(), ex.getMessage()));
+      StringWriter sw = new StringWriter();
+      PrintWriter pw = new PrintWriter(sw);
+      ex.printStackTrace(pw);
+      LOGGER.error(sw.toString());
+    }
 }
 


### PR DESCRIPTION
# Problem Statement
- CSM REST: Create S3 account failed with 500 ('InternalFailure' is not a valid IamErrors)

# Design
- Actual fix is done in CSM. Added a wait of 3 seconds between create account and create login profile to let openldap replicate the data. Added logs in s3 to trace the issue.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide

[Pre-Merge Test](http://eos-jenkins.colo.seagate.com/job/S3server/job/S3Server-PreMerge-Test/894/)

Signed-off-by: Shri Metta shri.metta@seagate.com