### PR TITLE
EOS-26124: Added delays in between ldap operations while create and delete S3 accounts

### DIFF
--- a/auth/server/src/main/java/com/seagates3/controller/AccountController.java
+++ b/auth/server/src/main/java/com/seagates3/controller/AccountController.java
@@ -450,10 +450,11 @@ public class AccountController extends AbstractController {
             accountDao.deleteOu(account, LDAPUtils.GROUP_OU);
             accountDao.deleteOu(account, LDAPUtils.POLICY_OU);
             try {
-				Thread.sleep(2000);
-			} catch (InterruptedException e) {
-				LOGGER.error("Error waiting.");
-			}
+              Thread.sleep(2000);
+            }
+            catch (InterruptedException e) {
+              LOGGER.error("Error waiting.");
+            }
             accountDao.delete(account);
         } catch (DataAccessException e) {
             if (e.getLocalizedMessage().contains("subordinate objects must be deleted first")) {

--- a/auth/server/src/main/java/com/seagates3/controller/AccountController.java
+++ b/auth/server/src/main/java/com/seagates3/controller/AccountController.java
@@ -449,6 +449,11 @@ public class AccountController extends AbstractController {
             accountDao.deleteOu(account, LDAPUtils.ROLE_OU);
             accountDao.deleteOu(account, LDAPUtils.GROUP_OU);
             accountDao.deleteOu(account, LDAPUtils.POLICY_OU);
+            try {
+				Thread.sleep(2000);
+			} catch (InterruptedException e) {
+				LOGGER.error("Error waiting.");
+			}
             accountDao.delete(account);
         } catch (DataAccessException e) {
             if (e.getLocalizedMessage().contains("subordinate objects must be deleted first")) {

--- a/auth/server/src/main/java/com/seagates3/dao/ldap/AccountImpl.java
+++ b/auth/server/src/main/java/com/seagates3/dao/ldap/AccountImpl.java
@@ -340,54 +340,10 @@ public class AccountImpl implements AccountDAO {
 
         sleep();
 
-        int count = 0;
-        int maxTries = 2;
-        while (true) {
-          try {
-            createUserOU(account.getName());
-            break;
-          }
-          catch (Exception e) {
-            sleep();
-            if (++count == maxTries) throw e;
-          }
-        }
-
-        count = 0;
-        while (true) {
-          try {
-            createRoleOU(account.getName());
-            break;
-          }
-          catch (Exception e) {
-            sleep();
-            if (++count == maxTries) throw e;
-          }
-        }
-
-        count = 0;
-        while (true) {
-          try {
-            createGroupsOU(account.getName());
-            break;
-          }
-          catch (Exception e) {
-            sleep();
-            if (++count == maxTries) throw e;
-          }
-        }
-
-        count = 0;
-        while (true) {
-          try {
-            createPolicyOU(account.getName());
-            break;
-          }
-          catch (Exception e) {
-            sleep();
-            if (++count == maxTries) throw e;
-          }
-        }
+        createUserOU(account.getName());
+        createRoleOU(account.getName());
+        createGroupsOU(account.getName());
+        createPolicyOU(account.getName());
     }
 
    private
@@ -474,11 +430,20 @@ public class AccountImpl implements AccountDAO {
 
         LOGGER.debug("Creating user dn: " + dn);
 
-        try {
-            LDAPUtils.add(new LDAPEntry(dn, attributeSet));
-        } catch (LDAPException ex) {
-          LOGGER.error("Failed to create dn: " + dn);
-            throw new DataAccessException("failed to create user ou.\n" + ex);
+        int count = 0;
+        int maxTries = 2;
+        while (true) {
+          try {
+        	LDAPUtils.add(new LDAPEntry(dn, attributeSet));
+            break;
+          }
+          catch (LDAPException ex) {
+            sleep();
+            if (++count >= maxTries) {
+            	LOGGER.error("Failed to create dn: " + dn);
+                throw new DataAccessException("failed to create user ou.\n" + ex);
+            }
+          }
         }
     }
 
@@ -501,11 +466,20 @@ public class AccountImpl implements AccountDAO {
 
         LOGGER.debug("Creating role dn: " + dn);
 
-        try {
-            LDAPUtils.add(new LDAPEntry(dn, attributeSet));
-        } catch (LDAPException ex) {
-            LOGGER.error("Failed to create role dn: " + dn);
-            throw new DataAccessException("failed to create role ou.\n" + ex);
+        int count = 0;
+        int maxTries = 2;
+        while (true) {
+          try {
+        	LDAPUtils.add(new LDAPEntry(dn, attributeSet));
+            break;
+          }
+          catch (LDAPException ex) {
+            sleep();
+            if (++count >= maxTries) {
+            	LOGGER.error("Failed to create role dn: " + dn);
+            	throw new DataAccessException("failed to create role ou.\n" + ex);
+            }
+          }
         }
     }
 
@@ -530,11 +504,20 @@ public class AccountImpl implements AccountDAO {
 
         LOGGER.debug("Creating Policy dn: " + dn);
 
-        try {
-            LDAPUtils.add(new LDAPEntry(dn, attributeSet));
-        } catch (LDAPException ex) {
-            LOGGER.error("Failed to create policy dn: " + dn);
-            throw new DataAccessException("failed to create policy ou.\n" + ex);
+        int count = 0;
+        int maxTries = 2;
+        while (true) {
+          try {
+        	LDAPUtils.add(new LDAPEntry(dn, attributeSet));
+            break;
+          }
+          catch (LDAPException ex) {
+            sleep();
+            if (++count >= maxTries) {
+            	LOGGER.error("Failed to create policy dn: " + dn);
+            	throw new DataAccessException("failed to create policy ou.\n" + ex);
+            }
+          }
         }
     }
 
@@ -559,11 +542,20 @@ public class AccountImpl implements AccountDAO {
         attributeSet.add(new LDAPAttribute(LDAPUtils.ORGANIZATIONAL_UNIT_NAME,
                 LDAPUtils.GROUP_OU));
 
-        try {
-            LDAPUtils.add(new LDAPEntry(dn, attributeSet));
-        } catch (LDAPException ex) {
-            LOGGER.error("Failed to create groups dn: " + dn);
-            throw new DataAccessException("failed to create groups ou.\n" + ex);
+        int count = 0;
+        int maxTries = 2;
+        while (true) {
+          try {
+        	LDAPUtils.add(new LDAPEntry(dn, attributeSet));
+            break;
+          }
+          catch (LDAPException ex) {
+            sleep();
+            if (++count >= maxTries) {
+            	LOGGER.error("Failed to create groups dn: " + dn);
+            	throw new DataAccessException("failed to create groups ou.\n" + ex);
+            }
+          }
         }
     }
 

--- a/auth/server/src/main/java/com/seagates3/dao/ldap/AccountImpl.java
+++ b/auth/server/src/main/java/com/seagates3/dao/ldap/AccountImpl.java
@@ -338,10 +338,60 @@ public class AccountImpl implements AccountDAO {
             throw new DataAccessException("failed to add new account.\n" + ex);
         }
 
-        createUserOU(account.getName());
-        createRoleOU(account.getName());
-        createGroupsOU(account.getName());
-        createPolicyOU(account.getName());
+        sleep();
+        
+        int count = 0;
+        int maxTries = 2;
+        while(true) {
+            try {
+            	createUserOU(account.getName());
+            	break;
+            } catch (Exception e) {
+            	sleep();
+                if (++count == maxTries) throw e;
+            }
+        }
+        
+        count = 0;
+        while(true) {
+            try {
+            	createRoleOU(account.getName());
+            	break;
+            } catch (Exception e) {
+            	sleep();
+                if (++count == maxTries) throw e;
+            }
+        }
+  
+        count = 0;
+        while(true) {
+            try {
+            	createGroupsOU(account.getName());
+            	break;
+            } catch (Exception e) {
+            	sleep();
+                if (++count == maxTries) throw e;
+            }
+        }
+  
+        count = 0;
+        while(true) {
+            try {
+            	createPolicyOU(account.getName());
+            	break;
+            } catch (Exception e) {
+            	sleep();
+                if (++count == maxTries) throw e;
+            }
+        }
+    }
+    
+    private void sleep() {
+    	try {
+			Thread.sleep(2000);
+		} catch (InterruptedException e) {
+			LOGGER.error("Error waiting.");
+		}
     }
 
     /**
@@ -380,12 +430,19 @@ public class AccountImpl implements AccountDAO {
 
         LOGGER.debug("Deleting account dn: " + dn);
 
-        try {
-            LDAPUtils.delete(dn);
-        } catch (LDAPException ex) {
-            LOGGER.error("Failed to delete dn: " + dn);
-            throw new DataAccessException("Failed to delete " + ou + " ou.\n" +
-                                          ex);
+        int count = 0;
+        int maxTries = 2;
+        while(true) {
+            try {
+            	LDAPUtils.delete(dn);
+            	break;
+            } catch (LDAPException e) {
+            	sleep();
+                if (++count == maxTries) {
+                	LOGGER.error("Failed to delete dn: " + dn);
+                    throw new DataAccessException("Failed to delete " + ou + " ou.\n" + e);
+                }
+            }
         }
     }
 

--- a/auth/server/src/main/java/com/seagates3/dao/ldap/AccountImpl.java
+++ b/auth/server/src/main/java/com/seagates3/dao/ldap/AccountImpl.java
@@ -434,14 +434,14 @@ public class AccountImpl implements AccountDAO {
         int maxTries = 2;
         while (true) {
           try {
-        	LDAPUtils.add(new LDAPEntry(dn, attributeSet));
+            LDAPUtils.add(new LDAPEntry(dn, attributeSet));
             break;
           }
           catch (LDAPException ex) {
             sleep();
             if (++count >= maxTries) {
-            	LOGGER.error("Failed to create dn: " + dn);
-                throw new DataAccessException("failed to create user ou.\n" + ex);
+              LOGGER.error("Failed to create dn: " + dn);
+              throw new DataAccessException("failed to create user ou.\n" + ex);
             }
           }
         }
@@ -470,14 +470,14 @@ public class AccountImpl implements AccountDAO {
         int maxTries = 2;
         while (true) {
           try {
-        	LDAPUtils.add(new LDAPEntry(dn, attributeSet));
+            LDAPUtils.add(new LDAPEntry(dn, attributeSet));
             break;
           }
           catch (LDAPException ex) {
             sleep();
             if (++count >= maxTries) {
-            	LOGGER.error("Failed to create role dn: " + dn);
-            	throw new DataAccessException("failed to create role ou.\n" + ex);
+              LOGGER.error("Failed to create role dn: " + dn);
+              throw new DataAccessException("failed to create role ou.\n" + ex);
             }
           }
         }
@@ -508,14 +508,15 @@ public class AccountImpl implements AccountDAO {
         int maxTries = 2;
         while (true) {
           try {
-        	LDAPUtils.add(new LDAPEntry(dn, attributeSet));
+            LDAPUtils.add(new LDAPEntry(dn, attributeSet));
             break;
           }
           catch (LDAPException ex) {
             sleep();
             if (++count >= maxTries) {
-            	LOGGER.error("Failed to create policy dn: " + dn);
-            	throw new DataAccessException("failed to create policy ou.\n" + ex);
+              LOGGER.error("Failed to create policy dn: " + dn);
+              throw new DataAccessException("failed to create policy ou.\n" +
+                                            ex);
             }
           }
         }
@@ -546,14 +547,15 @@ public class AccountImpl implements AccountDAO {
         int maxTries = 2;
         while (true) {
           try {
-        	LDAPUtils.add(new LDAPEntry(dn, attributeSet));
+            LDAPUtils.add(new LDAPEntry(dn, attributeSet));
             break;
           }
           catch (LDAPException ex) {
             sleep();
             if (++count >= maxTries) {
-            	LOGGER.error("Failed to create groups dn: " + dn);
-            	throw new DataAccessException("failed to create groups ou.\n" + ex);
+              LOGGER.error("Failed to create groups dn: " + dn);
+              throw new DataAccessException("failed to create groups ou.\n" +
+                                            ex);
             }
           }
         }

--- a/auth/server/src/main/java/com/seagates3/dao/ldap/AccountImpl.java
+++ b/auth/server/src/main/java/com/seagates3/dao/ldap/AccountImpl.java
@@ -339,59 +339,65 @@ public class AccountImpl implements AccountDAO {
         }
 
         sleep();
-        
+
         int count = 0;
         int maxTries = 2;
-        while(true) {
-            try {
-            	createUserOU(account.getName());
-            	break;
-            } catch (Exception e) {
-            	sleep();
-                if (++count == maxTries) throw e;
-            }
+        while (true) {
+          try {
+            createUserOU(account.getName());
+            break;
+          }
+          catch (Exception e) {
+            sleep();
+            if (++count == maxTries) throw e;
+          }
         }
-        
+
         count = 0;
-        while(true) {
-            try {
-            	createRoleOU(account.getName());
-            	break;
-            } catch (Exception e) {
-            	sleep();
-                if (++count == maxTries) throw e;
-            }
+        while (true) {
+          try {
+            createRoleOU(account.getName());
+            break;
+          }
+          catch (Exception e) {
+            sleep();
+            if (++count == maxTries) throw e;
+          }
         }
-  
+
         count = 0;
-        while(true) {
-            try {
-            	createGroupsOU(account.getName());
-            	break;
-            } catch (Exception e) {
-            	sleep();
-                if (++count == maxTries) throw e;
-            }
+        while (true) {
+          try {
+            createGroupsOU(account.getName());
+            break;
+          }
+          catch (Exception e) {
+            sleep();
+            if (++count == maxTries) throw e;
+          }
         }
-  
+
         count = 0;
-        while(true) {
-            try {
-            	createPolicyOU(account.getName());
-            	break;
-            } catch (Exception e) {
-            	sleep();
-                if (++count == maxTries) throw e;
-            }
+        while (true) {
+          try {
+            createPolicyOU(account.getName());
+            break;
+          }
+          catch (Exception e) {
+            sleep();
+            if (++count == maxTries) throw e;
+          }
         }
     }
-    
-    private void sleep() {
-    	try {
-			Thread.sleep(2000);
-		} catch (InterruptedException e) {
-			LOGGER.error("Error waiting.");
-		}
+
+   private
+    void sleep() {
+      try {
+        Thread.sleep(2000);
+      }
+      catch (InterruptedException e) {
+        LOGGER.error("Error waiting.");
+      }
     }
 
     /**
@@ -432,17 +438,19 @@ public class AccountImpl implements AccountDAO {
 
         int count = 0;
         int maxTries = 2;
-        while(true) {
-            try {
-            	LDAPUtils.delete(dn);
-            	break;
-            } catch (LDAPException e) {
-            	sleep();
-                if (++count == maxTries) {
-                	LOGGER.error("Failed to delete dn: " + dn);
-                    throw new DataAccessException("Failed to delete " + ou + " ou.\n" + e);
-                }
+        while (true) {
+          try {
+            LDAPUtils.delete (dn);
+            break;
+          }
+          catch (LDAPException e) {
+            sleep();
+            if (++count == maxTries) {
+              LOGGER.error("Failed to delete dn: " + dn);
+              throw new DataAccessException("Failed to delete " + ou +
+                                            " ou.\n" + e);
             }
+          }
         }
     }
 


### PR DESCRIPTION
# Problem Statement
- CSM REST: Create S3 account failed with 500 ('InternalFailure' is not a valid IamErrors)

# Design
-  This error is occurring due to data inconsistency between the nodes as replication operation is not happening properly. Hence added delays in between ldap operations to give time to OpenLDAP to replicate the data in other nodes.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide
