### PR TITLE
EOS-25051: Removed the retry loop from s3_start init script.

### DIFF
--- a/scripts/provisioning/s3_start
+++ b/scripts/provisioning/s3_start
@@ -143,12 +143,8 @@ def main():
 
       Log.info(f"sh /opt/seagate/cortx/s3/s3startsystem.sh -F {Fid} -P {fid_path} -C {s3configfile} -d")
       Log.info(f"Starting S3 Server with FID {Fid}...")
-      i = 0
-      while i < 10:
-        # Start S3 Server
-        os.system(f"sh /opt/seagate/cortx/s3/s3startsystem.sh -F {Fid} -P {fid_path} -C {s3configfile} -d")
-        i += 1
-        time.sleep(60)
+      # Start S3 Server
+      os.system(f"sh /opt/seagate/cortx/s3/s3startsystem.sh -F {Fid} -P {fid_path} -C {s3configfile} -d")
 
       # Read the log directory path from s3config file
       s3_log_dir = read_config_value("S3_CONFIG_FILE", "yaml", "S3_SERVER_CONFIG>S3_LOG_DIR")


### PR DESCRIPTION
Signed-off-by: Swapnil Chaudhary <swapnil.chaudhary@seagate.com>

# Problem Statement
- We have increased the timeout for start up script, hence there was no need of the retry mechanism. 
# Design
-  Remove the retry mechanism for s3_start script, before starting the service.

# Coding
   Checklist for Author
-  [ Y] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
Performed Test on 3N and 15N set-up. The results are uploaded on JIRA ticket.

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [Y ] JIRA number/GitHub Issue added to PR
- [ Y] PR is self reviewed
- [ Y] Jira and state/status is updated and JIRA is updated with PR link
- [ Y] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
