### PR TITLE
EOS-27323: Fix for range read of object.

### DIFF
--- a/server/s3_get_object_action.cc
+++ b/server/s3_get_object_action.cc
@@ -777,11 +777,13 @@ void S3GetObjectAction::read_object_data() {
     } else {
       blocks_to_read = total_blocks_to_read - blocks_already_read;
     }
-    // Below is only for first block read op and non-zero block start offset.
+    // Below is for only extended(multipart uploaded) object during
+    // first block read op and non-zero block start offset.
     // For the first block read op, if reading starts from non-zero offset
     // adjust number of 'blocks_to_read', so that the read does not go
     // beyond the object size.
-    if (blocks_already_read == 0 && (motr_reader->get_last_index() != 0)) {
+    if (blocks_already_read == 0 && (motr_reader->get_last_index() != 0) &&
+        object_metadata->is_object_extended()) {
       /*
         size_t unit_size_of_object_with_first_byte =
           S3MotrLayoutMap::get_instance()->get_unit_size_for_layout(


### PR DESCRIPTION
The issue is previous code changes for multipart object were executed
 for simple object. Fixed this by making code changes exclusively for multipart object.

Signed-off-by: Dattaprasad Govekar <dattaprasad.govekar@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
