### PR TITLE
[EOS-26912] Remove refs to get_unread_count

### DIFF
--- a/s3backgrounddelete/s3backgrounddelete/object_recovery_msgbus.py
+++ b/s3backgrounddelete/s3backgrounddelete/object_recovery_msgbus.py
@@ -240,23 +240,23 @@ class ObjectRecoveryMsgbus(object):
             self.__isproducersetupcomplete = False
             return False
             
-    def get_count(self):
-        """Get count of unread messages."""
-        self._logger.debug("In get_count")
-        
-        try:
-            consumer_group = self._config.get_msgbus_consumer_group()
-            if not self.__isproducersetupcomplete:
-                self.__setup_producer()
-                if not self.__isproducersetupcomplete:
-                    self._logger.debug("get_count producer connection issues")
-                    return 0
-            
-            unread_count = self.__msgbuslib.count(consumer_group)
-            if unread_count is None:
-                return 0
-            else:
-                return unread_count
-        except Exception as exception:
-            self._logger.error("Exception:{}".format(exception))
-            return 0
+#    def get_count(self):
+#        """Get count of unread messages."""
+#        self._logger.debug("In get_count")
+#        
+#        try:
+#            consumer_group = self._config.get_msgbus_consumer_group()
+#            if not self.__isproducersetupcomplete:
+#                self.__setup_producer()
+#                if not self.__isproducersetupcomplete:
+#                    self._logger.debug("get_count producer connection issues")
+#                    return 0
+#            
+#            unread_count = self.__msgbuslib.count(consumer_group)
+#            if unread_count is None:
+#                return 0
+#            else:
+#                return unread_count
+#        except Exception as exception:
+#            self._logger.error("Exception:{}".format(exception))
+#            return 0

--- a/s3backgrounddelete/s3backgrounddelete/object_recovery_scheduler.py
+++ b/s3backgrounddelete/s3backgrounddelete/object_recovery_scheduler.py
@@ -78,25 +78,25 @@ class ObjectRecoveryScheduler(object):
                 self.producer = ObjectRecoveryMsgbus(
                     self.config,
                     self.logger)
-            threshold = self.config.get_threshold()
-            self.logger.debug("Threshold is : " + str(threshold))
+#            threshold = self.config.get_threshold()
+#            self.logger.debug("Threshold is : " + str(threshold))
             if self.term_signal.shutdown_signal == True:
                 self.logger.info("Shutting down s3backgroundproducer service.")
                 sys.exit(0)
-            count = self.producer.get_count()
-            self.logger.debug("Count of unread msgs is : " + str(count))
+#            count = self.producer.get_count()
+#            self.logger.debug("Count of unread msgs is : " + str(count))
 
-            if ((int(count) < threshold) or (threshold == 0)):
-                self.logger.debug("Count of unread messages is less than threshold value.Hence continuing...")
-            else:
+#            if ((int(count) < threshold) or (threshold == 0)):
+#                self.logger.debug("Count of unread messages is less than threshold value.Hence continuing...")
+#            else:
                 #do nothing
-                self.logger.info("Queue has more messages than threshold value. Hence skipping addition of further entries.")
-                return
+#                self.logger.info("Queue has more messages than threshold value. Hence skipping addition of further entries.")
+#                return
             # Cleanup all entries and enqueue only 1000 entries
             #PurgeAPI Here
-            if self.term_signal.shutdown_signal == True:
-                self.logger.info("Shutting down s3backgroundproducer service.")
-                sys.exit(0)
+#            if self.term_signal.shutdown_signal == True:
+#                self.logger.info("Shutting down s3backgroundproducer service.")
+#                sys.exit(0)
             self.producer.purge()
             result, index_response = CORTXS3IndexApi(
                 self.config, connectionType=CONNECTION_TYPE_PRODUCER, logger=self.logger).list(

--- a/s3cortxutils/s3msgbus/s3msgbus/cortx_s3_msgbus.py
+++ b/s3cortxutils/s3msgbus/s3msgbus/cortx_s3_msgbus.py
@@ -95,14 +95,14 @@ class S3CortxMsgBus:
             return False, msg
         return True, None
 
-    def count(self, consumer_group):
-        """Get the count of unread messages."""
-        unread_count = 0
-        try:
-            unread_count = self._producer.get_unread_count(consumer_group)
-        except:
-            return 0
-        return unread_count
+#    def count(self, consumer_group):
+#        """Get the count of unread messages."""
+#        unread_count = 0
+#        try:
+#            unread_count = self._producer.get_unread_count(consumer_group)
+#        except:
+#            return 0
+#        return unread_count
 
     @staticmethod
     def create_topic(admin_id: str, message_types: list, partitions: int):


### PR DESCRIPTION
# Problem Statement
MessageBus library is removing API get_unread_count. Remove all references to this API from S3 code

# Design
Update S3 background delete code, so that it do not make use of get_unread_count method provided by MessageBus Library.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
