### PR TITLE
CORTX-34480: Fix to GitHub secrets reported during repo scan

### DIFF
--- a/auth/server/src/main/java/com/seagates3/authentication/AWSRequestParserV4.java
+++ b/auth/server/src/main/java/com/seagates3/authentication/AWSRequestParserV4.java
@@ -78,7 +78,7 @@ public class AWSRequestParserV4 extends AWSRequestParser {
      * Sample Authorization Header
      *
      * Authorization: AWS4-HMAC-SHA256
-     * Credential=AKIAJTYX36YCKQSAJT7Q/20150810/us-east-1/iam/aws4_request,
+     * Credential=v_accessKeyId/20150810/us-east-1/iam/aws4_request,
      * SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
      * Signature=b751427a69f5bb76fb171fec45bdb1e8f664fac7f7c23c983f9c7361bb382d76
      *

--- a/auth/server/src/main/java/com/seagates3/authentication/ClientRequestParser.java
+++ b/auth/server/src/main/java/com/seagates3/authentication/ClientRequestParser.java
@@ -178,7 +178,7 @@ public class ClientRequestParser {
         String access_key="";
         String[] tokens, subTokens;
 
-        //AuthorizationHeader of v2 is of type AWS AKIAJTYX36YCKQSAJT7Q:6IaKnMXRsQcsblXItQnSNB3EJEo=
+        //AuthorizationHeader of v2 is of type AWS v_accessKeyId:6IaKnMXRsQcsblXItQnSNB3EJEo=
         //V2 Pattern to match "AWS "
         //AuthorizationHeader of v4 is of type AWS4-HMAC-SHA256 Credential=AK IAJTYX36YCKQSAJT7Q/20190314/US/s3/          aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=310b0122f12459dfea171cac82bd          4930626d5a8db695fef6bc7bfd2a30a39ea3
 

--- a/auth/server/src/test/java/com/seagates3/authentication/AWSRequestParserV2Test.java
+++ b/auth/server/src/test/java/com/seagates3/authentication/AWSRequestParserV2Test.java
@@ -74,7 +74,7 @@ public class AWSRequestParserV2Test {
         FullHttpRequest fullHttpRequest = mock(FullHttpRequest.class);
         HttpHeaders httpHeaders = new DefaultHttpHeaders();
         httpHeaders.add("host", "s3.seagate.com");
-        httpHeaders.add("authorization", "AWS AKIAJTYX36YCKQSAJT7Q:uDWiVvxwCUR9YJ8EGJgbtW9tjFM=");
+        httpHeaders.add("authorization", "AWS v_accessKeyId:uDWiVvxwCUR9YJ8EGJgbtW9tjFM=");
 
         when(fullHttpRequest.headers()).thenReturn(httpHeaders);
         when(fullHttpRequest.method()).thenReturn(HttpMethod.GET);
@@ -109,14 +109,14 @@ public class AWSRequestParserV2Test {
     @Test
     public void authHeaderParserTest() throws InvalidTokenException {
         // Arrange
-        String authorizationHeaderValue = "AWS AKIAJTYX36YCKQSAJT7Q:uDWiVvxwCUR9YJ8EGJgbtW9tjFM=";
+        String authorizationHeaderValue = "AWS v_accessKeyId:uDWiVvxwCUR9YJ8EGJgbtW9tjFM=";
         ClientRequestToken clientRequestToken = new ClientRequestToken();
 
         // Act
         awsRequestParserV2.authHeaderParser(authorizationHeaderValue, clientRequestToken);
 
         // Verify
-        assertEquals("AKIAJTYX36YCKQSAJT7Q", clientRequestToken.accessKeyId);
+        assertEquals("v_accessKeyId", clientRequestToken.accessKeyId);
         assertEquals("uDWiVvxwCUR9YJ8EGJgbtW9tjFM=", clientRequestToken.getSignature());
     }
 

--- a/auth/server/src/test/java/com/seagates3/authentication/AWSRequestParserV4Test.java
+++ b/auth/server/src/test/java/com/seagates3/authentication/AWSRequestParserV4Test.java
@@ -159,7 +159,7 @@ import static org.mockito.Mockito.when;
     @Test(expected = InvalidTokenException.class)
     public void authHeaderParserTest_InvalidAuthorizationHeader_V4() throws InvalidTokenException {
         // Arrange
-        String authorizationHeaderValue = "AWS AKIAJTYX36YCKQSAJT7Q:uDWiVvxwCUR9YJ8EGJgbtW9tjFM=";
+        String authorizationHeaderValue = "AWS v_accessKeyId:uDWiVvxwCUR9YJ8EGJgbtW9tjFM=";
         ClientRequestToken clientRequestToken = new ClientRequestToken();
 
         // Act

--- a/auth/server/src/test/java/com/seagates3/authentication/ClientRequestParserTest.java
+++ b/auth/server/src/test/java/com/seagates3/authentication/ClientRequestParserTest.java
@@ -83,7 +83,7 @@ import io.netty.handler.codec.http.HttpVersion;
 
         // Verify
         assertNotNull(token);
-        assertEquals("AKIAJTYX36YCKQSAJT7Q", token.getAccessKeyId());
+        assertEquals("v_accessKeyId", token.getAccessKeyId());
     }
 
     @Test

--- a/auth/server/src/test/java/com/seagates3/aws/AWSV2RequestHelper.java
+++ b/auth/server/src/test/java/com/seagates3/aws/AWSV2RequestHelper.java
@@ -30,9 +30,9 @@ import java.util.TreeMap;
 
 public class AWSV2RequestHelper {
 
-    public final static String ACCESS_KEY_ID = "AKIAJTYX36YCKQSAJT7Q";
+    public final static String ACCESS_KEY_ID = "v_accessKeyId";
     public final static String SECRET_KEY
-            = "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";
+            = "v_secretAccessKey";
 
     /**
      * Create request headers for a regular request.
@@ -45,7 +45,7 @@ public class AWSV2RequestHelper {
 
         requestBody.put("Accept-Encoding", "identity");
         requestBody.put("Action", "AuthenticateUser");
-        requestBody.put("Authorization", "AWS AKIAJTYX36YCKQSAJT7Q:uDWiVvxwCUR"
+        requestBody.put("Authorization", "AWS v_accessKeyId:uDWiVvxwCUR"
                 + "9YJ8EGJgbtW9tjFM=");
         requestBody.put("ClientAbsoluteUri", "/seagatebucket/test.txt");
         requestBody.put("ClientQueryParams", "");
@@ -76,7 +76,7 @@ public class AWSV2RequestHelper {
 
         requestBody.put("Accept-Encoding", "identity");
         requestBody.put("Action", "AuthenticateUser");
-        requestBody.put("Authorization", "AWS AKIAJTYX36YCKQSAJT7Q:4dtRFT7O4a7nVZ"
+        requestBody.put("Authorization", "AWS v_accessKeyId:4dtRFT7O4a7nVZ"
                 + "ieelIicVLuGoE=");
         requestBody.put("ClientAbsoluteUri", "/test.txt");
         requestBody.put("ClientQueryParams", "");
@@ -141,7 +141,7 @@ public class AWSV2RequestHelper {
     public static HttpHeaders getHttpHeaders() {
         HttpHeaders httpHeaders = new DefaultHttpHeaders();
 
-        httpHeaders.add("Authorization", "AWS AKIAJTYX36YCKQSAJT7Q:4dtRFT7O4a7n"
+        httpHeaders.add("Authorization", "AWS v_accessKeyId:4dtRFT7O4a7n"
                 + "VZieelIicVLuGoE=");
         httpHeaders.add("Content-Length", "8");
         httpHeaders.add("Host", "seagatebucket123.s3.seagate.com");
@@ -163,7 +163,7 @@ public class AWSV2RequestHelper {
     public static ClientRequestToken getFullHttpRequestClientToken() {
         Map<String, String> requestBody
                 = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        requestBody.put("Authorization", "AWS AKIAJTYX36YCKQSAJT7Q:4dtRFT7O4a7n"
+        requestBody.put("Authorization", "AWS v_accessKeyId:4dtRFT7O4a7n"
                 + "VZieelIicVLuGoE=");
         requestBody.put("Content-Length", "8");
         requestBody.put("Host", "seagatebucket123.s3.seagate.com");
@@ -194,7 +194,7 @@ public class AWSV2RequestHelper {
                 = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         requestBody.put("Accept", "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2");
         requestBody.put("Action", "AuthenticateUser");
-        requestBody.put("Authorization", "AWS AKIAJTYX36YCKQSAJT7Q:g9ZXcuNXpaDDlP+j7B3vLfGE6Ow=");
+        requestBody.put("Authorization", "AWS v_accessKeyId:g9ZXcuNXpaDDlP+j7B3vLfGE6Ow=");
         requestBody.put("ClientAbsoluteUri", "/seagatebucket/1mbfile");
         requestBody.put("ClientQueryParams", "partNumber=1&uploadId=5e9bac46-8994-4bc9-87fd-3486af85314c");
         requestBody.put("Content-Length", "1048576");
@@ -206,7 +206,7 @@ public class AWSV2RequestHelper {
         requestBody.put("Version", "2010-05-08");
 
         ClientRequestToken requestToken = new ClientRequestToken();
-        requestToken.setAccessKeyId("AKIAJTYX36YCKQSAJT7Q");
+        requestToken.setAccessKeyId("v_accessKeyId");
         requestToken.setHttpMethod("PUT");
         requestToken.setQuery("partNumber=1&uploadId=5e9bac46-8994-4bc9-87fd-3486af85314c");
         requestToken.setSignature("g9ZXcuNXpaDDlP+j7B3vLfGE6Ow=");

--- a/auth/server/src/test/java/com/seagates3/aws/AWSV4RequestHelper.java
+++ b/auth/server/src/test/java/com/seagates3/aws/AWSV4RequestHelper.java
@@ -440,7 +440,7 @@ public class AWSV4RequestHelper {
      * @return
      */
     public static ClientRequestToken getFullHttpRequestClientTokenHEAD() {
-        String authHeader = "AWS4-HMAC-SHA256 Credential=AKIAJTYX36YCKQSAJT7Q/"
+        String authHeader = "AWS4-HMAC-SHA256 Credential=v_accessKeyId/"
                           + "20180719/us-east-1/s3/aws4_request,"
                           + "SignedHeaders=connection;date;host;"
                           + "x-amz-content-sha256;x-amz-date,"
@@ -463,7 +463,7 @@ public class AWSV4RequestHelper {
 
         ClientRequestToken requestToken = new ClientRequestToken();
         requestToken.setSignedVersion(ClientRequestToken.AWSSigningVersion.V4);
-        requestToken.setAccessKeyId("AKIAJTYX36YCKQSAJT7Q");
+        requestToken.setAccessKeyId("v_accessKeyId");
         requestToken.setCredentialScope("20180719/us-east-1/s3/aws4_request");
         requestToken.setDate("20180719");
         requestToken.setHttpMethod("HEAD");
@@ -491,7 +491,7 @@ public class AWSV4RequestHelper {
     public static ClientRequestToken getInvalidHttpRequestClientToken() {
        String authHeader =
            "AWS4-HMAC-SHA256 Credential=" +
-           "AKIAJTYX36YCKQSAJT7Q/20180719/us-east-1/s3/aws4_request," +
+           "v_accessKeyId/20180719/us-east-1/s3/aws4_request," +
            "SignedHeaders=connection1;date;" +
            "host;x-amz-content-sha256;x-amz-date," + "Signature=" +
            "aad057b69f74b68957f7d32c3c7c19b5a64d78749de4f5b328253629d9a55059";
@@ -513,7 +513,7 @@ public class AWSV4RequestHelper {
 
         ClientRequestToken requestToken = new ClientRequestToken();
         requestToken.setSignedVersion(ClientRequestToken.AWSSigningVersion.V4);
-        requestToken.setAccessKeyId("AKIAJTYX36YCKQSAJT7Q");
+        requestToken.setAccessKeyId("v_accessKeyId");
         requestToken.setCredentialScope("20180719/us-east-1/s3/aws4_request");
         requestToken.setDate("20180719");
         requestToken.setHttpMethod("HEAD");

--- a/auth/server/src/test/java/com/seagates3/aws/sign/AWSV4SignTest.java
+++ b/auth/server/src/test/java/com/seagates3/aws/sign/AWSV4SignTest.java
@@ -141,8 +141,8 @@ public class AWSV4SignTest {
                 = AWSV4RequestHelper.getFullHttpRequestClientTokenHEAD();
 
         Requestor requestor1 =
-                AWSV4RequestHelper.getRequestorMock("AKIAJTYX36YCKQSAJT7Q",
-                                "A6k2z84BqwXmee4WUUS2oWwM/tha7Wrd4Hc/8yRt");
+                AWSV4RequestHelper.getRequestorMock("v_accessKeyId",
+                                "v_secretAccessKey");
         try {
             Assert.assertEquals(awsv4Sign.authenticate(requestToken, requestor1),
                     Boolean.TRUE);
@@ -159,8 +159,8 @@ public class AWSV4SignTest {
                 = AWSV4RequestHelper.getInvalidHttpRequestClientToken();
 
         Requestor requestor1 =
-                AWSV4RequestHelper.getRequestorMock("AKIAJTYX36YCKQSAJT7Q",
-                                "A6k2z84BqwXmee4WUUS2oWwM/tha7Wrd4Hc/8yRt");
+                AWSV4RequestHelper.getRequestorMock("v_accessKeyId",
+                                "v_secretAccessKey");
         try {
             awsv4Sign.authenticate(requestToken, requestor1);
             Assert.fail("Didn't throw BadRequest Exception");

--- a/auth/server/src/test/java/com/seagates3/s3service/S3AccountNotifierTest.java
+++ b/auth/server/src/test/java/com/seagates3/s3service/S3AccountNotifierTest.java
@@ -86,7 +86,7 @@ public class S3AccountNotifierTest {
 
         S3AccountNotifier s3AccountNotifier = new S3AccountNotifier();
         ServerResponse resp = s3AccountNotifier.notifyNewAccount("12345",
-        "AKIAJTYX36YCKQSAJT7Q", "A6k2z84BqwXmee4WUUS2oWwM/tha7Wrd4Hc/8yRt");
+        "v_accessKeyId", "v_secretAccessKey");
 
         assertEquals(HttpResponseStatus.OK, resp.getResponseStatus());
     }
@@ -111,7 +111,7 @@ public class S3AccountNotifierTest {
 
         S3AccountNotifier s3AccountNotifier = new S3AccountNotifier();
         ServerResponse resp = s3AccountNotifier.notifyNewAccount("12345",
-        "AKIAJTYX36YCKQSAJT7Q", "A6k2z84BqwXmee4WUUS2oWwM/tha7Wrd4Hc/8yRt");
+        "v_accessKeyId", "v_secretAccessKey");
 
         assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR,
                                     resp.getResponseStatus());
@@ -137,7 +137,7 @@ public class S3AccountNotifierTest {
 
         S3AccountNotifier s3AccountNotifier = new S3AccountNotifier();
         ServerResponse resp = s3AccountNotifier.notifyNewAccount("12345",
-        "AKIAJTYX36YCKQSAJT7Q", "A6k2z84BqwXmee4WUUS2oWwM/tha7Wrd4Hc/8yRt");
+        "v_accessKeyId", "v_secretAccessKey");
 
         assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR,
                                     resp.getResponseStatus());
@@ -163,7 +163,7 @@ public class S3AccountNotifierTest {
 
         S3AccountNotifier s3AccountNotifier = new S3AccountNotifier();
         ServerResponse resp = s3AccountNotifier.notifyNewAccount("12345",
-        "AKIAJTYX36YCKQSAJT7Q", "A6k2z84BqwXmee4WUUS2oWwM/tha7Wrd4Hc/8yRt");
+        "v_accessKeyId", "v_secretAccessKey");
 
         assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR,
                                     resp.getResponseStatus());
@@ -189,7 +189,7 @@ public class S3AccountNotifierTest {
 
         S3AccountNotifier s3AccountNotifier = new S3AccountNotifier();
         ServerResponse resp = s3AccountNotifier.notifyNewAccount("12345",
-        "AKIAJTYX36YCKQSAJT7Q", "A6k2z84BqwXmee4WUUS2oWwM/tha7Wrd4Hc/8yRt");
+        "v_accessKeyId", "v_secretAccessKey");
 
         assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR,
                                     resp.getResponseStatus());
@@ -216,7 +216,7 @@ public class S3AccountNotifierTest {
 
         S3AccountNotifier s3AccountNotifier = new S3AccountNotifier();
         ServerResponse resp = s3AccountNotifier.notifyNewAccount("12345",
-        "AKIAJTYX36YCKQSAJT7Q", "A6k2z84BqwXmee4WUUS2oWwM/tha7Wrd4Hc/8yRt");
+        "v_accessKeyId", "v_secretAccessKey");
 
         assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR,
                                     resp.getResponseStatus());
@@ -242,8 +242,8 @@ public class S3AccountNotifierTest {
 
         S3AccountNotifier s3AccountNotifier = new S3AccountNotifier();
         ServerResponse resp = s3AccountNotifier.notifyDeleteAccount(
-            "12345", "AKIAJTYX36YCKQSAJT7Q",
-            "A6k2z84BqwXmee4WUUS2oWwM/tha7Wrd4Hc/8yRt", null);
+            "12345", "v_accessKeyId",
+            "v_secretAccessKey", null);
 
         assertEquals(HttpResponseStatus.OK, resp.getResponseStatus());
     }
@@ -268,8 +268,8 @@ public class S3AccountNotifierTest {
 
         S3AccountNotifier s3AccountNotifier = new S3AccountNotifier();
         ServerResponse resp = s3AccountNotifier.notifyDeleteAccount(
-            "12345", "AKIAJTYX36YCKQSAJT7Q",
-            "A6k2z84BqwXmee4WUUS2oWwM/tha7Wrd4Hc/8yRt", null);
+            "12345", "v_accessKeyId",
+            "v_secretAccessKey", null);
 
         assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR,
                                               resp.getResponseStatus());
@@ -295,8 +295,8 @@ public class S3AccountNotifierTest {
 
         S3AccountNotifier s3AccountNotifier = new S3AccountNotifier();
         ServerResponse resp = s3AccountNotifier.notifyDeleteAccount(
-            "12345", "AKIAJTYX36YCKQSAJT7Q",
-            "A6k2z84BqwXmee4WUUS2oWwM/tha7Wrd4Hc/8yRt", null);
+            "12345", "v_accessKeyId",
+            "v_secretAccessKey", null);
 
         assertEquals(HttpResponseStatus.CONFLICT, resp.getResponseStatus());
     }
@@ -321,8 +321,8 @@ public class S3AccountNotifierTest {
 
         S3AccountNotifier s3AccountNotifier = new S3AccountNotifier();
         ServerResponse resp = s3AccountNotifier.notifyDeleteAccount(
-            "12345", "AKIAJTYX36YCKQSAJT7Q",
-            "A6k2z84BqwXmee4WUUS2oWwM/tha7Wrd4Hc/8yRt", null);
+            "12345", "v_accessKeyId",
+            "v_secretAccessKey", null);
 
         assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR,
                                     resp.getResponseStatus());
@@ -348,8 +348,8 @@ public class S3AccountNotifierTest {
 
         S3AccountNotifier s3AccountNotifier = new S3AccountNotifier();
         ServerResponse resp = s3AccountNotifier.notifyDeleteAccount(
-            "12345", "AKIAJTYX36YCKQSAJT7Q",
-            "A6k2z84BqwXmee4WUUS2oWwM/tha7Wrd4Hc/8yRt", null);
+            "12345", "v_accessKeyId",
+            "v_secretAccessKey", null);
 
         assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR,
                                     resp.getResponseStatus());
@@ -376,8 +376,8 @@ public class S3AccountNotifierTest {
 
         S3AccountNotifier s3AccountNotifier = new S3AccountNotifier();
         ServerResponse resp = s3AccountNotifier.notifyDeleteAccount(
-            "12345", "AKIAJTYX36YCKQSAJT7Q",
-            "A6k2z84BqwXmee4WUUS2oWwM/tha7Wrd4Hc/8yRt", null);
+            "12345", "v_accessKeyId",
+            "v_secretAccessKey", null);
 
         assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR,
                                     resp.getResponseStatus());

--- a/auth/server/src/test/java/com/seagates3/service/RequestorServiceTest.java
+++ b/auth/server/src/test/java/com/seagates3/service/RequestorServiceTest.java
@@ -86,7 +86,7 @@ import com.seagates3.response.generator.ResponseGenerator;
   ServerResponse serverResponse;
 
  private
-  final String accessKeyID = "AKIAJTYX36YCKQSAJT7Q";
+  final String accessKeyID = "v_accessKeyId";
 
   @Before public void setUp() throws Exception {
     accessKeyDAO = mock(AccessKeyDAO.class);

--- a/perf/test_client.cc
+++ b/perf/test_client.cc
@@ -99,7 +99,7 @@ void setup_request_headers(evhtp_request_t* request, struct evbuffer* buf) {
   evhtp_headers_add_header(request->headers_out,
                            evhtp_header_new("Accept-Encoding", "identity", 0, 0));
   evhtp_headers_add_header(request->headers_out,
-                           evhtp_header_new("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAJTYX36YCKQSAJT7Q/20160523/US/s3/aws4_request,SignedHeaders=content-length;content-type;host;x-amz-content-sha256;x-amz-date;x-amz-meta-s3cmd-attrs;x-amz-storage-class,Signature=329ba550642531735976b2c19b7d49d7e084877a199e78ffb98f08f4ce61a3ba", 0, 0));
+                           evhtp_header_new("Authorization", "AWS4-HMAC-SHA256 Credential=v_accessKeyId/20160523/US/s3/aws4_request,SignedHeaders=content-length;content-type;host;x-amz-content-sha256;x-amz-date;x-amz-meta-s3cmd-attrs;x-amz-storage-class,Signature=329ba550642531735976b2c19b7d49d7e084877a199e78ffb98f08f4ce61a3ba", 0, 0));
   evhtp_headers_add_header(request->headers_out,
                            evhtp_header_new("Connection", "close", 0, 0));
 

--- a/scripts/ldap/delete_test_account.sh
+++ b/scripts/ldap/delete_test_account.sh
@@ -19,8 +19,8 @@
 #
 
 
-ldapdelete -x -w seagate -r "ak=AKIAJPINPFRBTPAYOGNA,ou=accesskeys,dc=s3,dc=seagate,dc=com" -D "cn=admin,dc=seagate,dc=com"
+ldapdelete -x -w seagate -r "ak=v_accessKeyId,ou=accesskeys,dc=s3,dc=seagate,dc=com" -D "cn=admin,dc=seagate,dc=com"
 
-ldapdelete -x -w seagate -r "ak=AKIAJTYX36YCKQSAJT7Q,ou=accesskeys,dc=s3,dc=seagate,dc=com" -D "cn=admin,dc=seagate,dc=com"
+ldapdelete -x -w seagate -r "ak=v_accessKeyId,ou=accesskeys,dc=s3,dc=seagate,dc=com" -D "cn=admin,dc=seagate,dc=com"
 
 ldapdelete -x -w seagate -r "o=s3_test,ou=accounts,dc=s3,dc=seagate,dc=com" -D "cn=admin,dc=seagate,dc=com"

--- a/scripts/tct-sanity/account.config
+++ b/scripts/tct-sanity/account.config
@@ -22,7 +22,7 @@
 CLOUD_NODECLASS="MyTctNodeClass"                            # tct node class
 CLOUD_NAME="seagate"                                        # cloud name
 CLOUD_TYPE=S3                                               # cloud type
-USERNAME="AKIAJTYX36YCKQSAJT7Q"                             # access key
+USERNAME="v_accessKeyId"                             # access key
 ENABLE="TRUE"                                               # enable cloud gateway after account creation
 PWD_FILE="/tmp/secret_key"                                  # location on primary tct node where password file will be created
 MPU_PARTS_SIZE=32                                           # chunk size in MB

--- a/st/clitests/auth_spec_param_validation.py
+++ b/st/clitests/auth_spec_param_validation.py
@@ -52,14 +52,14 @@ def before_all():
     S3PyCliTest('Before_all').before_all()
 
 def set_valid_credentials():
-    S3ClientConfig.access_key_id = "AKIAJTYX36YCKQSAJT7Q"
-    S3ClientConfig.secret_key = "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"
+    S3ClientConfig.access_key_id = "v_accessKeyId"
+    S3ClientConfig.secret_key = "v_secretAccessKey"
 
 def parameter_validation_tests():
     # Create user with wrong access key
     test_msg = "Create User s3user1 should fail if access key is invalid"
     S3ClientConfig.access_key_id = "INVALID-ACCESS-KEY-Z"
-    S3ClientConfig.secret_key = "A6k2z84BqwXmee4WUUS2oWwM/tha7Wrd4Hc/8yRt"
+    S3ClientConfig.secret_key = "v_secretAccessKey"
     user_args = {}
     user_args['UserName'] = "s3user1"
     AuthTest(test_msg).create_user(**user_args).execute_test(negative_case=True)\
@@ -70,7 +70,7 @@ def parameter_validation_tests():
 
     # Create user with wrong secret key
     test_msg = "Create User s3user1 should fail if secret key is invalid"
-    S3ClientConfig.access_key_id = "AKIAJTYX36YCKQSAJT7Q"
+    S3ClientConfig.access_key_id = "v_accessKeyId"
     S3ClientConfig.secret_key = "INVALID-SECRET-KEY-2oWwM/tha7Wrd4Hc/8yRt"
     user_args = {}
     user_args['UserName'] = "s3user1"

--- a/st/clitests/auth_spec_signcalc_test_data.yaml
+++ b/st/clitests/auth_spec_signcalc_test_data.yaml
@@ -22,7 +22,7 @@ test1:
     req-params:
         Action: AuthenticateUser
         Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
-        Authorization: AWS AKIAJPINPFRBTPAYOGNA:GHDa6voSj9LfLhDNNCUrrkMSwgg=
+        Authorization: AWS v_accessKeyId:GHDa6voSj9LfLhDNNCUrrkMSwgg=
         Cache-Control: no-cache
         ClientAbsoluteUri: /
         ClientQueryParams: acl
@@ -43,7 +43,7 @@ test2:
     req-params:
         Action: AuthenticateUser
         Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
-        Authorization: AWS AKIAJPINPFRBTPAYOGNA:GHDa6voSj9LfLhDNNCUrrkMSwgg=
+        Authorization: AWS v_accessKeyId:GHDa6voSj9LfLhDNNCUrrkMSwgg=
         Cache-Control: no-cache
         ClientAbsoluteUri: /
         ClientQueryParams: acl
@@ -65,7 +65,7 @@ test3:
     req-params:
         Action: AuthenticateUser
         Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
-        Authorization: AWS AKIAJPINPFRBTPAYOGNA:GHDa6voSj9LfLhDNNCUrrkMSwgg=
+        Authorization: AWS v_accessKeyId:GHDa6voSj9LfLhDNNCUrrkMSwgg=
         Cache-Control: no-cache
         ClientAbsoluteUri: /
         ClientQueryParams: acl
@@ -87,7 +87,7 @@ test4:
     req-params:
         Action: AuthenticateUser
         Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
-        Authorization: AWS AKIAJPINPFRBTPAYOGNA:GHDa6voSj9LfLhDNNCUrrkMSwgg=
+        Authorization: AWS v_accessKeyId:GHDa6voSj9LfLhDNNCUrrkMSwgg=
         Cache-Control: no-cache
         ClientAbsoluteUri: /
         ClientQueryParams: acl
@@ -108,7 +108,7 @@ test5:
     req-params:
         Action: AuthenticateUser
         Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
-        Authorization: AWS AKIAJPINPFRBTPAYOGNA:GHDa6voSj9LfLhDNNCUrrkMSwgg=
+        Authorization: AWS v_accessKeyId:GHDa6voSj9LfLhDNNCUrrkMSwgg=
         Cache-Control: no-cache
         ClientAbsoluteUri: /
         ClientQueryParams: acl
@@ -130,7 +130,7 @@ test6:
     req-params:
         Action: AuthenticateUser
         Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
-        Authorization: AWS AKIAJPINPFRBTPAYOGNA:GHDa6voSj9LfLhDNNCUrrkMSwgg=
+        Authorization: AWS v_accessKeyId:GHDa6voSj9LfLhDNNCUrrkMSwgg=
         Cache-Control: no-cache
         ClientAbsoluteUri: /
         ClientQueryParams: acl
@@ -153,7 +153,7 @@ test7:
     req-params:
         Action: AuthenticateUser
         Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
-        Authorization: AWS AKIAJPINPFRBTPAYOGNA:GHDa6voSj9LfLhDNNCUrrkMSwgg=
+        Authorization: AWS v_accessKeyId:GHDa6voSj9LfLhDNNCUrrkMSwgg=
         Cache-Control: no-cache
         ClientAbsoluteUri: /
         ClientQueryParams: acl&versionId!=1
@@ -174,7 +174,7 @@ test8:
     req-params:
         Action: AuthenticateUser
         Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
-        Authorization: AWS AKIAJPINPFRBTPAYOGNA:GHDa6voSj9LfLhDNNCUrrkMSwgg=
+        Authorization: AWS v_accessKeyId:GHDa6voSj9LfLhDNNCUrrkMSwgg=
         Cache-Control: no-cache
         ClientAbsoluteUri: /
         ClientQueryParams: acl
@@ -217,7 +217,7 @@ test10:
     test-title: Authenticate user using AWS Signature Version 4
     req-params:
         Action: AuthenticateUser
-        Authorization: AWS4-HMAC-SHA256 Credential=AKIAJPINPFRBTPAYOGNA/20161129/seagate/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-retry;content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=36fc0a941ed4f92e6cd20b97fe4a7dd18ab4960fdcf4ca8266d01f1f4a2003bf
+        Authorization: AWS4-HMAC-SHA256 Credential=v_accessKeyId/20161129/seagate/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-retry;content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=36fc0a941ed4f92e6cd20b97fe4a7dd18ab4960fdcf4ca8266d01f1f4a2003bf
         ClientAbsoluteUri: /nondnsbucket/
         Connection: close
         Content-Length: 151
@@ -239,7 +239,7 @@ test10:
 #    test-title: Authenticate user using AWS Signature Version 4 for chunked request
 #    req-params:
 #        Action: AuthenticateUser
-#        Authorization: AWS4-HMAC-SHA256 Credential=AKIAJPINPFRBTPAYOGNA/20161201/seagate/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-retry;content-length;content-md5;content-type;host;user-agent;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length, Signature=442bf538c8c30dc4d67c07668580926b49a58f37fde579fb310d9650b733d3ac
+#        Authorization: AWS4-HMAC-SHA256 Credential=v_accessKeyId/20161201/seagate/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-retry;content-length;content-md5;content-type;host;user-agent;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length, Signature=442bf538c8c30dc4d67c07668580926b49a58f37fde579fb310d9650b733d3ac
 #        ClientAbsoluteUri: /seagatebucket/3kfilec
 #        Connection: close
 #        Content-Length: 3174
@@ -262,7 +262,7 @@ test10:
 #    test-title: Authenticate user using AWS Signature Version 4 for chunked seed request
 #    req-params:
 #        Action: AuthenticateUser
-#        Authorization: AWS4-HMAC-SHA256 Credential=AKIAJPINPFRBTPAYOGNA/20161201/seagate/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-retry;content-length;content-md5;content-type;host;user-agent;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length, Signature=442bf538c8c30dc4d67c07668580926b49a58f37fde579fb310d9650b733d3ac
+#        Authorization: AWS4-HMAC-SHA256 Credential=v_accessKeyId/20161201/seagate/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-retry;content-length;content-md5;content-type;host;user-agent;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length, Signature=442bf538c8c30dc4d67c07668580926b49a58f37fde579fb310d9650b733d3ac
 #        ClientAbsoluteUri: /seagatebucket/3kfilec
 #            ClientQueryParams=
 #        Connection: close
@@ -288,7 +288,7 @@ test10:
 #    test-title: Authenticate user using AWS Signature Version 4 (with client query params)
 #    req-params:
 #        Action: AuthenticateUser
-#        Authorization: AWS4-HMAC-SHA256 Credential=AKIAJPINPFRBTPAYOGNA/20161201/seagate/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-retry;content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=d41dd2347a03bb161176580372beb38de4c4dfd2f68590cf0104a4e1cb051e04
+#        Authorization: AWS4-HMAC-SHA256 Credential=v_accessKeyId/20161201/seagate/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-retry;content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=d41dd2347a03bb161176580372beb38de4c4dfd2f68590cf0104a4e1cb051e04
 #        ClientAbsoluteUri: /seagatebucket/3kfile
 #        ClientQueryParams: acl
 #        Connection: close

--- a/st/clitests/aws_credential_file
+++ b/st/clitests/aws_credential_file
@@ -1,3 +1,3 @@
 [default]
-aws_access_key_id = AKIAJPINPFRBTPAYOGNA
-aws_secret_access_key = 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
+aws_access_key_id = v_accessKeyId
+aws_secret_access_key = v_secretAccessKey

--- a/st/clitests/cfg/cloud_config.yaml
+++ b/st/clitests/cfg/cloud_config.yaml
@@ -20,7 +20,7 @@
 cloud-nodeclass     : tctNodeclass                                  # tct node class
 cloud-name          : seagate                                       # cloud name
 cloud-type          : SWIFT3                                        # cloud type
-username            : AKIAJTYX36YCKQSAJT7Q                          # access key
+username            : v_accessKeyId                          # access key
 pwd-file            : secret_key_file                               # secret key file name
 enable              : TRUE                                          # enable cloud gateway after account creation
 cloud-url           : http://s3.seagate.com                         # cloud endpoint url
@@ -29,7 +29,7 @@ mpu-parts-size      : 32                                            # chunk size
 server-cert-path    :                                               # certificate path for the self-signed certificates
 enc-enable          : False                                         # enable encryption
 etag-enable         : True                                          # enable data integrity check
-secret-key          : A6k2z84BqwXmee4WUUS2oWwM/tha7Wrd4Hc/8yRt      # secret key
+secret-key          : v_secretAccessKey      # secret key
 fs-root             : /gpfs/fs1                                     # canonical path of GPFS mount point
 fs-name             : fs1                                           # filesystem name
 test-dir            : ABRACADABRA                                   # tmp test-directory which shouldn't already exists

--- a/st/clitests/jclient_spec.py
+++ b/st/clitests/jclient_spec.py
@@ -50,8 +50,8 @@ from s3client_config import S3ClientConfig
 print("Configuring LDAP")
 S3PyCliTest('Before_all').before_all()
 
-S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-S3ClientConfig.secret_key = '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'
+S3ClientConfig.access_key_id = 'v_accessKeyId'
+S3ClientConfig.secret_key = 'v_secretAccessKey'
 
 # Create Account
 # Extract the response elements from response which has the following format
@@ -148,8 +148,8 @@ for i, val in enumerate(pathstyle_values):
         .list_buckets().execute_test().command_is_successful().command_response_should_have('seagate-bucket')
 
     # ************ List buckets of specific account************
-    S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-    S3ClientConfig.secret_key = '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'
+    S3ClientConfig.access_key_id = 'v_accessKeyId'
+    S3ClientConfig.secret_key = 'v_secretAccessKey'
     JClientTest('Jclient can list buckets').list_buckets().execute_test()\
         .command_is_successful().command_response_should_have('seagatebucket')\
         .command_is_successful().command_response_should_not_have('seagate-bucket')
@@ -167,8 +167,8 @@ for i, val in enumerate(pathstyle_values):
         .create_bucket("seagatebucket").execute_test(negative_case=True).command_should_fail()\
         .command_error_should_have("BucketAlreadyExists")
 
-    S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-    S3ClientConfig.secret_key = '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'
+    S3ClientConfig.access_key_id = 'v_accessKeyId'
+    S3ClientConfig.secret_key = 'v_secretAccessKey'
     JClientTest('Jclient can not create bucket with name exsting in other account').create_bucket("seagate-bucket")\
         .execute_test(negative_case=True).command_should_fail().command_error_should_have("BucketAlreadyExists")
 
@@ -179,8 +179,8 @@ for i, val in enumerate(pathstyle_values):
         .delete_bucket("seagatebucket").execute_test(negative_case=True).command_should_fail()\
         .command_error_should_have("Access Denied")
 
-    S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-    S3ClientConfig.secret_key = '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'
+    S3ClientConfig.access_key_id = 'v_accessKeyId'
+    S3ClientConfig.secret_key = 'v_secretAccessKey'
     JClientTest('Jclient can not deelte bucket owned by another account').delete_bucket("seagate-bucket")\
         .execute_test(negative_case=True).command_should_fail().command_error_should_have("Access Denied")
 
@@ -191,8 +191,8 @@ for i, val in enumerate(pathstyle_values):
         .put_object("seagatebucket", "3kfile", 3000).execute_test(negative_case=True).command_should_fail()\
         .command_error_should_have("Access Denied")
 
-    S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-    S3ClientConfig.secret_key = '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'
+    S3ClientConfig.access_key_id = 'v_accessKeyId'
+    S3ClientConfig.secret_key = 'v_secretAccessKey'
     JClientTest('Jclient can not upload 3k file to bucket owned by another account')\
         .put_object("seagate-bucket", "3kfile", 3000).execute_test(negative_case=True)\
         .command_should_fail().command_error_should_have("Access Denied")
@@ -215,8 +215,8 @@ for i, val in enumerate(pathstyle_values):
         .command_is_successful().command_response_should_have('')
 
     # restore default access key and secret key.
-    S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-    S3ClientConfig.secret_key = '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'
+    S3ClientConfig.access_key_id = 'v_accessKeyId'
+    S3ClientConfig.secret_key = 'v_secretAccessKey'
 
     # ACL Tests.
     # Bucket ACL Tests.
@@ -648,8 +648,8 @@ for i, val in enumerate(pathstyle_values):
         .command_response_should_have("Account deleted successfully")
 
     # restore default access key and secret key.
-    S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-    S3ClientConfig.secret_key = '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'
+    S3ClientConfig.access_key_id = 'v_accessKeyId'
+    S3ClientConfig.secret_key = 'v_secretAccessKey'
 
     # ********** Tests to verify objects with special characters
     JClientTest('JClient can create bucket').create_bucket("seagatebucket").execute_test().command_is_successful()

--- a/st/clitests/jcloud_spec.py
+++ b/st/clitests/jcloud_spec.py
@@ -51,8 +51,8 @@ Config.socket_timeout = 300 * 1000 * 240
 print("Configuring LDAP")
 S3PyCliTest('Before_all').before_all()
 
-S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-S3ClientConfig.secret_key = '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'
+S3ClientConfig.access_key_id = 'v_accessKeyId'
+S3ClientConfig.secret_key = 'v_secretAccessKey'
 
 # Create Account
 # Extract the response elements from response which has the following format
@@ -129,8 +129,8 @@ for i, val in enumerate(pathstyle_values):
         .list_buckets().execute_test().command_is_successful().command_response_should_have('seagate-bucket')
 
     # ************ List buckets of specific account************
-    S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-    S3ClientConfig.secret_key = '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'
+    S3ClientConfig.access_key_id = 'v_accessKeyId'
+    S3ClientConfig.secret_key = 'v_secretAccessKey'
     JCloudTest('JCloudTest can list buckets').list_buckets().execute_test()\
         .command_is_successful().command_response_should_have('seagatebucket')\
         .command_is_successful().command_response_should_not_have('seagate-bucket')
@@ -148,8 +148,8 @@ for i, val in enumerate(pathstyle_values):
         .create_bucket("seagatebucket").execute_test(negative_case=True).command_should_fail()\
         .command_error_should_have("ResourceAlreadyExists")
 
-    S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-    S3ClientConfig.secret_key = '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'
+    S3ClientConfig.access_key_id = 'v_accessKeyId'
+    S3ClientConfig.secret_key = 'v_secretAccessKey'
     JCloudTest('JCloudTest can not create bucket with name exsting in other account').create_bucket("seagate-bucket")\
         .execute_test(negative_case=True).command_should_fail().command_error_should_have("ResourceAlreadyExists")
 
@@ -160,8 +160,8 @@ for i, val in enumerate(pathstyle_values):
         .check_bucket_exists("seagatebucket").execute_test(negative_case=True).command_should_fail()\
         .command_error_should_have('AuthorizationException')
 
-    S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-    S3ClientConfig.secret_key = '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'
+    S3ClientConfig.access_key_id = 'v_accessKeyId'
+    S3ClientConfig.secret_key = 'v_secretAccessKey'
     JCloudTest('JCloudTest can not access bucket owned by another account')\
         .check_bucket_exists("seagate-bucket").execute_test(negative_case=True).command_should_fail()\
         .command_error_should_have('AuthorizationException')
@@ -173,8 +173,8 @@ for i, val in enumerate(pathstyle_values):
         .delete_bucket("seagatebucket").execute_test(negative_case=True).command_should_fail()\
         .command_error_should_have("AuthorizationException")
 
-    S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-    S3ClientConfig.secret_key = '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'
+    S3ClientConfig.access_key_id = 'v_accessKeyId'
+    S3ClientConfig.secret_key = 'v_secretAccessKey'
     JCloudTest('JCloudTest can not deelte bucket owned by another account').delete_bucket("seagate-bucket")\
         .execute_test(negative_case=True).command_should_fail().command_error_should_have("AuthorizationException")
 
@@ -185,8 +185,8 @@ for i, val in enumerate(pathstyle_values):
         .put_object("seagatebucket", "3kfile", 3000).execute_test(negative_case=True).command_should_fail()\
         .command_error_should_have("AuthorizationException")
 
-    S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-    S3ClientConfig.secret_key = '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'
+    S3ClientConfig.access_key_id = 'v_accessKeyId'
+    S3ClientConfig.secret_key = 'v_secretAccessKey'
     JCloudTest('JCloudTest can not upload 3k file to bucket owned by another account')\
         .put_object("seagate-bucket", "3kfile", 3000).execute_test(negative_case=True)\
         .command_should_fail().command_error_should_have("AuthorizationException")
@@ -209,8 +209,8 @@ for i, val in enumerate(pathstyle_values):
         .command_is_successful().command_response_should_have('')
 
     # restore default access key and secret key.
-    S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-    S3ClientConfig.secret_key = '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'
+    S3ClientConfig.access_key_id = 'v_accessKeyId'
+    S3ClientConfig.secret_key = 'v_secretAccessKey'
 
     # ACL Tests.
     # Bucket ACL Tests.
@@ -326,8 +326,8 @@ for i, val in enumerate(pathstyle_values):
         .command_response_should_have("Account deleted successfully")
 
     # restore default access key and secret key.
-    S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-    S3ClientConfig.secret_key = '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'
+    S3ClientConfig.access_key_id = 'v_accessKeyId'
+    S3ClientConfig.secret_key = 'v_secretAccessKey'
 
     # Current version of Jcloud does not report error in deleteContainer
     # JCloudTest('Jcloud cannot delete bucket which is not empty').delete_bucket("seagatebucket").execute_test(negative_case=True).command_should_fail().command_error_should_have("NotEmpty")

--- a/st/clitests/negative_spec.py
+++ b/st/clitests/negative_spec.py
@@ -55,8 +55,8 @@ S3PyCliTest('Before_all').before_all()
 
 # Set pathstyle =false to run jclient for partial multipart upload
 S3ClientConfig.pathstyle = False
-S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-S3ClientConfig.secret_key = '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'
+S3ClientConfig.access_key_id = 'v_accessKeyId'
+S3ClientConfig.secret_key = 'v_secretAccessKey'
 
 S3fiTest('Disable bucket metadata cache').\
     enable_fi("enable", "", "disable_bucket_metadata_cache").\

--- a/st/clitests/pathstyle.s3cfg
+++ b/st/clitests/pathstyle.s3cfg
@@ -18,7 +18,7 @@
 #
 
 [default]
-access_key = AKIAJTYX36YCKQSAJT7Q
+access_key = v_accessKeyId
 access_token =
 add_encoding_exts =
 add_headers =
@@ -71,7 +71,7 @@ recv_chunk = 65536
 reduced_redundancy = False
 requester_pays = False
 restore_days = 1
-secret_key = A6k2z84BqwXmee4WUUS2oWwM/tha7Wrd4Hc/8yRt
+secret_key = v_secretAccessKey
 send_chunk = 65536
 server_side_encryption = False
 signature_v2 = False

--- a/st/clitests/rollback_spec.py
+++ b/st/clitests/rollback_spec.py
@@ -55,8 +55,8 @@ S3PyCliTest('Before_all').before_all()
 
 # Set pathstyle =false to run jclient for partial multipart upload
 S3ClientConfig.pathstyle = False
-S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-S3ClientConfig.secret_key = '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'
+S3ClientConfig.access_key_id = 'v_accessKeyId'
+S3ClientConfig.secret_key = 'v_secretAccessKey'
 
 # Path style tests.
 Config.config_file = "pathstyle.s3cfg"

--- a/st/clitests/s3_background_delete_config_test.yaml
+++ b/st/clitests/s3_background_delete_config_test.yaml
@@ -25,7 +25,7 @@ cortx_s3:                                   # Section for S3 background delete c
    service: "cortxs3"                                      # Default region specified for CORTX s3 client
    default_region: "us-west2"                              # CORTX s3 client will use the specified host
    access_key: "AKIAJPINPFRBTPAYXAHZ"                      # Access Key corresponding to account-name "s3-background-delete-svc"
-   secret_key: "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"  # Secret Key corresponding to account-name "s3-background-delete-svc"
+   secret_key: "v_secretAccessKey"  # Secret Key corresponding to account-name "s3-background-delete-svc"
    daemon_mode: "True"                                     # S3background process run in daemon mode and ST's run in non-daemon mode.
    s3_instance_count: 22                                   # Number of active s3 instances in release setup
    messaging_platform: "message_bus"                       # messaging platform

--- a/st/clitests/s3cmd_spec.py
+++ b/st/clitests/s3cmd_spec.py
@@ -54,8 +54,8 @@ S3PyCliTest('Before_all').before_all()
 
 # Set pathstyle =false to run jclient for partial multipart upload
 S3ClientConfig.pathstyle = False
-S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-S3ClientConfig.secret_key = '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'
+S3ClientConfig.access_key_id = 'v_accessKeyId'
+S3ClientConfig.secret_key = 'v_secretAccessKey'
 
 # Path style tests.
 Config.config_file = "pathstyle.s3cfg"
@@ -195,8 +195,8 @@ AuthTest(test_msg).delete_account(**account_args).execute_test()\
     .command_response_should_have("Account deleted successfully")
 
 # restore access key and secret key.
-S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-S3ClientConfig.secret_key = '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'
+S3ClientConfig.access_key_id = 'v_accessKeyId'
+S3ClientConfig.secret_key = 'v_secretAccessKey'
 
 # ************ List buckets ************
 S3cmdTest('s3cmd can list buckets').list_buckets().execute_test().command_is_successful().command_response_should_have('s3://seagatebucket')
@@ -701,5 +701,5 @@ AuthTest('s3cmd can delete s3secondaccount').delete_account(**account_args).exec
     .command_response_should_have("Account deleted successfully")
 
 # restore access key and secret key.
-S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-S3ClientConfig.secret_key = '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'
+S3ClientConfig.access_key_id = 'v_accessKeyId'
+S3ClientConfig.secret_key = 'v_secretAccessKey'

--- a/st/clitests/shutdown_spec.py
+++ b/st/clitests/shutdown_spec.py
@@ -52,8 +52,8 @@ S3PyCliTest('Before_all').before_all()
 
 # Set pathstyle =false to run jclient for partial multipart upload
 S3ClientConfig.pathstyle = False
-S3ClientConfig.access_key_id = 'AKIAJPINPFRBTPAYOGNA'
-S3ClientConfig.secret_key = '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'
+S3ClientConfig.access_key_id = 'v_accessKeyId'
+S3ClientConfig.secret_key = 'v_secretAccessKey'
 
 config_types = ["pathstyle.s3cfg", "virtualhoststyle.s3cfg"]
 for i, type in enumerate(config_types):

--- a/st/clitests/test_data/create_test_data.ldif
+++ b/st/clitests/test_data/create_test_data.ldif
@@ -51,17 +51,17 @@ objectclass: iamUser
 path: /
 arn: arn:aws:iam::12345:user/root
 
-dn: ak=AKIAJPINPFRBTPAYOGNA,ou=accesskeys,dc=s3,dc=seagate,dc=com
-ak: AKIAJPINPFRBTPAYOGNA
+dn: ak=v_accessKeyId,ou=accesskeys,dc=s3,dc=seagate,dc=com
+ak: v_accessKeyId
 s3userid: 123
-sk: ht8ntpB9DoChDrneKZHvPVTm+1mHbs7UdCyYZ5Hd
+sk: v_secretAccessKey
 status: Active
 objectclass: accessKey
 
-dn: ak=AKIAJTYX36YCKQSAJT7Q,ou=accesskeys,dc=s3,dc=seagate,dc=com
-ak: AKIAJTYX36YCKQSAJT7Q
+dn: ak=v_accessKeyId,ou=accesskeys,dc=s3,dc=seagate,dc=com
+ak: v_accessKeyId
 s3userid: 123
-sk: A6k2z84BqwXmee4WUUS2oWwM/tha7Wrd4Hc/8yRt
+sk: v_secretAccessKey
 status: Active
 objectclass: accessKey
 

--- a/st/clitests/virtualhoststyle.s3cfg
+++ b/st/clitests/virtualhoststyle.s3cfg
@@ -18,7 +18,7 @@
 #
 
 [default]
-access_key = AKIAJTYX36YCKQSAJT7Q
+access_key = v_accessKeyId
 access_token =
 add_encoding_exts =
 add_headers =
@@ -70,7 +70,7 @@ recv_chunk = 65536
 reduced_redundancy = False
 requester_pays = False
 restore_days = 1
-secret_key = A6k2z84BqwXmee4WUUS2oWwM/tha7Wrd4Hc/8yRt
+secret_key = v_secretAccessKey
 send_chunk = 65536
 server_side_encryption = False
 signature_v2 = False


### PR DESCRIPTION
# Problem Statement
Fix to update the secret id and key as variable
### Describe your changes in brief
During GitHub scan, it reported Possible valid secrets found in repository in form of AWS ID and key
Its decided to hide these secrets and update the actual values with v_key_name
There is no impact to any functional aspects as mainly its used as S3 client and not  actually being used.
whenever actual AWS Account is used its not active accounts. for safely reason we are replace all such instances as well.

### Changes
 - [*] Why is this change required? What problem does it solve? 
 Fix for secret warnings reported by GitHub
 - [ ] If proposing a new change then please raise an issue first

### How Has This Been Tested? (Optional)
 - [ ] Please describe in detail how you tested your changes.
 - [ ] Include details of your testing environment, and the tests you ran to
 - [ ] How your change affects other areas of the code, etc.

### Screenshots (if appropriate)

### Checklist
 - [ ] tested locally
 - [ ] added new dependencies
 - [ ] updated the docs
 - [ ] added a test
 Testing is not in scope as the accounts are not active and test are not being executed recently
